### PR TITLE
Add auto screenshot feature for tarkov.dev map position updates

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -133,7 +133,14 @@
             <div>
                 <MudSwitch @bind-Value="@AutomaticallyDeleteScreenshotsAfterRaid" Label="@LocalizationService.GetString("AutomaticallyDeleteScreenshotsAfterRaid")" Color="Color.Info" />
             </div>
-            <MudSelect @bind-Value="@MapOverrideSelect" T="string" Label="@LocalizationService.GetString("OfflineMap")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("MapToUseForOfflineRaids")" AnchorOrigin="Origin.BottomCenter" xs="3">
+            <div>
+                <MudSwitch @bind-Value="@AutoScreenshotSwitch" Label="@LocalizationService.GetString("AutoScreenshotEnable")" Color="Color.Info" Disabled="@(string.IsNullOrEmpty(RemoteID))" />
+            </div>
+            <div>
+                <MudNumericField @bind-Value="@AutoScreenshotInterval" Label="@LocalizationService.GetString("AutoScreenshotInterval")" Min="1" Max="60" Disabled="@(!AutoScreenshotSwitch)" Adornment="Adornment.End" AdornmentText="@LocalizationService.GetString("Seconds")" Class="d-inline-flex" Style="max-width: 200px;" />
+            </div>
+            <MudText Typo="Typo.caption" Class="mud-text-secondary">@LocalizationService.GetString("AutoScreenshotDescription")</MudText>
+            <MudSelect @bind-Value="@MapOverrideSelect" T="string" Label="@LocalizationService.GetString("OfflineMap")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("MapToUseForOfflineRaids")" AnchorOrigin="Origin.BottomCenter" xs="3" Class="mt-3">
                 <MudSelectItem T="string" Value="@string.Empty">@LocalizationService.GetString("None")</MudSelectItem>
                 @foreach (var map in TarkovDev.Maps)
                 {
@@ -659,6 +666,32 @@
         set
         {
             Properties.Settings.Default.automaticallyDeleteScreenshotsAfterRaid = value;
+            Properties.Settings.Default.Save();
+        }
+    }
+
+    public bool AutoScreenshotSwitch
+    {
+        get
+        {
+            return Properties.Settings.Default.autoScreenshot;
+        }
+        set
+        {
+            Properties.Settings.Default.autoScreenshot = value;
+            Properties.Settings.Default.Save();
+        }
+    }
+
+    public int AutoScreenshotInterval
+    {
+        get
+        {
+            return Properties.Settings.Default.autoScreenshotInterval;
+        }
+        set
+        {
+            Properties.Settings.Default.autoScreenshotInterval = value;
             Properties.Settings.Default.Save();
         }
     }

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -9,11 +9,47 @@ using System.ComponentModel;
 using MudBlazor;
 using Microsoft.Extensions.Localization;
 using System.Text.Json.Nodes;
+using System.Runtime.InteropServices;
 
 namespace TarkovMonitor
 {
     public partial class MainBlazorUI : Form
     {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr FindWindow(string? lpClassName, string lpWindowName);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct INPUT
+        {
+            public uint type;
+            public InputUnion U;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 32)]
+        private struct InputUnion
+        {
+            [FieldOffset(0)] public KEYBDINPUT ki;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct KEYBDINPUT
+        {
+            public ushort wVk;
+            public ushort wScan;
+            public uint dwFlags;
+            public uint time;
+            public IntPtr dwExtraInfo;
+        }
+
+        private const uint INPUT_KEYBOARD = 1;
+        private const uint KEYEVENTF_KEYUP = 0x0002;
+
         private readonly GameWatcher eft;
         private readonly MessageLog messageLog;
         private readonly LogRepository logRepository;
@@ -21,8 +57,10 @@ namespace TarkovMonitor
         private readonly TimersManager timersManager;
         private readonly System.Timers.Timer runthroughTimer;
         private readonly System.Timers.Timer scavCooldownTimer;
+        private readonly System.Timers.Timer autoScreenshotTimer;
         private LocalizationService localizationService;
         private bool inRaid;
+        private int screenshotKeyCode = 0x7B; // Default to F12 (VK_F12)
 
         public MainBlazorUI()
         {
@@ -140,6 +178,19 @@ namespace TarkovMonitor
                 {
                     eft.LogsPath = Properties.Settings.Default.customLogsPath;
                 }
+                if (e.PropertyName == "autoScreenshot" || e.PropertyName == "autoScreenshotInterval")
+                {
+                    if (inRaid && Properties.Settings.Default.autoScreenshot && !string.IsNullOrEmpty(Properties.Settings.Default.remoteId))
+                    {
+                        autoScreenshotTimer.Stop();
+                        autoScreenshotTimer.Interval = Properties.Settings.Default.autoScreenshotInterval * 1000;
+                        autoScreenshotTimer.Start();
+                    }
+                    else
+                    {
+                        autoScreenshotTimer.Stop();
+                    }
+                }
             };
 
             TarkovTracker.ProgressRetrieved += TarkovTracker_ProgressRetrieved;
@@ -165,22 +216,68 @@ namespace TarkovMonitor
                 Enabled = false
             };
             scavCooldownTimer.Elapsed += ScavCooldownTimer_Elapsed;
+
+            autoScreenshotTimer = new System.Timers.Timer(Properties.Settings.Default.autoScreenshotInterval * 1000)
+            {
+                AutoReset = true,
+                Enabled = false
+            };
+            autoScreenshotTimer.Elapsed += AutoScreenshotTimer_Elapsed;
         }
 
         private void Eft_ControlSettings(object? sender, ControlSettingsEventArgs e)
         {
             JsonArray keyBindings = e.ControlSettings["keyBindings"].AsArray();
-            JsonNode screenshotBind = keyBindings.FirstOrDefault((n) => n.AsObject()["keyName"].ToString() == "MakeScreenshot" && n.AsObject()["variants"].AsArray().Any(variant => variant.AsObject()["keyCode"].AsArray().Count > 0));
+            JsonNode? screenshotBind = keyBindings.FirstOrDefault((n) => n.AsObject()["keyName"].ToString() == "MakeScreenshot" && n.AsObject()["variants"].AsArray().Any(variant => variant.AsObject()["keyCode"].AsArray().Count > 0));
             if (screenshotBind == null)
             {
                 messageLog.AddMessage($"Screenshot key is not bound in EFT. Using this keybind is required to update tarkov.dev map position.", "info");
+                return;
             }
             var variant = screenshotBind["variants"].AsArray().First(variant => variant.AsObject()["keyCode"].AsArray().Count > 0);
             var keys = variant["keyCode"].AsArray().Select(n => n.GetValue<string>());
             if (keys.Any(key => key == "SysReq"))
             {
-                messageLog.AddMessage($"Screenshot key is not properly bound in EFT. Please re-bind your screenshot key in EFT for use with updatinge tarkov.dev map position.", "info");
+                messageLog.AddMessage($"Screenshot key is not properly bound in EFT. Please re-bind your screenshot key in EFT for use with updating tarkov.dev map position.", "info");
             }
+
+            var keyName = variant["keyCode"].AsArray()[0]?.GetValue<string>();
+            if (!string.IsNullOrEmpty(keyName))
+            {
+                screenshotKeyCode = UnityKeyCodeMapper.ToVirtualKey(keyName);
+            }
+        }
+
+        private void TriggerScreenshot()
+        {
+            IntPtr hWnd = FindWindow(null, "EscapeFromTarkov");
+            if (hWnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            IntPtr foregroundWindow = GetForegroundWindow();
+            if (foregroundWindow != hWnd)
+            {
+                return;
+            }
+
+            INPUT[] inputs = new INPUT[2];
+
+            inputs[0].type = INPUT_KEYBOARD;
+            inputs[0].U.ki.wVk = (ushort)screenshotKeyCode;
+            inputs[0].U.ki.dwFlags = 0;
+
+            inputs[1].type = INPUT_KEYBOARD;
+            inputs[1].U.ki.wVk = (ushort)screenshotKeyCode;
+            inputs[1].U.ki.dwFlags = KEYEVENTF_KEYUP;
+
+            SendInput(2, inputs, Marshal.SizeOf(typeof(INPUT)));
+        }
+
+        private void AutoScreenshotTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+        {
+            TriggerScreenshot();
         }
 
         private void Eft_ProfileChanged(object? sender, ProfileEventArgs e)
@@ -279,6 +376,7 @@ namespace TarkovMonitor
 
             messageLog.AddMessage(monMessage);
             runthroughTimer.Stop();
+            autoScreenshotTimer.Stop();
             if (Properties.Settings.Default.scavCooldownAlert && (e.RaidInfo.RaidType == RaidType.Scav || e.RaidInfo.RaidType == RaidType.PVE))
             {
                 scavCooldownTimer.Stop();
@@ -734,6 +832,12 @@ namespace TarkovMonitor
                 runthroughTimer.Stop();
                 runthroughTimer.Start();
             }
+            if (Properties.Settings.Default.autoScreenshot && !string.IsNullOrEmpty(Properties.Settings.Default.remoteId))
+            {
+                autoScreenshotTimer.Stop();
+                autoScreenshotTimer.Interval = Properties.Settings.Default.autoScreenshotInterval * 1000;
+                autoScreenshotTimer.Start();
+            }
             if (Properties.Settings.Default.submitQueueTime && e.RaidInfo.QueueTime > 0 && e.RaidInfo.RaidType != RaidType.Unknown)
             {
                 try
@@ -781,6 +885,7 @@ namespace TarkovMonitor
         {
             groupManager.Stale = true;
             runthroughTimer.Stop();
+            autoScreenshotTimer.Stop();
             inRaid = false;
             try
             {

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -334,5 +334,29 @@ namespace TarkovMonitor.Properties {
                 this["language"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool autoScreenshot {
+            get {
+                return ((bool)(this["autoScreenshot"]));
+            }
+            set {
+                this["autoScreenshot"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("30")]
+        public int autoScreenshotInterval {
+            get {
+                return ((int)(this["autoScreenshotInterval"]));
+            }
+            set {
+                this["autoScreenshotInterval"] = value;
+            }
+        }
     }
 }

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -80,5 +80,11 @@
     <Setting Name="language" Type="System.String" Scope="User">
       <Value Profile="(Default)">en</Value>
     </Setting>
+    <Setting Name="autoScreenshot" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="autoScreenshotInterval" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">30</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TarkovMonitor/Properties/Strings.resx
+++ b/TarkovMonitor/Properties/Strings.resx
@@ -207,6 +207,18 @@
   <data name="AutomaticallyDeleteScreenshotsAfterRaid" xml:space="preserve">
     <value>Automatically delete taken screenshots after raid</value>
   </data>
+  <data name="AutoScreenshotEnable" xml:space="preserve">
+    <value>Enable auto screenshot</value>
+  </data>
+  <data name="AutoScreenshotInterval" xml:space="preserve">
+    <value>Interval</value>
+  </data>
+  <data name="AutoScreenshotDescription" xml:space="preserve">
+    <value>Automatically takes screenshots during raids to update your position on tarkov.dev map.</value>
+  </data>
+  <data name="Seconds" xml:space="preserve">
+    <value>seconds</value>
+  </data>
   <data name="OfflineMap" xml:space="preserve">
     <value>Offline Map</value>
   </data>

--- a/TarkovMonitor/UnityKeyCodeMapper.cs
+++ b/TarkovMonitor/UnityKeyCodeMapper.cs
@@ -1,0 +1,178 @@
+using System.Collections.Generic;
+
+namespace TarkovMonitor
+{
+    /// <summary>
+    /// Maps Unity KeyCode names to Windows Virtual Key codes.
+    /// Based on: https://gist.github.com/jhincapie/8a4c95d5cbe81d79b329ffc37e9f6c97
+    /// </summary>
+    public static class UnityKeyCodeMapper
+    {
+        private static readonly Dictionary<string, int> UnityToVirtualKey = new()
+        {
+            // Function keys
+            ["F1"] = 0x70,
+            ["F2"] = 0x71,
+            ["F3"] = 0x72,
+            ["F4"] = 0x73,
+            ["F5"] = 0x74,
+            ["F6"] = 0x75,
+            ["F7"] = 0x76,
+            ["F8"] = 0x77,
+            ["F9"] = 0x78,
+            ["F10"] = 0x79,
+            ["F11"] = 0x7A,
+            ["F12"] = 0x7B,
+            ["F13"] = 0x7C,
+            ["F14"] = 0x7D,
+            ["F15"] = 0x7E,
+
+            // Alphanumeric - letters
+            ["A"] = 0x41,
+            ["B"] = 0x42,
+            ["C"] = 0x43,
+            ["D"] = 0x44,
+            ["E"] = 0x45,
+            ["F"] = 0x46,
+            ["G"] = 0x47,
+            ["H"] = 0x48,
+            ["I"] = 0x49,
+            ["J"] = 0x4A,
+            ["K"] = 0x4B,
+            ["L"] = 0x4C,
+            ["M"] = 0x4D,
+            ["N"] = 0x4E,
+            ["O"] = 0x4F,
+            ["P"] = 0x50,
+            ["Q"] = 0x51,
+            ["R"] = 0x52,
+            ["S"] = 0x53,
+            ["T"] = 0x54,
+            ["U"] = 0x55,
+            ["V"] = 0x56,
+            ["W"] = 0x57,
+            ["X"] = 0x58,
+            ["Y"] = 0x59,
+            ["Z"] = 0x5A,
+
+            // Alphanumeric - numbers (top row)
+            ["Alpha0"] = 0x30,
+            ["Alpha1"] = 0x31,
+            ["Alpha2"] = 0x32,
+            ["Alpha3"] = 0x33,
+            ["Alpha4"] = 0x34,
+            ["Alpha5"] = 0x35,
+            ["Alpha6"] = 0x36,
+            ["Alpha7"] = 0x37,
+            ["Alpha8"] = 0x38,
+            ["Alpha9"] = 0x39,
+
+            // Numpad
+            ["Keypad0"] = 0x60,
+            ["Keypad1"] = 0x61,
+            ["Keypad2"] = 0x62,
+            ["Keypad3"] = 0x63,
+            ["Keypad4"] = 0x64,
+            ["Keypad5"] = 0x65,
+            ["Keypad6"] = 0x66,
+            ["Keypad7"] = 0x67,
+            ["Keypad8"] = 0x68,
+            ["Keypad9"] = 0x69,
+            ["KeypadMultiply"] = 0x6A,
+            ["KeypadPlus"] = 0x6B,
+            ["KeypadMinus"] = 0x6D,
+            ["KeypadPeriod"] = 0x6E,
+            ["KeypadDivide"] = 0x6F,
+            ["KeypadEnter"] = 0x0D,
+            ["KeypadEquals"] = 0xBB,
+
+            // Navigation
+            ["UpArrow"] = 0x26,
+            ["DownArrow"] = 0x28,
+            ["LeftArrow"] = 0x25,
+            ["RightArrow"] = 0x27,
+            ["Home"] = 0x24,
+            ["End"] = 0x23,
+            ["PageUp"] = 0x21,
+            ["PageDown"] = 0x22,
+            ["Insert"] = 0x2D,
+            ["Delete"] = 0x2E,
+
+            // Modifiers
+            ["LeftShift"] = 0xA0,
+            ["RightShift"] = 0xA1,
+            ["LeftControl"] = 0xA2,
+            ["RightControl"] = 0xA3,
+            ["LeftAlt"] = 0xA4,
+            ["RightAlt"] = 0xA5,
+            ["LeftWindows"] = 0x5B,
+            ["RightWindows"] = 0x5C,
+            ["LeftCommand"] = 0x5B,
+            ["RightCommand"] = 0x5C,
+
+            // Special keys
+            ["Backspace"] = 0x08,
+            ["Tab"] = 0x09,
+            ["Return"] = 0x0D,
+            ["Escape"] = 0x1B,
+            ["Space"] = 0x20,
+            ["Pause"] = 0x13,
+            ["Clear"] = 0x0C,
+            ["Help"] = 0x2F,
+            ["Print"] = 0x2A,
+            ["SysReq"] = 0x2C,
+            ["Break"] = 0x03,
+            ["Menu"] = 0x5D,
+
+            // Lock keys
+            ["Numlock"] = 0x90,
+            ["CapsLock"] = 0x14,
+            ["ScrollLock"] = 0x91,
+
+            // OEM keys (punctuation)
+            ["BackQuote"] = 0xC0,
+            ["Minus"] = 0xBD,
+            ["Equals"] = 0xBB,
+            ["Plus"] = 0xBB,
+            ["LeftBracket"] = 0xDB,
+            ["RightBracket"] = 0xDD,
+            ["Backslash"] = 0xDC,
+            ["Semicolon"] = 0xBA,
+            ["Colon"] = 0xBA,
+            ["Quote"] = 0xDE,
+            ["DoubleQuote"] = 0xDE,
+            ["Comma"] = 0xBC,
+            ["Period"] = 0xBE,
+            ["Slash"] = 0xBF,
+            ["Question"] = 0xBF,
+            ["Less"] = 0xBC,
+            ["Greater"] = 0xBE,
+            ["At"] = 0x32,
+            ["Exclaim"] = 0x31,
+            ["Hash"] = 0x33,
+            ["Dollar"] = 0x34,
+            ["Percent"] = 0x35,
+            ["Caret"] = 0x36,
+            ["Ampersand"] = 0x37,
+            ["Asterisk"] = 0x38,
+            ["LeftParen"] = 0x39,
+            ["RightParen"] = 0x30,
+            ["Underscore"] = 0xBD,
+            ["Tilde"] = 0xC0,
+        };
+
+        /// <summary>
+        /// Converts a Unity KeyCode name to a Windows Virtual Key code.
+        /// </summary>
+        /// <param name="unityKeyName">The Unity KeyCode name (e.g., "F12", "Equals", "Space")</param>
+        /// <param name="defaultKey">The default VK code to return if not found (default: F12 = 0x7B)</param>
+        /// <returns>The Windows Virtual Key code</returns>
+        public static int ToVirtualKey(string unityKeyName, int defaultKey = 0x7B)
+        {
+            if (string.IsNullOrEmpty(unityKeyName))
+                return defaultKey;
+
+            return UnityToVirtualKey.TryGetValue(unityKeyName, out var vk) ? vk : defaultKey;
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds an optional auto-screenshot feature that automatically takes in-game screenshots at a configurable interval during raids. This enables continuous position updates on tarkov.dev maps without manual key presses.

## How it works
1. Detects the screenshot keybind from EFT's control settings automatically
2. When enabled and in a raid, triggers the screenshot key at the configured interval (1-60 seconds, default 30)
3. Screenshots are only sent when EFT is the active foreground window
4. Timer starts on raid start and stops on raid end/exit

## Implementation
- Uses Windows `SendInput` API to simulate the screenshot keypress
- Added `UnityKeyCodeMapper.cs` - maps Unity KeyCode names to Windows Virtual Key codes (based on [this gist](https://gist.github.com/jhincapie/8a4c95d5cbe81d79b329ffc37e9f6c97))
- Settings: `autoScreenshot` (bool) and `autoScreenshotInterval` (int)
- UI: Toggle and interval field in Settings under tarkov.dev section

## Requirements
- Requires TarkovMonitor to run as Administrator (for SendInput to work with EFT)
- Requires Remote ID to be configured

---

I'd like to open a discussion about whether this feature is appropriate for TarkovMonitor.

This feature only automates taking screenshots - the same action a player can do manually or achieve with screen recording software. It doesn't read game memory, modify game files, or provide any information not already available through screenshots. The position tracking on tarkov.dev already exists and works via manual screenshots. This simply automates the keypress. I understand if the maintainers prefer to keep TarkovMonitor strictly passive (read-only from logs). Happy to close this and resort to a simple AHK script instead.

The `SendInput` API requires elevated privileges to send keystrokes to EFT. Is this a dealbreaker for the project?

I'm not a fan of having to add the full Unity to Windows key mapping file (`UnityKeyCodeMapper.cs`), but it's the only way to leverage the existing functionality that detects the screenshot key from EFT's settings. An alternative would be to have the user manually set the screenshot key in TarkovMonitor settings instead.