### PR TITLE
Added visual timers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ TarkovMonitor is an Escape from Tarkov companion application that provides usefu
 - Statistics (all stored locally on your computer)
     - Track the your total sales on the flea market
     - Track how many times you play on each map
+- Visual Timers (have that friend that never heard the audio and asks "has the runthrough timer happened yet?")
+   - Displays "Time in Raid"
+   - Displays countdown for "Runthrough time"
+   - Display countdown for Scav cooldown time
 
 ## Installation
 

--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -70,6 +70,12 @@
             <setting name="tarkovTrackerTokens" serializeAs="String">
                 <value>{}</value>
             </setting>
+            <setting name="runthroughTime" serializeAs="String">
+                <value>00:07:10</value>
+            </setting>
+            <setting name="automaticallyDeleteScreenshotsAfterRaid" serializeAs="String">
+                <value>False</value>
+            </setting>
         </TarkovMonitor.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TarkovMonitor/Blazor/AppLayout.razor
+++ b/TarkovMonitor/Blazor/AppLayout.razor
@@ -25,6 +25,7 @@
 				<MudNavLink Href="/sounds" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Speaker">Sounds</MudNavLink>
 				<MudNavLink Href="/stats" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.BarChart">Stats</MudNavLink>
 				<MudNavLink Href="/raw" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.RawOn">Raw Logs</MudNavLink>
+				<MudNavLink Href="/timers" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Timer">Timers</MudNavLink>
 			</MudNavMenu>
 		</MudDrawer>
 		<MudMainContent Class="mt-2">

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -9,7 +9,7 @@
 @implements IDisposable
 
 <MudGrid Class="pa-0" Spacing="0">
-	<MudItem xs="12">
+    <MudItem xs="12">
         <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Notifications" Class="mr-2" />Notifications</MudText>
             <div>
@@ -53,6 +53,9 @@
                     }
                 </MudSelect>
             </div>
+            <div>
+                <MudTextField @bind-Value="@RunthroughTime" Label="Runthrough Time (HH:MM:SS)" Class="d-inline-flex" sx="3" />
+            </div>
         </MudPaper>
     </MudItem>
 
@@ -72,14 +75,14 @@
                 <MudSwitch @bind-Value="@SkipSplashSwitch" Label="Skip Tarkov.dev Splash Logo" Color="Color.Info" />
             </div>
         </MudPaper>
-	</MudItem>
+    </MudItem>
 
     <MudItem xs="12">
         <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Handshake" Class="mr-2"/>Data Collection</MudText>
             <MudSwitch @bind-Value="@SubmitQueueTimeSwitch" Label="Submit Queue Time Data" Color="Color.Info" />
         </MudPaper>
-	</MudItem>
+    </MudItem>
 
     <MudItem xs="12">
         <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
@@ -395,6 +398,19 @@
         set
         {
 
+        }
+    }
+
+    public TimeSpan RunthroughTime
+    {
+        get
+        {
+            return Properties.Settings.Default.runthroughTime;
+        }
+        set
+        {
+            Properties.Settings.Default.runthroughTime = value;
+            Properties.Settings.Default.Save();
         }
     }
 

--- a/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
+++ b/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
@@ -19,13 +19,17 @@
 
 @code {
 
+    [CascadingParameter(Name = "AppLayout")]
+    public AppLayout AppLayout { get; set; }
+
     private TimeSpan RunThroughRemainingTime;
     private TimeSpan TimeInRaidTime;
     private TimeSpan ScavCooldownTime;
     private DateTime? RaidStartTime;
-    private System.Timers.Timer timerRaid;
-    private System.Timers.Timer timerRunThrough;
-    private System.Timers.Timer timerScavCooldown;
+    private System.Threading.Timer timerRaid;
+    private System.Threading.Timer timerRunThrough;
+    private System.Threading.Timer timerScavCooldown;
+    private CancellationTokenSource cancellationTokenSource = new();
 
     protected override void OnInitialized()
     {
@@ -37,36 +41,30 @@
         eft.RaidStarted += Eft_RaidStarted;
         eft.RaidEnded += Eft_RaidEnded;
 
-        timerRaid = new System.Timers.Timer(TimeSpan.FromSeconds(1).TotalMilliseconds)
-            {
-                AutoReset = true,
-                Enabled = false
-            };
-        timerRaid.Elapsed += TimerRaid_Elapsed;
+        timerRaid = new System.Threading.Timer(TimerRaid_Elapsed, null, Timeout.Infinite, 1000);
+        timerRunThrough = new System.Threading.Timer(TimerRunThrough_Elapsed, null, Timeout.Infinite, 1000);
+        timerScavCooldown = new System.Threading.Timer(timerScanCooldown_Elapsed, null, Timeout.Infinite, 1000);
+    }
 
-        timerRunThrough = new System.Timers.Timer(TimeSpan.FromSeconds(1).TotalMilliseconds)
-            {
-                AutoReset = true,
-                Enabled = false
-            };
-        timerRunThrough.Elapsed += TimerRunThrough_Elapsed;
-
-        timerScavCooldown = new System.Timers.Timer(TimeSpan.FromSeconds(TarkovDev.ScavCooldownSeconds()).TotalMilliseconds)
-            {
-                AutoReset = true,
-                Enabled = false
-            };
-        timerScavCooldown.Elapsed += timerScanCooldown_Elapsed;
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        if (firstRender)
+        {
+            AppLayout.SetTitle("Timers");
+        }
     }
 
     private async void Eft_RaidStarted(object? sender, RaidInfoEventArgs e)
     {
-        Debug.Write(e.RaidInfo.StartedTime);
+        if (e.RaidInfo.Reconnected)
+            return;
+
         TimeInRaidTime = TimeSpan.Zero;
         RunThroughRemainingTime = Properties.Settings.Default.runthroughTime;
 
-        timerRaid.Start();
-        timerRunThrough.Start();
+        timerRaid.Change(0, 1000);
+        timerRunThrough.Change(0, 1000);
 
         await InvokeAsync(() => StateHasChanged());
     }
@@ -74,51 +72,56 @@
     private async void Eft_RaidEnded(object? sender, RaidInfoEventArgs e)
     {
         RunThroughRemainingTime = TimeSpan.Zero;
-        timerRunThrough.Stop();
-        timerRaid.Stop();
+        timerRunThrough.Change(Timeout.Infinite, Timeout.Infinite);
+        timerRaid.Change(Timeout.Infinite, Timeout.Infinite);
 
-        Debug.WriteLine(e.RaidInfo.RaidType);
-
-        if (e.RaidInfo.RaidType == RaidType.Scav || e.RaidInfo.RaidType == RaidType.PVE)
+        if (!e.RaidInfo.Reconnected && (e.RaidInfo.RaidType == RaidType.Scav || e.RaidInfo.RaidType == RaidType.PVE))
         {
-            timerScavCooldown.Stop();
-            timerScavCooldown.Interval = TimeSpan.FromSeconds(1).TotalMilliseconds;
-            timerScavCooldown.Start();
+            timerScavCooldown.Change(0, 1000);
         }
 
         await InvokeAsync(() => StateHasChanged());
     }
 
-    private async void TimerRaid_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+    private async void TimerRaid_Elapsed(object state)
     {
+        if (cancellationTokenSource.IsCancellationRequested)
+            return;
+
         TimeInRaidTime += TimeSpan.FromSeconds(1);
 
         await InvokeAsync(() => StateHasChanged());
     }
 
-    private async void TimerRunThrough_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+    private async void TimerRunThrough_Elapsed(object state)
     {
+        if (cancellationTokenSource.IsCancellationRequested)
+            return;
+
         if (RunThroughRemainingTime > TimeSpan.Zero)
         {
-            RunThroughRemainingTime = RunThroughRemainingTime.Subtract(TimeSpan.FromSeconds(1));
+            RunThroughRemainingTime -= TimeSpan.FromSeconds(1);
         }
         else
         {
-            timerRunThrough.Stop();
+            timerRunThrough.Change(Timeout.Infinite, Timeout.Infinite);
         }
 
         await InvokeAsync(() => StateHasChanged());
     }
 
-    private async void timerScanCooldown_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    private async void timerScanCooldown_Elapsed(object state)
     {
+        if (cancellationTokenSource.IsCancellationRequested)
+            return;
+
         if (ScavCooldownTime > TimeSpan.Zero)
         {
-            ScavCooldownTime = ScavCooldownTime.Subtract(TimeSpan.FromSeconds(1));
+            ScavCooldownTime -= TimeSpan.FromSeconds(1);
         }
         else
         {
-            timerScavCooldown.Stop();
+            timerScavCooldown.Change(Timeout.Infinite, Timeout.Infinite);
         }
 
         await InvokeAsync(() => StateHasChanged());
@@ -127,28 +130,24 @@
     // Clean Up Events
     public void Dispose()
     {
+        cancellationTokenSource.Cancel();
+        cancellationTokenSource.Dispose();
+
         eft.RaidStarted -= Eft_RaidStarted;
         eft.RaidEnded -= Eft_RaidEnded;
 
-        if (timerRunThrough != null)
-        {
-            timerRunThrough.Stop();
-            timerRunThrough.Elapsed -= TimerRunThrough_Elapsed;
-            timerRunThrough.Dispose();
-        }
+        DisposeTimer(timerRunThrough);
+        DisposeTimer(timerRaid);
+        DisposeTimer(timerScavCooldown);
 
-        if (timerRaid != null)
-        {
-            timerRaid.Stop();
-            timerRaid.Elapsed -= TimerRaid_Elapsed;
-            timerRaid.Dispose();
-        }
+    }
 
-        if (timerScavCooldown != null)
+    private void DisposeTimer(System.Threading.Timer timer)
+    {
+        if (timer != null)
         {
-            timerScavCooldown.Stop();
-            timerScavCooldown.Elapsed -= timerScanCooldown_Elapsed;
-            timerScavCooldown.Dispose();
+            timer.Change(Timeout.Infinite, Timeout.Infinite);
+            timer.Dispose();
         }
     }
 

--- a/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
+++ b/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
@@ -1,0 +1,155 @@
+﻿@page "/timers"
+@using System.Diagnostics
+@inject GameWatcher eft
+@layout AppLayout
+@implements IDisposable
+
+<MudGrid Class="pa-0" Spacing="0">
+    <MudItem xs="12">
+        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" />Timers</MudText>
+            <MudList T="string">
+                <MudListItem>Time In Raid: @TimeInRaidTime</MudListItem>
+                <MudListItem>Runthrough Period: @RunThroughRemainingTime</MudListItem>
+                <MudListItem>Scav Cooldown: @ScavCooldownTime</MudListItem>
+            </MudList>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+@code {
+
+    private TimeSpan RunThroughRemainingTime;
+    private TimeSpan TimeInRaidTime;
+    private TimeSpan ScavCooldownTime;
+    private DateTime? RaidStartTime;
+    private System.Timers.Timer timerRaid;
+    private System.Timers.Timer timerRunThrough;
+    private System.Timers.Timer timerScavCooldown;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        RunThroughRemainingTime = Properties.Settings.Default.runthroughTime;
+        ScavCooldownTime = TimeSpan.FromSeconds(TarkovDev.ScavCooldownSeconds());
+
+        eft.RaidStarted += Eft_RaidStarted;
+        eft.RaidEnded += Eft_RaidEnded;
+
+        timerRaid = new System.Timers.Timer(TimeSpan.FromSeconds(1).TotalMilliseconds)
+            {
+                AutoReset = true,
+                Enabled = false
+            };
+        timerRaid.Elapsed += TimerRaid_Elapsed;
+
+        timerRunThrough = new System.Timers.Timer(TimeSpan.FromSeconds(1).TotalMilliseconds)
+            {
+                AutoReset = true,
+                Enabled = false
+            };
+        timerRunThrough.Elapsed += TimerRunThrough_Elapsed;
+
+        timerScavCooldown = new System.Timers.Timer(TimeSpan.FromSeconds(TarkovDev.ScavCooldownSeconds()).TotalMilliseconds)
+            {
+                AutoReset = true,
+                Enabled = false
+            };
+        timerScavCooldown.Elapsed += timerScanCooldown_Elapsed;
+    }
+
+    private async void Eft_RaidStarted(object? sender, RaidInfoEventArgs e)
+    {
+        Debug.Write(e.RaidInfo.StartedTime);
+        TimeInRaidTime = TimeSpan.Zero;
+        RunThroughRemainingTime = Properties.Settings.Default.runthroughTime;
+
+        timerRaid.Start();
+        timerRunThrough.Start();
+
+        await InvokeAsync(() => StateHasChanged());
+    }
+
+    private async void Eft_RaidEnded(object? sender, RaidInfoEventArgs e)
+    {
+        RunThroughRemainingTime = TimeSpan.Zero;
+        timerRunThrough.Stop();
+        timerRaid.Stop();
+
+        Debug.WriteLine(e.RaidInfo.RaidType);
+
+        if (e.RaidInfo.RaidType == RaidType.Scav || e.RaidInfo.RaidType == RaidType.PVE)
+        {
+            timerScavCooldown.Stop();
+            timerScavCooldown.Interval = TimeSpan.FromSeconds(1).TotalMilliseconds;
+            timerScavCooldown.Start();
+        }
+
+        await InvokeAsync(() => StateHasChanged());
+    }
+
+    private async void TimerRaid_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+    {
+        TimeInRaidTime += TimeSpan.FromSeconds(1);
+
+        await InvokeAsync(() => StateHasChanged());
+    }
+
+    private async void TimerRunThrough_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (RunThroughRemainingTime > TimeSpan.Zero)
+        {
+            RunThroughRemainingTime = RunThroughRemainingTime.Subtract(TimeSpan.FromSeconds(1));
+        }
+        else
+        {
+            timerRunThrough.Stop();
+        }
+
+        await InvokeAsync(() => StateHasChanged());
+    }
+
+    private async void timerScanCooldown_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        if (ScavCooldownTime > TimeSpan.Zero)
+        {
+            ScavCooldownTime = ScavCooldownTime.Subtract(TimeSpan.FromSeconds(1));
+        }
+        else
+        {
+            timerScavCooldown.Stop();
+        }
+
+        await InvokeAsync(() => StateHasChanged());
+    }
+
+    // Clean Up Events
+    public void Dispose()
+    {
+        eft.RaidStarted -= Eft_RaidStarted;
+        eft.RaidEnded -= Eft_RaidEnded;
+
+        if (timerRunThrough != null)
+        {
+            timerRunThrough.Stop();
+            timerRunThrough.Elapsed -= TimerRunThrough_Elapsed;
+            timerRunThrough.Dispose();
+        }
+
+        if (timerRaid != null)
+        {
+            timerRaid.Stop();
+            timerRaid.Elapsed -= TimerRaid_Elapsed;
+            timerRaid.Dispose();
+        }
+
+        if (timerScavCooldown != null)
+        {
+            timerScavCooldown.Stop();
+            timerScavCooldown.Elapsed -= timerScanCooldown_Elapsed;
+            timerScavCooldown.Dispose();
+        }
+    }
+
+}

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -263,9 +263,13 @@ namespace TarkovMonitor
                 //var logPattern = @"(?<message>^\d{4}-\d{2}-\d{2}.+$)\s*(?<json>^{[\s\S]+?^})?";
                 //var logPattern = @"(?<date>^\d{4}-\d{2}-\d{2}) (?<time>\d{2}:\d{2}:\d{2}\.\d{3} [+-]\d{2}:\d{2})\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|(?<message>.+$)\s*(?<json>^{[\s\S]+?^})?";
                 var logMessages = Regex.Matches(e.Data, logPattern, RegexOptions.Multiline);
-                /*Debug.WriteLine("===log chunk start===");
-                Debug.WriteLine(e.NewMessage);
-                Debug.WriteLine("===log chunk end===");*/
+
+#if DEBUG                
+                Debug.WriteLine("===log chunk start===");
+                Debug.WriteLine(e.Data);
+                Debug.WriteLine("===log chunk end===");
+#endif
+
                 foreach (Match logMessage in logMessages)
                 {
                     var eventDate = new DateTime();

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -134,7 +134,7 @@ namespace TarkovMonitor
 
             blazorWebView1.WebView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
 
-            runthroughTimer = new System.Timers.Timer(TimeSpan.FromMinutes(7).TotalMilliseconds + TimeSpan.FromSeconds(10).TotalMilliseconds)
+            runthroughTimer = new System.Timers.Timer(Properties.Settings.Default.runthroughTime.TotalMilliseconds)
             {
                 AutoReset = false,
                 Enabled = false

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -180,6 +180,7 @@ namespace TarkovMonitor
             if (Properties.Settings.Default.runthroughAlert)
             {
                 Sound.Play("runthrough_over");
+                messageLog.AddMessage("Runthrough period over", "info");
             }
         }
 

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace TarkovMonitor.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.12.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -178,22 +178,7 @@ namespace TarkovMonitor.Properties {
                 this["navigateMapOnPositionUpdate"] = value;
             }
         }
-
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool automaticallyDeleteScreenshotsAfterRaid
-        {
-            get
-            {
-                return ((bool)(this["automaticallyDeleteScreenshotsAfterRaid"]));
-            }
-            set
-            {
-                this["automaticallyDeleteScreenshotsAfterRaid"] = value;
-            }
-        }        
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -287,6 +272,30 @@ namespace TarkovMonitor.Properties {
             }
             set {
                 this["tarkovTrackerTokens"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("00:07:10")]
+        public global::System.TimeSpan runthroughTime {
+            get {
+                return ((global::System.TimeSpan)(this["runthroughTime"]));
+            }
+            set {
+                this["runthroughTime"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool automaticallyDeleteScreenshotsAfterRaid {
+            get {
+                return ((bool)(this["automaticallyDeleteScreenshotsAfterRaid"]));
+            }
+            set {
+                this["automaticallyDeleteScreenshotsAfterRaid"] = value;
             }
         }
     }

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -65,5 +65,11 @@
     <Setting Name="tarkovTrackerTokens" Type="System.String" Scope="User">
       <Value Profile="(Default)">{}</Value>
     </Setting>
+    <Setting Name="runthroughTime" Type="System.TimeSpan" Scope="User">
+      <Value Profile="(Default)">00:07:10</Value>
+    </Setting>
+    <Setting Name="automaticallyDeleteScreenshotsAfterRaid" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\TarkovDev.ico</ApplicationIcon>
-    <AssemblyVersion>1.6.2.0</AssemblyVersion>
+    <AssemblyVersion>1.6.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have added a visual timers section for friends who do not hear the audio notification that always asks, "Has the run-through timer passed yet?"

![image](https://github.com/user-attachments/assets/38345876-18dd-456e-8635-39db89029acb)

Timers:
- Time in Raid
- Runthrough Period Countdown
- Scav Cooldown Countdown

**Additional Changes:**
- Moved runthrough value to settings in an attempt to reduce duplicative values.
- added "#if DEBUG" around Debug.WriteLine statements in GameWatcher_NewLogData. Code does not exist in the release build; it will only exist and run in debug mode.
- automaticallyDeleteScreenshotsAfterRaid was missing from settings -- added.
- added message.add for runthrough alert so it shows up in messages.