### PR TITLE
Ensure profileId is set when testing API token

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -417,18 +417,6 @@
         }
     }
 
-    public string ProfileId
-    {
-        get
-        {
-            return eft.CurrentProfile.Id;
-        }
-        set
-        {
-            eft.CurrentProfile.Id = value;
-        }
-    }
-
     void TokenShowClick()
     {
         if (tokenShow)
@@ -454,7 +442,7 @@
         } else {
             try
             {
-                var tokenResponse = await TarkovTracker.TestToken(ProfileId, TarkovTrackerToken);
+                var tokenResponse = await TarkovTracker.TestToken(TarkovTrackerToken);
                 if (!tokenResponse.permissions.Contains("WP"))
                 {
                     messageLog.AddMessage("You do not have write permissions with this token.", "warning");

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -417,6 +417,18 @@
         }
     }
 
+    public string ProfileId
+    {
+        get
+        {
+            return eft.CurrentProfile.Id;
+        }
+        set
+        {
+            eft.CurrentProfile.Id = value;
+        }
+    }
+
     void TokenShowClick()
     {
         if (tokenShow)
@@ -442,7 +454,7 @@
         } else {
             try
             {
-                var tokenResponse = await TarkovTracker.TestToken(TarkovTrackerToken);
+                var tokenResponse = await TarkovTracker.TestToken(ProfileId, TarkovTrackerToken);
                 if (!tokenResponse.permissions.Contains("WP"))
                 {
                     messageLog.AddMessage("You do not have write permissions with this token.", "warning");

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -482,7 +482,7 @@ namespace TarkovMonitor
             }
             try
             {
-                var tokenResponse = await TarkovTracker.TestToken(eft.CurrentProfile.Id, TarkovTracker.GetToken(eft.CurrentProfile.Id));
+                var tokenResponse = await TarkovTracker.TestToken(TarkovTracker.GetToken(eft.CurrentProfile.Id));
                 if (!tokenResponse.permissions.Contains("WP"))
                 {
                     messageLog.AddMessage("Your Tarkov Tracker token is missing the required write permissions");

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -77,7 +77,7 @@ namespace TarkovMonitor
                     try {
                         TarkovTracker.SetToken(e.Profile.Id, Properties.Settings.Default.tarkovTrackerToken);
                     } catch (Exception ex) {
-                        messageLog.AddMessage($"Error starting game watcher: {ex.Message} {ex.StackTrace}", "exception");
+                        messageLog.AddMessage($"Error setting token from previously saved settings {ex.Message}", "exception");
                     }
 
                     Properties.Settings.Default.tarkovTrackerToken = "";

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -477,7 +477,7 @@ namespace TarkovMonitor
             }
             try
             {
-                var tokenResponse = await TarkovTracker.TestToken(TarkovTracker.GetToken(eft.CurrentProfile.Id));
+                var tokenResponse = await TarkovTracker.TestToken(eft.CurrentProfile.Id, TarkovTracker.GetToken(eft.CurrentProfile.Id));
                 if (!tokenResponse.permissions.Contains("WP"))
                 {
                     messageLog.AddMessage("Your Tarkov Tracker token is missing the required write permissions");

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -74,7 +74,12 @@ namespace TarkovMonitor
             {
                 if (Properties.Settings.Default.tarkovTrackerToken != "")
                 {
-                    TarkovTracker.SetToken(e.Profile.Id, Properties.Settings.Default.tarkovTrackerToken);
+                    try {
+                        TarkovTracker.SetToken(e.Profile.Id, Properties.Settings.Default.tarkovTrackerToken);
+                    } catch (Exception ex) {
+                        messageLog.AddMessage($"Error starting game watcher: {ex.Message} {ex.StackTrace}", "exception");
+                    }
+
                     Properties.Settings.Default.tarkovTrackerToken = "";
                     Properties.Settings.Default.Save();
                 }
@@ -460,20 +465,20 @@ namespace TarkovMonitor
 
         private async Task InitializeProgress()
         {
+            try
+            {
+                await TarkovTracker.SetProfile(eft.CurrentProfile.Id);
+            }
+            catch (Exception ex)
+            {
+                messageLog.AddMessage($"Profile does not exist: {ex.Message}");
+                return;
+            }
+            messageLog.AddMessage($"Using {eft.CurrentProfile.Type} profile");
             if (TarkovTracker.GetToken(eft.CurrentProfile.Id) == "")
             {
                 messageLog.AddMessage("To automatically track task progress, set your Tarkov Tracker token in Settings");
                 return;
-            }
-            messageLog.AddMessage($"Using {eft.CurrentProfile.Type} profile");
-            try
-            {
-                await TarkovTracker.SetProfile(eft.CurrentProfile.Id);
-                return;
-            }
-            catch (Exception ex)
-            {
-                messageLog.AddMessage($"Error getting Tarkov Tracker progress: {ex.Message}");
             }
             try
             {
@@ -486,6 +491,7 @@ namespace TarkovMonitor
             catch (Exception ex)
             {
                 messageLog.AddMessage($"Error updating progress: {ex.Message}");
+                return;
             }
         }
 

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -35,12 +35,7 @@ namespace TarkovMonitor
             {
                 AuthorizationHeaderValueGetter = (rq, cr) => {
                     return Task.Run<string>(() => {
-                        string token = GetToken(currentProfile);
-                        if (token == "") {
-                            throw new Exception("No PVE or PVP profile could be found, launch tarkov first");
-                        }
-                        
-                        return token;
+                        return GetToken(currentProfile);
                     });
                 },
             }

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -15,7 +15,7 @@ namespace TarkovMonitor
 
             [Get("/token")]
             [Headers("Authorization: Bearer {token}")]
-            Task<TokenResponse> TestToken(string profileId, string token);
+            Task<TokenResponse> TestToken(string token);
 
             [Get("/progress")]
             [Headers("Authorization: Bearer")]
@@ -102,7 +102,7 @@ namespace TarkovMonitor
                 Progress = new();
                 return Progress;
             }
-            await TestToken(profileId, newToken);
+            await TestToken(newToken);
             return Progress;
         }
 
@@ -293,11 +293,11 @@ namespace TarkovMonitor
             }
         }
 
-        public static async Task<TokenResponse> TestToken(string profileId, string apiToken)
+        public static async Task<TokenResponse> TestToken(string apiToken)
         {
             try
             {
-                var response = await api.TestToken(profileId, apiToken);
+                var response = await api.TestToken(apiToken);
                 if (response.permissions.Contains("WP"))
                 {
                     ValidToken = true;

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -15,7 +15,7 @@ namespace TarkovMonitor
 
             [Get("/token")]
             [Headers("Authorization: Bearer {token}")]
-            Task<TokenResponse> TestToken(string token);
+            Task<TokenResponse> TestToken(string profileId, string token);
 
             [Get("/progress")]
             [Headers("Authorization: Bearer")]
@@ -35,7 +35,9 @@ namespace TarkovMonitor
             {
                 AuthorizationHeaderValueGetter = (rq, cr) => {
                     return Task.Run<string>(() => {
-                        return tokens[currentProfile];
+                        string token = null;
+                        tokens.TryGetValue(currentProfile, out token);
+                        return token;
                     });
                 },
             }
@@ -94,7 +96,7 @@ namespace TarkovMonitor
                 Progress = new();
                 return Progress;
             }
-            await TestToken(newToken);
+            await TestToken(profileId, newToken);
             return Progress;
         }
 
@@ -285,11 +287,11 @@ namespace TarkovMonitor
             }
         }
 
-        public static async Task<TokenResponse> TestToken(string apiToken)
+        public static async Task<TokenResponse> TestToken(string profileId, string apiToken)
         {
             try
             {
-                var response = await api.TestToken(apiToken);
+                var response = await api.TestToken(profileId, apiToken);
                 if (response.permissions.Contains("WP"))
                 {
                     ValidToken = true;

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -35,9 +35,11 @@ namespace TarkovMonitor
             {
                 AuthorizationHeaderValueGetter = (rq, cr) => {
                     return Task.Run<string>(() => {
-                        string token = null;
-                        tokens.TryGetValue(currentProfile, out token);
-                        return token;
+                        if (tokens == null || !tokens.ContainsKey(currentProfile)) {
+                            throw new Exception("No PVE or PVP profile could be found, launch tarkov first");
+                        }
+                        
+                        return tokens[currentProfile];
                     });
                 },
             }
@@ -70,7 +72,7 @@ namespace TarkovMonitor
         {
             if (profileId == "")
             {
-                return;
+                throw new Exception("No PVP or PVE profile initialised, please launch Escape from Tarkov first");
             }
             tokens[profileId] = token;
             Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
@@ -79,6 +81,10 @@ namespace TarkovMonitor
 
         public static async Task<ProgressResponse> SetProfile(string profileId)
         {
+            if (profileId == "") {
+                throw new Exception("Can't set PVP or PVE profile, please launch Escape from Tarkov and then restart this application");
+            }
+
             if (currentProfile == profileId)
             {
                 return Progress;

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -35,11 +35,12 @@ namespace TarkovMonitor
             {
                 AuthorizationHeaderValueGetter = (rq, cr) => {
                     return Task.Run<string>(() => {
-                        if (tokens == null || !tokens.ContainsKey(currentProfile)) {
+                        string token = GetToken(currentProfile);
+                        if (token == "") {
                             throw new Exception("No PVE or PVP profile could be found, launch tarkov first");
                         }
                         
-                        return tokens[currentProfile];
+                        return token;
                     });
                 },
             }


### PR DESCRIPTION
Resolves [#73](https://github.com/the-hideout/TarkovMonitor/issues/73)

Not sure if the profile ID needs to be mapped to the API key as TarkovTracker isn't separating profiles (yet). This should do the job though 👍 

This also fixes the scenario where a user could be confused launching TarkovMonitor before launching Tarkov or having a profile reported in their logs. You'll still need to handle launching TarkovMonitor without even having Tarkov installed though....