### PR TITLE
Pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@8e6bd2905eef86446227f003dda1deb3916c4aaf # pin@v2
         with:
           dotnet-version: "6.x" # Change this to the desired .NET version
 
@@ -28,7 +28,7 @@ jobs:
         run: dotnet publish -c Release --self-contained --runtime win-x64 -p:PublishSingleFile=true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: Published Application
           path: TarkovMonitor\bin\Release\net6.0-windows\win-x64\publish\*

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@8e6bd2905eef86446227f003dda1deb3916c4aaf # pin@v2
         with:
           dotnet-version: "6.x" # Change this to the desired .NET version
 
@@ -31,7 +31,7 @@ jobs:
           Compress-Archive -Destination $Env:GITHUB_WORKSPACE/TarkovMonitor.zip -Path .\*
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1
         with:
           files: TarkovMonitor.zip
           prerelease: true


### PR DESCRIPTION
## Summary
- Pin workflow `uses:` refs to full-length commit SHAs
- Remove the retired Combine PR workflow when present
- Preserve readable source refs in `# pin@...` comments

## Test
- Verified via GitHub API scan that workflow `uses:` refs on this branch are pinned to full-length SHAs
