### PR TITLE
Fix for read past logs while EFT is running

### DIFF
--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -489,7 +489,9 @@ namespace TarkovMonitor
                 }
 
                 // Read the file into memory using UTF-8 encoding
-                var fileContents = File.ReadAllText(logFile, Encoding.UTF8);
+                using var fileStream = new FileStream(logFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var textReader = new StreamReader(fileStream, Encoding.UTF8);
+                var fileContents = textReader.ReadToEnd();
 
                 GameWatcher_NewLogData(this, new NewLogDataEventArgs { Type = logType, Data = fileContents });
             }
@@ -514,7 +516,9 @@ namespace TarkovMonitor
             {
                 return null;
             }
-            var applicationLog = File.ReadAllText(appLogPath);
+            using var fileStream = new FileStream(appLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var textReader = new StreamReader(fileStream, Encoding.UTF8);
+            var applicationLog = textReader.ReadToEnd();
             var match = Regex.Match(applicationLog, @"(?<date>^\d{4}-\d{2}-\d{2}) (?<time>\d{2}:\d{2}:\d{2}\.\d{3} [+-]\d{2}:\d{2})\|(?<version>\d+\.\d+\.\d+\.\d+)\.\d+\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|SelectProfile ProfileId:(?<profileId>[a-f0-9]+) AccountId:(?<accountId>\d+)", RegexOptions.Multiline);
             if (!match.Success)
             {

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\TarkovDev.ico</ApplicationIcon>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
+    <AssemblyVersion>1.4.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The "Read Past Logs" feature currently hangs if it's used while the game is running. This should fix that issue.

Resolves #69 