### PR TITLE
Feature: Add option to minimize tarkov monitor to the system try when the app is launched

### DIFF
--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -22,6 +22,9 @@
             <setting name="restartTaskAlert" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="minimizeAtStartup" serializeAs="String">
+                <value>False</value>
+            </setting>
             <setting name="upgradeRequired" serializeAs="String">
                 <value>True</value>
             </setting>

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -25,6 +25,15 @@
 
     <MudItem xs="12">
         <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.PowerSettingsNew" Class="mr-2"/>Startup</MudText>
+            <div>
+                <MudSwitch @bind-Checked="@MinimizeAtStartupSwitch" Label="Start Tarkov Monitor Minimized" Color="Color.Info" />
+            </div>
+        </MudPaper>
+	</MudItem>
+
+    <MudItem xs="12">
+        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Handshake" Class="mr-2"/>Data Collection</MudText>
             <MudSwitch @bind-Checked="@SubmitQueueTimeSwitch" Label="Submit Queue Time Data" Color="Color.Info" />
         </MudPaper>
@@ -127,6 +136,19 @@
         set
         {
             Properties.Settings.Default.restartTaskAlert = value;
+            Properties.Settings.Default.Save();
+        }
+    }
+    
+    public bool MinimizeAtStartupSwitch
+    {
+        get
+        {
+            return Properties.Settings.Default.minimizeAtStartup;
+        }
+        set
+        {
+            Properties.Settings.Default.minimizeAtStartup = value;
             Properties.Settings.Default.Save();
         }
     }

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -92,13 +92,16 @@ namespace TarkovMonitor
             blazorWebView1.RootComponents.Add<TarkovMonitor.Blazor.App>("#app");
 
             blazorWebView1.WebView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
 
             if (Properties.Settings.Default.minimizeAtStartup)
             {
 
-                this.WindowState = FormWindowState.Minimized;
-                this.ShowInTaskbar = false;
-                notifyIconTarkovMonitor.Visible = true;
+                WindowState = FormWindowState.Minimized;
             }
         }
 

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -92,6 +92,14 @@ namespace TarkovMonitor
             blazorWebView1.RootComponents.Add<TarkovMonitor.Blazor.App>("#app");
 
             blazorWebView1.WebView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
+
+            if (Properties.Settings.Default.minimizeAtStartup)
+            {
+
+                this.WindowState = FormWindowState.Minimized;
+                this.ShowInTaskbar = false;
+                notifyIconTarkovMonitor.Visible = true;
+            }
         }
 
         private void Eft_MapLoaded(object? sender, MatchFoundEventArgs e)

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -82,7 +82,22 @@ namespace TarkovMonitor.Properties {
                 this["restartTaskAlert"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool minimizeAtStartup
+        {
+            get
+            {
+                return ((bool)(this["minimizeAtStartup"]));
+            }
+            set
+            {
+                this["minimizeAtStartup"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -17,6 +17,9 @@
     <Setting Name="restartTaskAlert" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="minimizeAtStartup" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="upgradeRequired" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>


### PR DESCRIPTION
### Additions in this PR

- Added an option to automatically minimize Tarkov Monitor to the system tray when the app is launched.

### Motivation

Because I often forget to launch Tarkov Monitor before playing EFT, I keep a shortcut to it in my Windows startup folder so that the app launches when I start my PC. However, it's annoying to have it pop up every time :). This PR addresses that issue by adding the option to hide it at startup.

> Note: this is my first time working with .NET, so if anything needs to be changed, please let me know and I'll update the PR promptly. Thank you!


![image](https://github.com/the-hideout/TarkovMonitor/assets/16705594/6b9e60c0-d974-4f0d-b86c-7b9b62534717)
