### PR TITLE
Fix development artifact upload path

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -25,10 +25,27 @@ jobs:
         run: dotnet restore
 
       - name: Build and publish
-        run: dotnet publish -c Release --self-contained --runtime win-x64 -p:PublishSingleFile=true
+        shell: pwsh
+        run: |
+          dotnet publish TarkovMonitor/TarkovMonitor.csproj `
+            -c Release `
+            --self-contained `
+            --runtime win-x64 `
+            -p:PublishSingleFile=true `
+            --output "$Env:GITHUB_WORKSPACE\publish"
+
+      - name: Verify published application
+        shell: pwsh
+        run: |
+          $executable = "$Env:GITHUB_WORKSPACE\publish\TarkovMonitor.exe"
+
+          if (-not (Test-Path -LiteralPath $executable)) {
+            throw "Published executable was not found: $executable"
+          }
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: Published Application
-          path: TarkovMonitor\bin\Release\net6.0-windows\win-x64\publish\*
+          path: publish
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

This updates the development build workflow to use the same stable publish directory as the tag-release workflow.

After the project target changed to `net6.0-windows10.0.17763.0`, the application continued to build successfully, but `build-dev.yml` still tried to upload files from the old `net6.0-windows` output directory. That caused the artifact step to report that no files were found.

## Changes

- publish the application project directly to `$GITHUB_WORKSPACE\publish`
- verify that `TarkovMonitor.exe` exists before artifact upload
- upload the stable `publish` directory instead of a target-framework-specific path
- fail the job when no artifact files are found instead of producing only a warning

## Validation

- parsed both GitHub Actions workflow files successfully
- confirmed no target-framework-dependent publish paths remain in `.github/workflows`
- ran the workflow-equivalent self-contained `win-x64` publish successfully
- verified the publish output contained 35 files and `TarkovMonitor.exe`
- created and verified `TarkovMonitor.zip` from the shared staging layout used by the release workflow
- `git diff --check` passed