### PR TITLE
Apply fix for log error caused by flea sales on PVE

### DIFF
--- a/TarkovMonitor/Stats.cs
+++ b/TarkovMonitor/Stats.cs
@@ -58,7 +58,7 @@ namespace TarkovMonitor
 
         public static void AddFleaSale(FleaSoldMessageLogContent e, Profile profile)
         {
-            var sql = "INSERT INTO flea_sales(profile_id, item_id, buyer, count, currency, price) VALUES(@item_id, @buyer, @count, @currency, @price);";
+            var sql = "INSERT INTO flea_sales(profile_id, item_id, buyer, count, currency, price) VALUES(@profile_id, @item_id, @buyer, @count, @currency, @price);";
             var parameters = new Dictionary<string, object>
             {
                 {


### PR DESCRIPTION
There is a log error when a flea sale is made on PVE, the `profile_id` is not being inserted into the `flea_sales` table

Resolves [#74](https://github.com/the-hideout/TarkovMonitor/issues/74)
