### PR TITLE
Improve pause-media state handling and raid transitions

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
+++ b/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
@@ -46,7 +46,7 @@
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.MusicNote" Class="mr-2"/>Media Control</MudText>
             <div>
                 <MudSwitch @bind-Value="@PauseMediaOnRaidSwitch" Label="Pause media on raid start" Color="Color.Primary" />
-                <MudText Typo="Typo.caption" Class="ml-7">Automatically pause playing Spotify, Apple Music, or iTunes sessions when entering a raid and resume them when leaving</MudText>
+                <MudText Typo="Typo.caption" Class="ml-7">Automatically fade and pause playing music apps when entering a raid, then resume them when leaving</MudText>
             </div>
         </MudPaper>
 	</MudItem>

--- a/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
+++ b/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
@@ -46,7 +46,7 @@
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.MusicNote" Class="mr-2"/>Media Control</MudText>
             <div>
                 <MudSwitch @bind-Value="@PauseMediaOnRaidSwitch" Label="Pause media on raid start" Color="Color.Primary" />
-                <MudText Typo="Typo.caption" Class="ml-7">Automatically pause music/media when entering a raid and resume when extracting</MudText>
+                <MudText Typo="Typo.caption" Class="ml-7">Automatically pause playing Spotify, Apple Music, or iTunes sessions when entering a raid and resume them when leaving</MudText>
             </div>
         </MudPaper>
 	</MudItem>

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -11,6 +11,8 @@ namespace TarkovMonitor
     internal class GameWatcher
     {
         private Process? process;
+        private const string GameStoppingMarker = "EFT.NetworkGame`1:GameStopping()";
+        private string outputLogTail = "";
         private readonly System.Timers.Timer processTimer;
         private readonly FileSystemWatcher logFileCreateWatcher;
         private readonly FileSystemWatcher screenshotWatcher;
@@ -96,6 +98,7 @@ namespace TarkovMonitor
         public event EventHandler<RaidInfoEventArgs>? MatchingAborted;
         public event EventHandler<RaidInfoEventArgs>? RaidStarting;
         public event EventHandler<RaidInfoEventArgs>? RaidStarted;
+        public event EventHandler? RaidStopping;
         public event EventHandler<RaidExitedEventArgs>? RaidExited;
         public event EventHandler<RaidInfoEventArgs>? RaidEnded;
         public event EventHandler<RaidInfoEventArgs>? ExitedPostRaidMenus;
@@ -307,6 +310,10 @@ namespace TarkovMonitor
             {
                 StartNewMonitor(e.FullPath);
             }
+            if (filename.Contains("output.log") || filename.Contains("output_000.log"))
+            {
+                StartNewMonitor(e.FullPath);
+            }
         }
 
         internal void GameWatcher_NewLogData(object? sender, NewLogDataEventArgs e)
@@ -315,6 +322,22 @@ namespace TarkovMonitor
             {
                 //DebugMessage?.Invoke(this, new DebugEventArgs(e.NewMessage));
                 NewLogData?.Invoke(this, e);
+                if (e.Type == GameLogType.Output)
+                {
+                    string outputData = outputLogTail + e.Data;
+                    if (outputData.Contains(GameStoppingMarker))
+                    {
+                        RaidStopping?.Invoke(this, EventArgs.Empty);
+                    }
+
+                    int tailLength = Math.Min(outputData.Length, GameStoppingMarker.Length - 1);
+                    outputLogTail = outputData[^tailLength..];
+
+                    // output.log repeats messages that are already handled by the
+                    // dedicated application and notification log monitors. It is
+                    // watched only for the earlier GameStopping marker.
+                    return;
+                }
                 //var logPattern = @"(?<message>^\d{4}-\d{2}-\d{2}.+$)\s*(?<json>^{[\s\S]+?^})?";
                 //var logPattern = @"(?<date>^\d{4}-\d{2}-\d{2}) (?<time>\d{2}:\d{2}:\d{2}\.\d{3} [+-]\d{2}:\d{2})\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|(?<message>.+$)\s*(?<json>^{[\s\S]+?^})?";
                 var logMessages = Regex.Matches(e.Data, logPattern, RegexOptions.Multiline);
@@ -342,10 +365,12 @@ namespace TarkovMonitor
                         raidInfo.Profile = CurrentProfile;
                         continue;
                     }
-                    // old message was SelectProfile, new is SelectedProfile
-                    if (eventLine.Contains("SelectProfile ProfileId:") || eventLine.Contains("SelectedProfile ProfileId:"))
+                    // Profile selection messages have changed names across EFT versions.
+                    if (eventLine.Contains("SelectProfile ProfileId:")
+                        || eventLine.Contains("SelectedProfile ProfileId:")
+                        || eventLine.Contains("PrepareSelectedProfileLocally ProfileId:"))
                     {
-                        var profileIdMatch = Regex.Match(eventLine, @"Select(?:ed)?Profile ProfileId:(?<profileId>\w+) AccountId:(?<accountId>\d+)");
+                        var profileIdMatch = Regex.Match(eventLine, @"(?:Select(?:ed)?Profile|PrepareSelectedProfileLocally) ProfileId:(?<profileId>\w+) AccountId:(?<accountId>\d+)");
                         if (!profileIdMatch.Success)
                         {
                             continue;
@@ -837,7 +862,7 @@ namespace TarkovMonitor
             var files = System.IO.Directory.GetFiles(folderPath);
             var monitorsStarted = 0;
             var monitorsCompletedInitialRead = 0;
-            List<string> monitoringLogs = new() { "notifications.log", "application.log", "notifications_000.log", "application_000.log" };
+            List<string> monitoringLogs = new() { "notifications.log", "application.log", "output.log", "notifications_000.log", "application_000.log", "output_000.log" };
             foreach (var file in files)
             {
                 foreach (var logType in monitoringLogs)
@@ -879,6 +904,11 @@ namespace TarkovMonitor
             {
                 newType = GameLogType.Notifications;
             }
+            if (path.Contains("output.log") || path.Contains("output_000.log"))
+            {
+                newType = GameLogType.Output;
+                outputLogTail = "";
+            }
             if (path.Contains("traces.log") || path.Contains("traces_000.log"))
             {
                 newType = GameLogType.Traces;
@@ -906,6 +936,7 @@ namespace TarkovMonitor
 	{
 		Application,
 		Notifications,
+		Output,
 		Traces
 	}
     public enum MessageType

--- a/TarkovMonitor/LogMonitor.cs
+++ b/TarkovMonitor/LogMonitor.cs
@@ -82,7 +82,7 @@ namespace TarkovMonitor
                         Exception?.Invoke(this, new(ex, $"reading {this.Type} log data"));
                     }
 
-                    Thread.Sleep(5000);
+                    Thread.Sleep(Type == GameLogType.Output ? 250 : 5000);
                 }
             });
         }

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -78,6 +78,7 @@ namespace TarkovMonitor
             eft.ExceptionThrown += Eft_ExceptionThrown;
             eft.RaidStarting += Eft_RaidStarting;
             eft.RaidStarted += Eft_RaidStart;
+            eft.RaidStopping += Eft_RaidStopping;
             eft.RaidExited += Eft_RaidExited;
             eft.RaidEnded += Eft_RaidEnded;
             eft.ExitedPostRaidMenus += Eft_ExitedPostRaidMenus;
@@ -280,20 +281,7 @@ namespace TarkovMonitor
         private async void Eft_RaidEnded(object? sender, RaidInfoEventArgs e)
         {
             inRaid = false;
-            
-            // Resume media on raid end
-            if (Properties.Settings.Default.pauseMediaOnRaid)
-            {
-                try
-                {
-                    int resumedSessions = await MediaController.ResumeAsync();
-                    messageLog.AddMessage($"Resumed {resumedSessions} music session(s)", "info");
-                }
-                catch (Exception ex)
-                {
-                    messageLog.AddMessage($"Error resuming media: {ex.Message}", "exception");
-                }
-            }
+            await ResumeMediaAfterRaid();
             
             //groupManager.Stale = true;
             MonitorMessage monMessage = new($"Ended {e.RaidInfo.Map?.name} raid");
@@ -690,12 +678,52 @@ namespace TarkovMonitor
             messageLog.AddMessage($"Error {e.Context}: {e.Exception.Message}\n{e.Exception.StackTrace}", "exception");
         }
 
-        private void Eft_RaidStarting(object? sender, RaidInfoEventArgs e)
+        private async void Eft_RaidStarting(object? sender, RaidInfoEventArgs e)
         {
             if (Properties.Settings.Default.raidStartAlert)
             {
                 // always notify if the GameStarting event appeared
                 Sound.Play("raid_starting");
+            }
+
+            await PauseMediaForRaid();
+        }
+
+        private async Task PauseMediaForRaid()
+        {
+            if (!Properties.Settings.Default.pauseMediaOnRaid) return;
+
+            try
+            {
+                int pausedSessions = await MediaController.PauseAsync();
+                messageLog.AddMessage($"Paused {pausedSessions} music session(s)", "info");
+            }
+            catch (Exception ex)
+            {
+                messageLog.AddMessage($"Error pausing media: {ex.Message}", "exception");
+            }
+        }
+
+        private async void Eft_RaidStopping(object? sender, EventArgs e)
+        {
+            await ResumeMediaAfterRaid();
+        }
+
+        private async Task ResumeMediaAfterRaid()
+        {
+            if (!Properties.Settings.Default.pauseMediaOnRaid) return;
+
+            try
+            {
+                int resumedSessions = await MediaController.ResumeAsync();
+                if (resumedSessions > 0)
+                {
+                    messageLog.AddMessage($"Resumed {resumedSessions} music session(s)", "info");
+                }
+            }
+            catch (Exception ex)
+            {
+                messageLog.AddMessage($"Error resuming media: {ex.Message}", "exception");
             }
         }
 
@@ -704,18 +732,10 @@ namespace TarkovMonitor
             inRaid = true;
             Stats.AddRaid(e);
             
-            // Pause media on raid start
-            if (Properties.Settings.Default.pauseMediaOnRaid)
+            // GameStarting is not always logged for scav raids, so pause here as a fallback.
+            if (e.RaidInfo.StartingTime == null)
             {
-                try
-                {
-                    int pausedSessions = await MediaController.PauseAsync();
-                    messageLog.AddMessage($"Paused {pausedSessions} music session(s)", "info");
-                }
-                catch (Exception ex)
-                {
-                    messageLog.AddMessage($"Error pausing media: {ex.Message}", "exception");
-                }
+                await PauseMediaForRaid();
             }
             
             if (!e.RaidInfo.Reconnected && e.RaidInfo.RaidType != RaidType.Unknown)
@@ -821,20 +841,7 @@ namespace TarkovMonitor
             //groupManager.Stale = true;
             runthroughTimer.Stop();
             inRaid = false;
-            
-            // Resume media on raid exit
-            if (Properties.Settings.Default.pauseMediaOnRaid)
-            {
-                try
-                {
-                    int resumedSessions = await MediaController.ResumeAsync();
-                    messageLog.AddMessage($"Resumed {resumedSessions} music session(s)", "info");
-                }
-                catch (Exception ex)
-                {
-                    messageLog.AddMessage($"Error resuming media: {ex.Message}", "exception");
-                }
-            }
+            await ResumeMediaAfterRaid();
             
             try
             {

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -277,7 +277,7 @@ namespace TarkovMonitor
             monMessage.Buttons.Add(screenshotButton);
         }
 
-        private void Eft_RaidEnded(object? sender, RaidInfoEventArgs e)
+        private async void Eft_RaidEnded(object? sender, RaidInfoEventArgs e)
         {
             inRaid = false;
             
@@ -286,8 +286,8 @@ namespace TarkovMonitor
             {
                 try
                 {
-                    messageLog.AddMessage("Playing media...", "info");
-                    MediaController.Play();
+                    int resumedSessions = await MediaController.ResumeAsync();
+                    messageLog.AddMessage($"Resumed {resumedSessions} music session(s)", "info");
                 }
                 catch (Exception ex)
                 {
@@ -709,8 +709,8 @@ namespace TarkovMonitor
             {
                 try
                 {
-                    messageLog.AddMessage("Pausing media...", "info");
-                    MediaController.Pause();
+                    int pausedSessions = await MediaController.PauseAsync();
+                    messageLog.AddMessage($"Paused {pausedSessions} music session(s)", "info");
                 }
                 catch (Exception ex)
                 {
@@ -816,7 +816,7 @@ namespace TarkovMonitor
             }
         }
 
-        private void Eft_RaidExited(object? sender, RaidExitedEventArgs e)
+        private async void Eft_RaidExited(object? sender, RaidExitedEventArgs e)
         {
             //groupManager.Stale = true;
             runthroughTimer.Stop();
@@ -827,9 +827,8 @@ namespace TarkovMonitor
             {
                 try
                 {
-                    messageLog.AddMessage("Attempting to resume media...", "info");
-                    MediaController.Play();
-                    messageLog.AddMessage("Media resume command sent", "info");
+                    int resumedSessions = await MediaController.ResumeAsync();
+                    messageLog.AddMessage($"Resumed {resumedSessions} music session(s)", "info");
                 }
                 catch (Exception ex)
                 {

--- a/TarkovMonitor/MediaController.cs
+++ b/TarkovMonitor/MediaController.cs
@@ -1,46 +1,88 @@
-using System.Runtime.InteropServices;
+using Windows.Media.Control;
 
 namespace TarkovMonitor
 {
     /// <summary>
-    /// Controls system media playback (play/pause) for background applications like Spotify, YouTube, etc.
+    /// Controls supported music playback through Windows media sessions.
     /// </summary>
     internal static class MediaController
     {
-        private const int KEYEVENTF_EXTENDEDKEY = 0x0001;
-        private const int KEYEVENTF_KEYUP = 0x0002;
-        private const byte VK_MEDIA_PLAY_PAUSE = 0xB3;
+        private static readonly SemaphoreSlim mediaSessionLock = new(1, 1);
+        private static List<GlobalSystemMediaTransportControlsSession> pausedSessions = new();
 
-        [DllImport("user32.dll")]
-        private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
-
-        /// <summary>
-        /// Sends a media play/pause key event to toggle media playback
-        /// </summary>
-        public static void TogglePlayPause()
+        private static bool IsSupportedMusicSession(GlobalSystemMediaTransportControlsSession session)
         {
-            // Press the key
-            keybd_event(VK_MEDIA_PLAY_PAUSE, 0, KEYEVENTF_EXTENDEDKEY, UIntPtr.Zero);
-            // Release the key
-            keybd_event(VK_MEDIA_PLAY_PAUSE, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, UIntPtr.Zero);
+            string source = session.SourceAppUserModelId;
+            return source.Contains("spotify", StringComparison.OrdinalIgnoreCase)
+                || source.Contains("applemusic", StringComparison.OrdinalIgnoreCase)
+                || source.Contains("itunes", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
-        /// Pauses media playback by sending play/pause command
-        /// Note: This toggles play/pause state. The media must be playing for this to pause it.
+        /// Pauses supported music sessions that are currently playing and remembers
+        /// only the sessions successfully paused by TarkovMonitor.
         /// </summary>
-        public static void Pause()
+        public static async Task<int> PauseAsync()
         {
-            TogglePlayPause();
+            await mediaSessionLock.WaitAsync();
+            try
+            {
+                pausedSessions.Clear();
+
+                var manager = await GlobalSystemMediaTransportControlsSessionManager.RequestAsync();
+                foreach (var session in manager.GetSessions())
+                {
+                    if (!IsSupportedMusicSession(session)
+                        || session.GetPlaybackInfo().PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
+                    {
+                        continue;
+                    }
+
+                    if (await session.TryPauseAsync())
+                    {
+                        pausedSessions.Add(session);
+                    }
+                }
+
+                return pausedSessions.Count;
+            }
+            finally
+            {
+                mediaSessionLock.Release();
+            }
         }
 
         /// <summary>
-        /// Resumes media playback by sending play/pause command
-        /// Note: This toggles play/pause state. The media must be paused for this to resume it.
+        /// Resumes only the music sessions that TarkovMonitor paused at raid start.
         /// </summary>
-        public static void Play()
+        public static async Task<int> ResumeAsync()
         {
-            TogglePlayPause();
+            await mediaSessionLock.WaitAsync();
+            try
+            {
+                var sessionsToResume = pausedSessions;
+                pausedSessions = new();
+                int resumedCount = 0;
+
+                foreach (var session in sessionsToResume)
+                {
+                    if (session.GetPlaybackInfo().PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Paused)
+                    {
+                        continue;
+                    }
+
+                    if (await session.TryPlayAsync())
+                    {
+                        resumedCount++;
+                    }
+                }
+
+                return resumedCount;
+            }
+            finally
+            {
+                mediaSessionLock.Release();
+            }
         }
     }
 }

--- a/TarkovMonitor/MediaController.cs
+++ b/TarkovMonitor/MediaController.cs
@@ -1,3 +1,5 @@
+using NAudio.CoreAudioApi;
+using Windows.Media;
 using Windows.Media.Control;
 
 namespace TarkovMonitor
@@ -7,15 +9,295 @@ namespace TarkovMonitor
     /// </summary>
     internal static class MediaController
     {
+        private const int FadeDurationMilliseconds = 3000;
+        private const int FadeFrameMilliseconds = 16;
+        private const int ResumeDelayMilliseconds = 2000;
+        private const int PauseTransitionTimeoutMilliseconds = 1000;
+        private const int SilenceTransitionTimeoutMilliseconds = 1000;
+        private const int SilentSampleCount = 3;
+        private const float SilencePeakThreshold = 0.001f;
         private static readonly SemaphoreSlim mediaSessionLock = new(1, 1);
-        private static List<GlobalSystemMediaTransportControlsSession> pausedSessions = new();
+        private static readonly string[] browserSources = { "chrome", "msedge", "firefox", "opera", "brave", "vivaldi", "arc" };
+        private static List<PausedMediaSession> pausedSessions = new();
+        private static List<AudioSessionVolume> pausedSessionVolumes = new();
 
-        private static bool IsSupportedMusicSession(GlobalSystemMediaTransportControlsSession session)
+        private sealed record PausedMediaSession(GlobalSystemMediaTransportControlsSession Session, string SourceId);
+        private sealed record AudioSessionVolume(string DeviceId, uint ProcessId, string SourceId, float Volume);
+        private sealed record ActiveAudioSession(AudioSessionControl Session, SimpleAudioVolume VolumeControl, float OriginalVolume);
+
+        private static bool IsBrowserSource(string source)
         {
-            string source = session.SourceAppUserModelId;
-            return source.Contains("spotify", StringComparison.OrdinalIgnoreCase)
-                || source.Contains("applemusic", StringComparison.OrdinalIgnoreCase)
-                || source.Contains("itunes", StringComparison.OrdinalIgnoreCase);
+            return browserSources.Any(browser => source.Contains(browser, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static async Task<string?> GetMusicSourceIdAsync(GlobalSystemMediaTransportControlsSession session)
+        {
+            string sourceId = session.SourceAppUserModelId;
+            if (IsBrowserSource(sourceId)) return null;
+
+            MediaPlaybackType? playbackType = session.GetPlaybackInfo().PlaybackType;
+            if (playbackType == MediaPlaybackType.Music) return sourceId;
+            if (playbackType == MediaPlaybackType.Video || playbackType == MediaPlaybackType.Image) return null;
+
+            var properties = await session.TryGetMediaPropertiesAsync();
+            if (properties.PlaybackType == MediaPlaybackType.Music) return sourceId;
+            if (properties.PlaybackType == MediaPlaybackType.Video || properties.PlaybackType == MediaPlaybackType.Image) return null;
+
+            // Some desktop players omit PlaybackType but provide music-specific metadata.
+            return !string.IsNullOrWhiteSpace(properties.Artist)
+                || !string.IsNullOrWhiteSpace(properties.AlbumArtist)
+                || !string.IsNullOrWhiteSpace(properties.AlbumTitle)
+                || properties.Genres.Count > 0
+                    ? sourceId
+                    : null;
+        }
+
+        private static string NormalizeIdentity(string value)
+        {
+            return new string(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+        }
+
+        private static bool AudioProcessMatchesSource(string processName, string sourceId)
+        {
+            string processIdentity = NormalizeIdentity(processName);
+            string sourceIdentity = NormalizeIdentity(sourceId);
+            return processIdentity.Length >= 4 && sourceIdentity.Contains(processIdentity);
+        }
+
+        private static List<AudioSessionVolume> GetAudioSessionVolumes(IReadOnlyCollection<string> sourceIds)
+        {
+            List<AudioSessionVolume> volumes = new();
+            using var enumerator = new MMDeviceEnumerator();
+            var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+
+            foreach (var device in devices)
+            {
+                try
+                {
+                    var sessions = device.AudioSessionManager.Sessions;
+                    for (int i = 0; i < sessions.Count; i++)
+                    {
+                        using var session = sessions[i];
+                        if (session.IsSystemSoundsSession
+                            || session.GetProcessID == 0
+                            || session.State != NAudio.CoreAudioApi.Interfaces.AudioSessionState.AudioSessionStateActive)
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            using var process = System.Diagnostics.Process.GetProcessById((int)session.GetProcessID);
+                            string? sourceId = sourceIds.FirstOrDefault(source => AudioProcessMatchesSource(process.ProcessName, source));
+                            if (sourceId != null)
+                            {
+                                volumes.Add(new(device.ID, session.GetProcessID, sourceId, session.SimpleAudioVolume.Volume));
+                            }
+                        }
+                        catch (ArgumentException)
+                        {
+                            // The application exited while its audio session was being inspected.
+                        }
+                    }
+                }
+                finally
+                {
+                    device.Dispose();
+                }
+            }
+
+            return volumes.GroupBy(volume => (volume.DeviceId, volume.ProcessId)).Select(group => group.First()).ToList();
+        }
+
+        private static void SetAudioSessionVolumes(IEnumerable<AudioSessionVolume> volumes, float progress)
+        {
+            var targetVolumes = volumes.ToDictionary(volume => (volume.DeviceId, volume.ProcessId));
+            if (targetVolumes.Count == 0) return;
+
+            using var enumerator = new MMDeviceEnumerator();
+            var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+
+            foreach (var device in devices)
+            {
+                try
+                {
+                    var sessions = device.AudioSessionManager.Sessions;
+                    for (int i = 0; i < sessions.Count; i++)
+                    {
+                        using var session = sessions[i];
+                        if (targetVolumes.TryGetValue((device.ID, session.GetProcessID), out var target))
+                        {
+                            session.SimpleAudioVolume.Volume = target.Volume * progress;
+                        }
+                    }
+                }
+                finally
+                {
+                    device.Dispose();
+                }
+            }
+        }
+
+        private static async Task FadeAudioSessionsAsync(IEnumerable<AudioSessionVolume> volumes, bool fadeIn)
+        {
+            var volumeList = volumes.ToList();
+            var targetVolumes = volumeList.ToDictionary(volume => (volume.DeviceId, volume.ProcessId));
+            if (targetVolumes.Count == 0) return;
+
+            using var enumerator = new MMDeviceEnumerator();
+            var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active).ToList();
+            List<ActiveAudioSession> activeSessions = new();
+
+            try
+            {
+                foreach (var device in devices)
+                {
+                    var sessions = device.AudioSessionManager.Sessions;
+                    for (int i = 0; i < sessions.Count; i++)
+                    {
+                        var session = sessions[i];
+                        if (targetVolumes.TryGetValue((device.ID, session.GetProcessID), out var target))
+                        {
+                            activeSessions.Add(new(session, session.SimpleAudioVolume, target.Volume));
+                        }
+                        else
+                        {
+                            session.Dispose();
+                        }
+                    }
+                }
+
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                while (stopwatch.ElapsedMilliseconds < FadeDurationMilliseconds)
+                {
+                    float progress = (float)stopwatch.ElapsedMilliseconds / FadeDurationMilliseconds;
+                    float easedProgress = progress * progress * (3 - 2 * progress);
+                    float volumeProgress = fadeIn ? easedProgress : 1 - easedProgress;
+
+                    foreach (var audioSession in activeSessions)
+                    {
+                        audioSession.VolumeControl.Volume = audioSession.OriginalVolume * volumeProgress;
+                    }
+
+                    await Task.Delay(FadeFrameMilliseconds);
+                }
+
+                foreach (var audioSession in activeSessions)
+                {
+                    audioSession.VolumeControl.Volume = fadeIn ? audioSession.OriginalVolume : 0;
+                }
+            }
+            finally
+            {
+                foreach (var audioSession in activeSessions)
+                {
+                    audioSession.VolumeControl.Dispose();
+                    audioSession.Session.Dispose();
+                }
+
+                foreach (var device in devices)
+                {
+                    device.Dispose();
+                }
+            }
+        }
+
+        private static async Task HoldMutedUntilPausedAsync(
+            IReadOnlyCollection<PausedMediaSession> requestedSessions,
+            IReadOnlyCollection<AudioSessionVolume> volumes)
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            do
+            {
+                // A successful TryPauseAsync means the command was accepted, but the
+                // player may still emit audio until its playback state changes.
+                SetAudioSessionVolumes(volumes, 0);
+                int confirmedPausedCount = requestedSessions
+                    .Where(session => session.Session.GetPlaybackInfo().PlaybackStatus
+                        == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Paused)
+                    .Count();
+
+                if (confirmedPausedCount == requestedSessions.Count)
+                {
+                    break;
+                }
+
+                await Task.Delay(FadeFrameMilliseconds);
+            }
+            while (stopwatch.ElapsedMilliseconds < PauseTransitionTimeoutMilliseconds);
+
+            await HoldMutedUntilSilentAsync(volumes);
+
+            // Pin the sessions at zero once more before their original volume is
+            // restored while paused.
+            SetAudioSessionVolumes(volumes, 0);
+        }
+
+        private static async Task HoldMutedUntilSilentAsync(IReadOnlyCollection<AudioSessionVolume> volumes)
+        {
+            var targets = volumes.ToDictionary(volume => (volume.DeviceId, volume.ProcessId));
+            if (targets.Count == 0) return;
+
+            using var enumerator = new MMDeviceEnumerator();
+            var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active).ToList();
+            List<ActiveAudioSession> sessions = new();
+
+            try
+            {
+                foreach (var device in devices)
+                {
+                    var deviceSessions = device.AudioSessionManager.Sessions;
+                    for (int i = 0; i < deviceSessions.Count; i++)
+                    {
+                        var session = deviceSessions[i];
+                        if (targets.TryGetValue((device.ID, session.GetProcessID), out var target))
+                        {
+                            sessions.Add(new(session, session.SimpleAudioVolume, target.Volume));
+                        }
+                        else
+                        {
+                            session.Dispose();
+                        }
+                    }
+                }
+
+                int consecutiveSilentSamples = 0;
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+                while (stopwatch.ElapsedMilliseconds < SilenceTransitionTimeoutMilliseconds)
+                {
+                    bool silent = true;
+                    foreach (var session in sessions)
+                    {
+                        session.VolumeControl.Volume = 0;
+                        if (session.Session.AudioMeterInformation.MasterPeakValue > SilencePeakThreshold)
+                        {
+                            silent = false;
+                        }
+                    }
+
+                    consecutiveSilentSamples = silent ? consecutiveSilentSamples + 1 : 0;
+                    if (consecutiveSilentSamples >= SilentSampleCount)
+                    {
+                        break;
+                    }
+
+                    await Task.Delay(FadeFrameMilliseconds);
+                }
+            }
+            finally
+            {
+                foreach (var session in sessions)
+                {
+                    session.VolumeControl.Dispose();
+                    session.Session.Dispose();
+                }
+
+                foreach (var device in devices)
+                {
+                    device.Dispose();
+                }
+            }
         }
 
         /// <summary>
@@ -27,22 +309,58 @@ namespace TarkovMonitor
             await mediaSessionLock.WaitAsync();
             try
             {
+                // A duplicate raid-start event must not erase sessions already
+                // paused and tracked for the current raid.
+                if (pausedSessions.Count > 0) return 0;
+
                 pausedSessions.Clear();
+                pausedSessionVolumes.Clear();
 
                 var manager = await GlobalSystemMediaTransportControlsSessionManager.RequestAsync();
+                List<PausedMediaSession> playingSessions = new();
                 foreach (var session in manager.GetSessions())
                 {
-                    if (!IsSupportedMusicSession(session)
-                        || session.GetPlaybackInfo().PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
+                    if (session.GetPlaybackInfo().PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
                     {
                         continue;
                     }
 
-                    if (await session.TryPauseAsync())
+                    string? sourceId = await GetMusicSourceIdAsync(session);
+                    if (sourceId != null)
                     {
-                        pausedSessions.Add(session);
+                        playingSessions.Add(new(session, sourceId));
                     }
                 }
+
+                if (playingSessions.Count == 0) return 0;
+
+                var sourceIds = playingSessions.Select(session => session.SourceId).ToHashSet();
+                var originalVolumes = GetAudioSessionVolumes(sourceIds);
+                try
+                {
+                    await FadeAudioSessionsAsync(originalVolumes, fadeIn: false);
+
+                    List<PausedMediaSession> pauseRequestsAccepted = new();
+                    foreach (var mediaSession in playingSessions)
+                    {
+                        if (await mediaSession.Session.TryPauseAsync())
+                        {
+                            pauseRequestsAccepted.Add(mediaSession);
+                        }
+                    }
+
+                    // Retain accepted pause requests even if a player reports its
+                    // state transition later than the handoff timeout.
+                    pausedSessions = pauseRequestsAccepted;
+                    await HoldMutedUntilPausedAsync(pauseRequestsAccepted, originalVolumes);
+                }
+                finally
+                {
+                    SetAudioSessionVolumes(originalVolumes, 1);
+                }
+
+                var pausedSources = pausedSessions.Select(session => session.SourceId).ToHashSet();
+                pausedSessionVolumes = originalVolumes.Where(volume => pausedSources.Contains(volume.SourceId)).ToList();
 
                 return pausedSessions.Count;
             }
@@ -60,22 +378,59 @@ namespace TarkovMonitor
             await mediaSessionLock.WaitAsync();
             try
             {
-                var sessionsToResume = pausedSessions;
-                pausedSessions = new();
+                var sessionsToResume = pausedSessions.ToList();
+                var volumesToRestore = pausedSessionVolumes.ToList();
+                if (sessionsToResume.Count == 0) return 0;
+
+                await Task.Delay(ResumeDelayMilliseconds);
+
+                var manager = await GlobalSystemMediaTransportControlsSessionManager.RequestAsync();
+                var currentSessions = manager.GetSessions();
                 int resumedCount = 0;
+                var trackedSources = sessionsToResume.Select(session => session.SourceId).ToHashSet();
+                var volumesToFade = volumesToRestore.Where(volume => trackedSources.Contains(volume.SourceId)).ToList();
 
-                foreach (var session in sessionsToResume)
+                HashSet<string> resumedApps = new();
+                List<PausedMediaSession> resolvedSessions = new();
+                try
                 {
-                    if (session.GetPlaybackInfo().PlaybackStatus != GlobalSystemMediaTransportControlsSessionPlaybackStatus.Paused)
+                    SetAudioSessionVolumes(volumesToFade, 0);
+
+                    foreach (var trackedSession in sessionsToResume)
                     {
-                        continue;
+                        var currentSession = currentSessions.FirstOrDefault(session =>
+                            string.Equals(session.SourceAppUserModelId, trackedSession.SourceId, StringComparison.OrdinalIgnoreCase));
+                        var mediaSession = currentSession ?? trackedSession.Session;
+                        var status = mediaSession.GetPlaybackInfo().PlaybackStatus;
+
+                        if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing)
+                        {
+                            resolvedSessions.Add(trackedSession);
+                            continue;
+                        }
+
+                        if (await mediaSession.TryPlayAsync())
+                        {
+                            resumedCount++;
+                            resumedApps.Add(trackedSession.SourceId);
+                            resolvedSessions.Add(trackedSession);
+                        }
                     }
 
-                    if (await session.TryPlayAsync())
-                    {
-                        resumedCount++;
-                    }
+                    var resumedVolumes = volumesToFade.Where(volume => resumedApps.Contains(volume.SourceId)).ToList();
+                    await FadeAudioSessionsAsync(resumedVolumes, fadeIn: true);
                 }
+                finally
+                {
+                    SetAudioSessionVolumes(volumesToFade, 1);
+                }
+
+                // Keep unsuccessful sessions so RaidEnded/RaidExited can retry.
+                pausedSessions.RemoveAll(session => resolvedSessions.Contains(session));
+                var unresolvedSources = pausedSessions.Select(session => session.SourceId).ToHashSet();
+                pausedSessionVolumes = pausedSessionVolumes
+                    .Where(volume => unresolvedSources.Contains(volume.SourceId))
+                    .ToList();
 
                 return resumedCount;
             }

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\TarkovDev.ico</ApplicationIcon>
-    <AssemblyVersion>1.13.0.1</AssemblyVersion>
+    <AssemblyVersion>1.13.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\TarkovDev.ico</ApplicationIcon>
-    <AssemblyVersion>1.13.0.0</AssemblyVersion>
+    <AssemblyVersion>1.13.0.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Bug

When **Pause media on raid start** was enabled and no media was playing, TarkovMonitor could start music when the raid began.

## Summary

This fixes the pause-media behavior so TarkovMonitor only pauses music that is already playing and only resumes music that it paused itself.

While working through the raid lifecycle, I also moved the pause and resume timing closer to the actual start and end of a raid. Music now fades out over three seconds, stays paused during the raid, waits two seconds after the raid-ending signal, and then fades back in over three seconds.

The fade only changes the matched media application's audio session. It does not change the Windows master volume, audio-device volume, game audio, browser audio, or video-player audio.

## What was causing the problem

The existing pause and play methods both sent the same system play/pause media key. Since that key is a toggle, starting a raid while music was already paused could start it instead. Multiple raid lifecycle events could also toggle playback more than once.

## How this works

TarkovMonitor now uses Windows media sessions to find music that is currently playing and remembers which sessions it successfully paused. At the end of the raid, it resumes only those remembered sessions.

The implementation stays local and does not add integrations with individual music-service APIs. Windows Core Audio is used only to fade an application when its media session can be safely matched to its audio process. Browsers and sessions identified as video are excluded. If a media application cannot be matched safely, TarkovMonitor leaves its volume alone.

The earlier `GameStarting` and `GameStopping` log signals are used for the main pause and resume timing. The original raid-started, raid-ended, and raid-exited events remain as fallbacks for log variations such as Scav raids.

## Testing

- Published the Release build with `dotnet publish TarkovMonitor.sln -c Release --self-contained --runtime win-x64 -p:PublishSingleFile=true`
- Tested PVE PMC and Scav raid start/end flows across multiple raids
- Confirmed that playing music fades out, pauses, waits two seconds after raid end, and fades back in
- Confirmed that already-paused or stopped media does not start at either raid boundary
- Confirmed that YouTube and VLC video playback are not paused
- Confirmed that game audio is unaffected
- Repeated the raid tests without reproducing the intermittent end-of-fade audio blip after the final settling fix

Closes #176