### PR TITLE
Allow use of other tracker services

### DIFF
--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -10,6 +10,12 @@
             <setting name="tarkovTrackerToken" serializeAs="String">
                 <value />
             </setting>
+            <setting name="tarkovTrackerUseCustomUrl" serializeAs="String">
+              <value>False</value>
+            </setting>
+            <setting name="tarkovTrackerUrl" serializeAs="String">
+              <value>https://tarkovtracker.io/api/v2</value>
+            </setting>
             <setting name="submitQueueTime" serializeAs="String">
                 <value>False</value>
             </setting>

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -91,8 +91,21 @@
     <MudItem xs="12">
         <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/>TarkovTracker</MudText>
-            <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">Get A Token</MudButton><MudButton @onclick="TestToken" @bind-Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">Test Token</MudButton>
+            @if (!Properties.Settings.Default.tarkovTrackerUseCustomUrl)
+            {
+              <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">Get A Token</MudButton>
+            }
+            <MudButton @onclick="TestToken" @bind-Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">Test Token</MudButton>
             <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Label="API Token" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
+            <div>
+                <MudSwitch @bind-Value="@TarkovTrackerUseCustomUrl" Label="Use custom tracking service" Color="Color.Info" />
+            </div>
+            @if (Properties.Settings.Default.tarkovTrackerUseCustomUrl)
+            {
+                <div>
+                  <MudTextField @bind-Value="@TarkovTrackerUrl" Label="Tracker API URL" />
+                </div>
+            }
         </MudPaper>
     </MudItem>
 
@@ -455,6 +468,35 @@
         set
         {
             TarkovTracker.SetToken(eft.CurrentProfile.Id, value);
+        }
+    }
+    public bool TarkovTrackerUseCustomUrl
+    {
+        get
+        {
+            return Properties.Settings.Default.tarkovTrackerUseCustomUrl;
+        }
+        set
+        {
+            Properties.Settings.Default.tarkovTrackerUseCustomUrl = value;
+            if (!value) {
+              Properties.Settings.Default.tarkovTrackerUrl = "https://tarkovtracker.io/api/v2";
+              TarkovTracker.InitAPI();
+            }
+            Properties.Settings.Default.Save();
+        }
+    }
+    public string TarkovTrackerUrl
+    {
+        get
+        {
+            return Properties.Settings.Default.tarkovTrackerUrl;
+        }
+        set
+        {
+            Properties.Settings.Default.tarkovTrackerUrl = value;
+            Properties.Settings.Default.Save();
+            TarkovTracker.InitAPI();
         }
     }
 

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -38,6 +38,30 @@ namespace TarkovMonitor.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool tarkovTrackerUseCustomUrl {
+            get {
+                return ((bool)(this["tarkovTrackerUseCustomUrl"]));
+            }
+            set {
+                this["tarkovTrackerUseCustomUrl"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("https://tarkovtracker.io/api/v2")]
+        public string tarkovTrackerUrl {
+            get {
+                return ((string)(this["tarkovTrackerUrl"]));
+            }
+            set {
+                this["tarkovTrackerUrl"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool submitQueueTime {
             get {
                 return ((bool)(this["submitQueueTime"]));

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -5,6 +5,12 @@
     <Setting Name="tarkovTrackerToken" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="tarkovTrackerUseCustomUrl" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="tarkovTrackerUrl" Type="System.String" Scope="User">
+      <Value Profile="(Default)">https://tarkovtracker.io/api/v2</Value>
+    </Setting>
     <Setting Name="submitQueueTime" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -30,16 +30,7 @@ namespace TarkovMonitor
             Task<string> SetTaskStatuses([Body] List<TaskStatusBody> body);
         }
 
-        private static ITarkovTrackerAPI api = RestService.For<ITarkovTrackerAPI>("https://tarkovtracker.io/api/v2",
-            new RefitSettings
-            {
-                AuthorizationHeaderValueGetter = (rq, cr) => {
-                    return Task.Run<string>(() => {
-                        return GetToken(currentProfile ?? "");
-                    });
-                },
-            }
-        );
+        private static ITarkovTrackerAPI api = InitAPI();
 
         public static ProgressResponse Progress { get; private set; } = new();
         public static bool ValidToken { get; private set; } = false;
@@ -53,6 +44,19 @@ namespace TarkovMonitor
 
         static TarkovTracker() {
             tokens = JsonSerializer.Deserialize<Dictionary<string, string>>(Properties.Settings.Default.tarkovTrackerTokens) ?? tokens;
+        }
+
+        public static ITarkovTrackerAPI InitAPI()
+        {
+            return api = RestService.For<ITarkovTrackerAPI>(Properties.Settings.Default.tarkovTrackerUrl,
+                new RefitSettings {
+                    AuthorizationHeaderValueGetter = (rq, cr) => {
+                        return Task.Run<string>(() => {
+                            return GetToken(currentProfile ?? "");
+                        });
+                    },
+                }
+            );
         }
 
         public static string GetToken(string profileId)


### PR DESCRIPTION
Adds an option to the settings to allow a custom URL to be used for TarkovTracker - enabling alternative tracking services (that follow Tracker's schema) to be used. 

Default state: 
![image](https://github.com/user-attachments/assets/8a206dd3-742a-4735-82e6-179413a0a339)

"Use custom tracking service" enabled:
![image](https://github.com/user-attachments/assets/63ae58b1-9de2-4a3f-97f0-e4bb21f9f7c1)

When the switch is toggled **off**, the URL is reverted to the default TarkovTracker URL.
