### PR TITLE
Updated TarkovMonitor to .NET 10 and refreshed the desktop UI

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # pin@v6.0.0
         with:
-          dotnet-version: "6.x" # Change this to the desired .NET version
+          dotnet-version: "10.x"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # pin@v6.0.0
         with:
-          dotnet-version: "6.x"
+          dotnet-version: "10.x"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/TarkovMonitor/Blazor/AppLayout.razor
+++ b/TarkovMonitor/Blazor/AppLayout.razor
@@ -1,40 +1,65 @@
 ﻿@using System.Diagnostics
 @inherits LayoutComponentBase
 @layout MainLayout
+@implements IDisposable
 
 @inject IJSRuntime JSRuntime;
 @inject LocalizationService LocalizationService
+@inject MainBlazorUI WindowHost
+@inject MessageLog MessageLog
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
 
 <div style="width: 100%; height: 100%" class="tarkov-dev-bg">
 	<MudLayout>
-		<MudAppBar Elevation="1" Bottom="false" Dense="true">
+		<MudAppBar Class="window-app-bar" Elevation="1" Bottom="false" Dense="true">
 			<MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer"/>
-			@CurrentPageTitle
-			<MudSpacer/>
+			<span class="window-page-title">@CurrentPageTitle</span>
+			<div class="window-drag-region" @onmousedown="BeginWindowDrag">
+				<span class="window-product-title">@LocalizationService.GetString("TarkovMonitor")</span>
+			</div>
+			<div class="window-controls" aria-label="Window controls">
+				<MudIconButton Class="window-control" Icon="@Icons.Material.Filled.Remove" Color="Color.Inherit" Size="Size.Small" OnClick="MinimizeWindow" aria-label="Minimize" />
+				<MudIconButton Class="window-control" Icon="@(WindowHost.IsMaximized ? Icons.Material.Filled.FilterNone : Icons.Material.Filled.CropSquare)" Color="Color.Inherit" Size="Size.Small" OnClick="ToggleMaximizeWindow" aria-label="@(WindowHost.IsMaximized ? "Restore" : "Maximize")" />
+				<MudIconButton Class="window-control window-control-close" Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Size="Size.Small" OnClick="CloseWindow" aria-label="Close" />
+			</div>
 		</MudAppBar>
-		<MudDrawer @bind-Open="@drawerOpen" Elevation="1" Anchor="Anchor.Left" Variant="@DrawerVariant.Responsive">
-			<MudDrawerHeader LinkToIndex="true">
-				<div>
-					<img src="tarkov-dev-logo.svg" width="100%" style="vertical-align: middle;"/>
-					                <MudText Align="Align.Center" Typo="Typo.h6">@LocalizationService.GetString("TarkovMonitor")</MudText>
-				</div>
+		<MudDrawer Class="navigation-drawer" @bind-Open="@drawerOpen" Elevation="1" Anchor="Anchor.Left" Variant="@DrawerVariant.Responsive">
+			<MudDrawerHeader Class="navigation-drawer-header">
+				<button class="navigation-brand" type="button" @onclick="@ToggleDrawer" aria-label="Collapse navigation">
+					<div class="navigation-brand-copy">
+						<img class="navigation-brand-logo" src="tarkov-dev-logo.svg" alt="Tarkov.dev" />
+					</div>
+					<MudIcon Class="drawer-collapse-cue" Icon="@Icons.Material.Filled.ChevronLeft" Size="Size.Small" />
+				</button>
 			</MudDrawerHeader>
-			<MudNavMenu Color="Color.Secondary" Bordered="true">
+			<MudNavMenu Class="navigation-menu" Color="Color.Secondary" Bordered="false">
 				<MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Message">@LocalizationService.GetString("Messages")</MudNavLink>
                 <!--MudNavLink Href="/group" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Group">@LocalizationService.GetString("Group")</!--MudNavLink-->
-                <MudNavLink Href="/settings" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Settings">@LocalizationService.GetString("Settings")</MudNavLink>
-                <MudNavLink Href="/sounds" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Speaker">@LocalizationService.GetString("Sounds")</MudNavLink>
-                <MudNavLink Href="/stats" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.BarChart">@LocalizationService.GetString("Stats")</MudNavLink>
-                <MudNavLink Href="/raw" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.RawOn">@LocalizationService.GetString("RawLogs")</MudNavLink>
-                <MudNavLink Href="/timers" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Timer">@LocalizationService.GetString("Timers")</MudNavLink>
+				<MudNavLink Href="/settings" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Settings">@LocalizationService.GetString("Settings")</MudNavLink>
+				<MudNavLink Href="/sounds" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Speaker">@LocalizationService.GetString("Sounds")</MudNavLink>
+				<MudNavLink Href="/stats" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.BarChart">@LocalizationService.GetString("Stats")</MudNavLink>
+				<MudNavLink Href="/raw" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.RawOn">@LocalizationService.GetString("RawLogs")</MudNavLink>
+				<MudNavLink Href="/timers" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Timer">@LocalizationService.GetString("Timers")</MudNavLink>
 			</MudNavMenu>
 		</MudDrawer>
-		<MudMainContent Class="mt-2">
+		<MudMainContent Class="app-main-content" Style="box-sizing: border-box;">
 			<CascadingValue Name="AppLayout" Value="this">
 				@Body
 			</CascadingValue>
 		</MudMainContent>
 	</MudLayout>
+	@if (!WindowHost.IsMaximized)
+	{
+		<div class="resize-zone resize-edge-top" @onmousedown="() => BeginWindowResize(12)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-edge-right" @onmousedown="() => BeginWindowResize(11)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-edge-bottom" @onmousedown="() => BeginWindowResize(15)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-edge-left" @onmousedown="() => BeginWindowResize(10)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-corner-top-left" @onmousedown="() => BeginWindowResize(13)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-corner-top-right" @onmousedown="() => BeginWindowResize(14)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-corner-bottom-left" @onmousedown="() => BeginWindowResize(16)" @onmousedown:preventDefault="true"></div>
+		<div class="resize-zone resize-corner-bottom-right" @onmousedown="() => BeginWindowResize(17)" @onmousedown:preventDefault="true"></div>
+	}
 </div>
 
 @code {
@@ -46,6 +71,8 @@
 	protected override void OnInitialized()
 	{
 		LocalizationService.LanguageChanged += OnLanguageChanged;
+		WindowHost.WindowStateChanged += OnWindowStateChanged;
+		MessageLog.newMessage += OnMessageAdded;
 	}
 
 	public void SetTitle(string value) {
@@ -58,8 +85,68 @@
 		drawerOpen = !drawerOpen;
 	}
 
+	private void BeginWindowDrag() => WindowHost.BeginWindowDrag();
+
+	private void BeginWindowResize(int hitTest) => WindowHost.BeginWindowResize(hitTest);
+
+	private void MinimizeWindow() => WindowHost.MinimizeWindow();
+
+	private void ToggleMaximizeWindow() => WindowHost.ToggleMaximizeWindow();
+
+	private void CloseWindow() => WindowHost.CloseWindow();
+
+	private void OnWindowStateChanged(object? sender, EventArgs e)
+	{
+		InvokeAsync(StateHasChanged);
+	}
+
+	private void OnMessageAdded(object? sender, NewLogMessageArgs e)
+	{
+		InvokeAsync(StateHasChanged);
+
+		if (e.Message.Type == "quest" && GameWatcher.ReadingPastLogs)
+		{
+			return;
+		}
+
+		var severity = e.Message.Type switch
+		{
+			"exception" => Severity.Error,
+			"warning" => Severity.Warning,
+			"update" => Severity.Success,
+			_ => Severity.Info
+		};
+
+		var path = NavigationManager.ToBaseRelativePath(NavigationManager.Uri)
+			.Split('?', '#')[0]
+			.Trim('/');
+		var messagesAreVisible = string.IsNullOrEmpty(path) || path.Equals("app", StringComparison.OrdinalIgnoreCase);
+		var requiresImmediateAttention = severity is Severity.Error or Severity.Warning;
+
+		if (messagesAreVisible && !requiresImmediateAttention)
+		{
+			return;
+		}
+
+		Snackbar.Add(e.Message.Message, severity, configuration =>
+		{
+			configuration.Onclick = snackbar =>
+			{
+				NavigationManager.NavigateTo("/");
+				return Task.CompletedTask;
+			};
+		});
+	}
+
 	private void OnLanguageChanged(object? sender, EventArgs e)
 	{
 		InvokeAsync(StateHasChanged);
+	}
+
+	public void Dispose()
+	{
+		LocalizationService.LanguageChanged -= OnLanguageChanged;
+		WindowHost.WindowStateChanged -= OnWindowStateChanged;
+		MessageLog.newMessage -= OnMessageAdded;
 	}
 }

--- a/TarkovMonitor/Blazor/AppLayout.razor.css
+++ b/TarkovMonitor/Blazor/AppLayout.razor.css
@@ -1,3 +1,275 @@
 ﻿.tarkov-dev-bg {
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAgMAAAANjH3HAAAADFBMVEUtLS8uLjAvLzEsKy2xgXVgAAAASElEQVR4Ae3QoQ3AAAwDQa9Qmu1DX5kk6lAdoEbBJk8tn4qHdtHyMi7qpspFM+y6iKJxEcvgctm5/IlBDGIQgxjEIAYxiME/H1nLq0bNJikRAAAAAElFTkSuQmCC)
 }
+
+::deep .app-main-content {
+    height: calc(100vh - 48px);
+    margin-top: 0;
+    padding-top: 8px !important;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-color: #8f825f #252522;
+    scrollbar-width: auto;
+}
+
+::deep .app-main-content::-webkit-scrollbar {
+    width: 12px;
+}
+
+::deep .app-main-content::-webkit-scrollbar-track {
+    margin-top: 6px;
+    margin-bottom: 6px;
+    border-left: 1px solid rgba(255, 255, 255, 0.05);
+    background: #252522;
+}
+
+::deep .app-main-content::-webkit-scrollbar-thumb {
+    min-height: 44px;
+    border: 3px solid #252522;
+    border-radius: 999px;
+    background: #8f825f;
+}
+
+::deep .app-main-content::-webkit-scrollbar-thumb:hover {
+    background: #ad9d70;
+}
+
+::deep .app-main-content::-webkit-scrollbar-thumb:active {
+    background: #c2b27e;
+}
+
+.window-drag-region {
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1 1 auto;
+    min-width: 0;
+    cursor: default;
+    user-select: none;
+}
+
+::deep .window-app-bar {
+    position: relative;
+}
+
+.window-page-title {
+    align-self: stretch;
+    display: flex;
+    align-items: center;
+    flex: 0 1 140px;
+    min-width: 0;
+    margin-left: 4px;
+    overflow: hidden;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    transform: translateY(1px);
+    white-space: nowrap;
+}
+
+.window-product-title {
+    position: absolute;
+    left: 50%;
+    overflow: hidden;
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 0.025em;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    transform: translateX(-50%);
+    white-space: nowrap;
+}
+
+.window-controls {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding: 2px;
+    margin-left: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.18);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+::deep .navigation-drawer {
+    top: 0 !important;
+    height: 100vh !important;
+    z-index: 1300;
+    border-right: 1px solid rgba(169, 154, 107, 0.32);
+}
+
+::deep .navigation-drawer-header {
+    min-height: 96px;
+    padding: 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.navigation-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    min-height: 96px;
+    padding: 14px 10px 14px 18px;
+    border: 0;
+    color: inherit;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+}
+
+.navigation-brand-copy {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.navigation-brand-logo {
+    display: block;
+    width: 100%;
+    max-width: 198px;
+    height: auto;
+}
+
+::deep .drawer-collapse-cue {
+    flex: 0 0 auto;
+    color: rgba(255, 255, 255, 0.60);
+}
+
+::deep .navigation-brand:hover .drawer-collapse-cue,
+::deep .navigation-brand:focus-visible .drawer-collapse-cue {
+    color: #ffffff;
+}
+
+.navigation-brand:hover {
+    background: rgba(255, 255, 255, 0.035);
+}
+
+.navigation-brand:focus-visible {
+    outline: 2px solid rgba(194, 178, 126, 0.85);
+    outline-offset: -3px;
+}
+
+::deep .navigation-menu {
+    padding: 8px;
+}
+
+::deep .navigation-menu .mud-nav-link {
+    min-height: 40px;
+    margin: 2px 0;
+    border-left: 3px solid transparent;
+    border-radius: 4px;
+    color: rgba(255, 255, 255, 0.68);
+}
+
+::deep .navigation-menu .mud-nav-link .mud-nav-link-icon {
+    color: rgba(255, 255, 255, 0.58);
+}
+
+::deep .navigation-menu .mud-nav-link:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.90);
+}
+
+::deep .navigation-menu .mud-nav-link:focus-visible {
+    outline: 2px solid rgba(194, 178, 126, 0.85);
+    outline-offset: -2px;
+    color: #ffffff;
+}
+
+::deep .navigation-menu .mud-nav-link.active:not(.mud-nav-link-disabled) {
+    border-left-color: #a99a6b;
+    background: #3b3a35;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+::deep .navigation-menu .mud-nav-link.active:not(.mud-nav-link-disabled) .mud-nav-link-icon {
+    color: #c2b27e;
+}
+
+::deep .window-control {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+}
+
+::deep .window-control:hover {
+    background: rgba(255, 255, 255, 0.10);
+}
+
+::deep .window-control-close:hover {
+    color: white;
+    background: #b3261e;
+}
+
+.resize-zone {
+    position: fixed;
+    z-index: 2000;
+    background: transparent;
+}
+
+.resize-edge-top,
+.resize-edge-bottom {
+    right: 4px;
+    left: 4px;
+    height: 4px;
+    cursor: ns-resize;
+}
+
+.resize-edge-top {
+    top: 0;
+}
+
+.resize-edge-bottom {
+    bottom: 0;
+}
+
+.resize-edge-left,
+.resize-edge-right {
+    top: 4px;
+    bottom: 4px;
+    width: 4px;
+    cursor: ew-resize;
+}
+
+.resize-edge-left {
+    left: 0;
+}
+
+.resize-edge-right {
+    right: 0;
+}
+
+.resize-corner-top-left,
+.resize-corner-top-right,
+.resize-corner-bottom-left,
+.resize-corner-bottom-right {
+    width: 4px;
+    height: 4px;
+}
+
+.resize-corner-top-left {
+    top: 0;
+    left: 0;
+    cursor: nwse-resize;
+}
+
+.resize-corner-top-right {
+    top: 0;
+    right: 0;
+    cursor: nesw-resize;
+}
+
+.resize-corner-bottom-left {
+    bottom: 0;
+    left: 0;
+    cursor: nesw-resize;
+}
+
+.resize-corner-bottom-right {
+    right: 0;
+    bottom: 0;
+    cursor: nwse-resize;
+}

--- a/TarkovMonitor/Blazor/Components/LogBoard.razor
+++ b/TarkovMonitor/Blazor/Components/LogBoard.razor
@@ -1,6 +1,6 @@
 ﻿@using Humanizer
 @inject LogRepository logRepository
-<MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Center" Class="ma-3">
+<MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Center" Class="ma-2">
     @if (logRepository.Logs.Count == 0)
     {
         <MudAlert Severity="Severity.Info">No new logs have been seen since launching the monitor.</MudAlert>

--- a/TarkovMonitor/Blazor/Components/MessageBoard.razor
+++ b/TarkovMonitor/Blazor/Components/MessageBoard.razor
@@ -2,11 +2,10 @@
 @using System.Diagnostics;
 @using System.Threading
 @inject MessageLog messageLog
-@inject ISnackbar Snackbar
 @inject IDialogService DialogService
-@inject NavigationManager NavManager
 @inject LocalizationService LocalizationService
-<MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Center" Class="ma-3">
+<MudPaper Class="app-surface dashboard-notification-surface" Elevation="3">
+<MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Center" Class="pa-3">
     @if (messageLog.Messages.Count == 0)
     {
         <MudAlert Severity="Severity.Info">@LocalizationService.GetString("ThereArentAnyMessagesYet")</MudAlert>
@@ -48,6 +47,7 @@
     }
     
 </MudStack>
+</MudPaper>
 
 @code {
     // Force refresh every minute to update timestamps
@@ -57,7 +57,6 @@
     {
         base.OnInitialized();
 
-        messageLog.newMessage += MessageAdded;
         timer = new Timer(RefreshCallback, null, 1000, 1000);
     }
 
@@ -119,36 +118,6 @@
     private void RefreshCallback(object? state)
     {
         InvokeAsync(() => StateHasChanged());
-    }
-
-    private void MessageAdded(object? sender, NewLogMessageArgs e)
-    {
-        InvokeAsync(() => StateHasChanged());
-        var severity = Severity.Info;
-        if (e.Message.Type == "quest" && GameWatcher.ReadingPastLogs)
-        {
-            return;
-        }
-        if (e.Message.Type == "exception")
-        {
-            severity = Severity.Error;
-        }
-        if (e.Message.Type == "warning")
-        {
-            severity = Severity.Warning;
-        }
-        if (e.Message.Type == "update")
-        {
-            severity = Severity.Success;
-        }
-        Snackbar.Add(e.Message.Message, severity, config =>
-        {
-            config.Onclick = snackbar =>
-            {
-                NavManager.NavigateTo("/");
-                return Task.CompletedTask;
-            };
-        });
     }
 
     private async void MessageButtonClick(MonitorMessageButton button)

--- a/TarkovMonitor/Blazor/Pages/Dashboard/Dashboard.razor
+++ b/TarkovMonitor/Blazor/Pages/Dashboard/Dashboard.razor
@@ -7,8 +7,8 @@
 @layout AppLayout
 @implements IDisposable
 
-<MudGrid Class="pa-0" Spacing="0">
-	<MudItem xs="12">
+<MudGrid Class="dashboard-page-grid pa-0" Spacing="0">
+	<MudItem Class="dashboard-page-item" xs="12">
         <MessageBoard>
         </MessageBoard>
 	</MudItem>

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -12,7 +12,7 @@
 
 <MudGrid Class="pa-0" Spacing="0">
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Notifications" Class="mr-2" />@LocalizationService.GetString("Notifications")</MudText>
             <div>
                 <MudSelect @bind-Value="@AudioOutputDeviceSelect" T="int" Label="@LocalizationService.GetString("NotificationsPlaybackDevice")" AnchorOrigin="Origin.BottomCenter" xs="3">
@@ -66,7 +66,7 @@
     </MudItem>
 
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Language" Class="mr-2"/>@LocalizationService.GetString("Language")</MudText>
             <div>
                 <MudSelect @bind-Value="@SelectedLanguage" T="string" Label="@LocalizationService.GetString("SelectLanguage")" AnchorOrigin="Origin.BottomCenter" xs="6">
@@ -80,7 +80,7 @@
     </MudItem>
 
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Window" Class="mr-2"/>@LocalizationService.GetString("WindowBehavior")</MudText>
             <div>
                 <MudSwitch @bind-Value="@MinimizeAtStartupSwitch" Label="@LocalizationService.GetString("StartTarkovMonitorMinimized")" Color="Color.Info" />
@@ -98,14 +98,14 @@
     </MudItem>
 
     <!--MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Handshake" Class="mr-2"/>@LocalizationService.GetString("DataCollection")</MudText>
             <MudSwitch @bind-Value="@SubmitQueueTimeSwitch" Label="@LocalizationService.GetString("SubmitQueueTimeData")" Color="Color.Info" />
         </MudPaper>
     </MudItem-->
 
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/>@LocalizationService.GetString("TarkovTracker")</MudText>
             <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
             <MudButton @onclick="TestToken" @bind-Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
@@ -122,7 +122,7 @@
     </MudItem>
 
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsRemote" Class="mr-2" /><MudButton @onclick="VisitWebsite" Variant="Variant.Text">@LocalizationService.GetString("TarkovDevWebsiteRemote")</MudButton></MudText>
             <MudTextField @bind-Value="@RemoteID" MaxLength="4" Label="@LocalizationService.GetString("RemoteID")" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.ContentPaste" OnAdornmentClick="PasteRemoteClick"></MudTextField>
             <div>
@@ -145,7 +145,7 @@
     </MudItem>
 
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Folder" Class="mr-2" />@LocalizationService.GetString("LogsFolder")</MudText><MudText>@LocalizationService.GetString("DontChangeThisUnlessYouReallyKnowWhatYoureDoing")</MudText>
             <MudTextField @bind-Value="@CustomLogsFolder" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="CustomLogsFolderClick"></MudTextField>
             @if (Properties.Settings.Default.customLogsPath != null && Properties.Settings.Default.customLogsPath != "")
@@ -158,7 +158,7 @@
     </MudItem>
 
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsSuggest" Class="mr-2" />@LocalizationService.GetString("InitialSetup")</MudText>
             <div>
                 <MudButton @onclick="ReadPastLogs" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("ReadPastLogs")</MudButton>

--- a/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
+++ b/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
@@ -10,7 +10,7 @@
 
 <MudGrid Class="pa-0" Spacing="0">
 	<MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Speaker" Class="mr-2"/>@LocalizationService.GetString("Sounds")</MudText>
             <div>
                 <MudSwitch @bind-Value="@RaidStartSwitch" Label="@LocalizationService.GetString("CustomRaidStartingSound")" Color="Color.Info" Class="d-inline-flex" />
@@ -42,7 +42,7 @@
             </div>
         </MudPaper>
         
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.MusicNote" Class="mr-2"/>Media Control</MudText>
             <div>
                 <MudSwitch @bind-Value="@PauseMediaOnRaidSwitch" Label="Pause media on raid start" Color="Color.Primary" />

--- a/TarkovMonitor/Blazor/Pages/Stats/Stats.razor
+++ b/TarkovMonitor/Blazor/Pages/Stats/Stats.razor
@@ -10,7 +10,7 @@
 
 <MudGrid Class="pa-0" Spacing="0">
 	<MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.CurrencyRuble" Class="mr-2"/>@LocalizationService.GetString("FleaMarketSales")</MudText>
             @foreach (KeyValuePair<string, string> currency in Currencies)
             {
@@ -19,7 +19,7 @@
         </MudPaper>
 	</MudItem>
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Map" Class="mr-2" />@LocalizationService.GetString("Raids")</MudText>
             @foreach (var map in TarkovDev.Maps)
             {
@@ -29,7 +29,7 @@
         <!--MudChart ChartType="ChartType.StackedBar" ChartSeries="@Series" XAxisLabels="@XAxisLabels" Width="100%" Height="350px"></MudChart-->
     </MudItem>
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudButton @onclick="ClearData" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("ClearData")</MudButton>
         </MudPaper>
     </MudItem>

--- a/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
+++ b/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
@@ -7,7 +7,7 @@
 
 <MudGrid Class="pa-0" Spacing="0">
     <MudItem xs="12">
-        <MudPaper Class="pa-2 ma-2 mx-4" Elevation="3">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" />@LocalizationService.GetString("Timers")</MudText>
             <MudList T="string">
                 <MudListItem>@LocalizationService.GetString("TimeInRaid"): @TimeInRaidTime</MudListItem>

--- a/TarkovMonitor/MainBlazorUI.Designer.cs
+++ b/TarkovMonitor/MainBlazorUI.Designer.cs
@@ -73,11 +73,15 @@
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
+            BackColor = Color.FromArgb(47, 47, 45);
             ClientSize = new Size(914, 667);
             Controls.Add(blazorWebView1);
+            FormBorderStyle = FormBorderStyle.None;
             Icon = (Icon)resources.GetObject("$this.Icon");
             Margin = new Padding(3, 4, 3, 4);
+            MinimumSize = new Size(720, 480);
             Name = "MainBlazorUI";
+            Padding = new Padding(1);
             Text = "Tarkov Monitor";
             Resize += MainBlazorUI_Resize;
             contextMenuStripTarkovMonitor.ResumeLayout(false);

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -9,11 +9,49 @@ using System.ComponentModel;
 using MudBlazor;
 using Microsoft.Extensions.Localization;
 using System.Text.Json.Nodes;
+using System.Runtime.InteropServices;
 
 namespace TarkovMonitor
 {
     public partial class MainBlazorUI : Form
     {
+        private const int WmNcHitTest = 0x0084;
+        private const int WmNcCalcSize = 0x0083;
+        private const int WmNcLButtonDown = 0x00A1;
+        private const int HtCaption = 0x0002;
+        private const int HtClient = 0x0001;
+        private const int ResizeBorderWidth = 4;
+        private const int WsThickFrame = 0x00040000;
+        private const int WsMinimizeBox = 0x00020000;
+        private const int WsMaximizeBox = 0x00010000;
+        private const int DwmWindowCornerPreference = 33;
+        private const int DwmBorderColor = 34;
+        private const int DwmCaptionColor = 35;
+        private const int DwmRound = 2;
+        private const int TarkovBorderColor = 0x003B555F;
+        private const int TarkovHeaderColor = 0x002D2F2F;
+
+        public event EventHandler? WindowStateChanged;
+
+        [DllImport("user32.dll")]
+        private static extern bool ReleaseCapture();
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr windowHandle, int attribute, ref int value, int valueSize);
+
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                var parameters = base.CreateParams;
+                parameters.Style |= WsThickFrame | WsMinimizeBox | WsMaximizeBox;
+                return parameters;
+            }
+        }
+
         private readonly GameWatcher eft;
         private readonly MessageLog messageLog;
         private readonly LogRepository logRepository;
@@ -56,7 +94,10 @@ namespace TarkovMonitor
             // Creates the dependency injection services which are the in-betweens for the Blazor interface and the rest of the C# application.
             var services = new ServiceCollection();
             services.AddWindowsFormsBlazorWebView();
-            services.AddMudServices();
+            services.AddMudServices(configuration =>
+            {
+                configuration.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.TopCenter;
+            });
             services.AddLocalization();
             services.AddSingleton<LocalizationService>();
             services.AddSingleton<GameWatcher>(eft);
@@ -64,6 +105,7 @@ namespace TarkovMonitor
             services.AddSingleton<LogRepository>(logRepository);
             services.AddSingleton<GroupManager>(groupManager);
             services.AddSingleton<TimersManager>(timersManager);
+            services.AddSingleton<MainBlazorUI>(this);
 
             blazorWebView1.HostPage = "wwwroot\\index.html";
             var serviceProvider = services.BuildServiceProvider();
@@ -167,6 +209,102 @@ namespace TarkovMonitor
             };
             scavCooldownTimer.Elapsed += ScavCooldownTimer_Elapsed;
         }
+
+        public bool IsMaximized => WindowState == FormWindowState.Maximized;
+
+        public void MinimizeWindow() => WindowState = FormWindowState.Minimized;
+
+        public void ToggleMaximizeWindow()
+        {
+            WindowState = IsMaximized ? FormWindowState.Normal : FormWindowState.Maximized;
+        }
+
+        public void CloseWindow() => Close();
+
+        public void BeginWindowDrag()
+        {
+            if (IsMaximized)
+            {
+                return;
+            }
+
+            ReleaseCapture();
+            SendMessage(Handle, WmNcLButtonDown, (IntPtr)HtCaption, IntPtr.Zero);
+        }
+
+        public void BeginWindowResize(int hitTest)
+        {
+            if (WindowState != FormWindowState.Normal || !IsResizeHit(hitTest))
+            {
+                return;
+            }
+
+            ReleaseCapture();
+            SendMessage(Handle, WmNcLButtonDown, (IntPtr)hitTest, IntPtr.Zero);
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+
+            var cornerPreference = DwmRound;
+            DwmSetWindowAttribute(Handle, DwmWindowCornerPreference, ref cornerPreference, sizeof(int));
+
+            var borderColor = TarkovBorderColor;
+            DwmSetWindowAttribute(Handle, DwmBorderColor, ref borderColor, sizeof(int));
+
+            var captionColor = TarkovHeaderColor;
+            DwmSetWindowAttribute(Handle, DwmCaptionColor, ref captionColor, sizeof(int));
+        }
+
+        protected override void WndProc(ref Message message)
+        {
+            if (message.Msg == WmNcCalcSize && message.WParam != IntPtr.Zero && WindowState == FormWindowState.Normal)
+            {
+                message.Result = IntPtr.Zero;
+                return;
+            }
+
+            if (message.Msg == WmNcHitTest && WindowState == FormWindowState.Normal)
+            {
+                message.Result = (IntPtr)GetResizeHitTest(GetScreenPosition(message.LParam));
+                return;
+            }
+
+            base.WndProc(ref message);
+        }
+
+        private static Point GetScreenPosition(IntPtr packedCoordinates)
+        {
+            var packedPosition = packedCoordinates.ToInt64();
+            return new Point(
+                unchecked((short)(packedPosition & 0xffff)),
+                unchecked((short)((packedPosition >> 16) & 0xffff)));
+        }
+
+        private int GetResizeHitTest(Point screenPosition)
+        {
+            var cursor = PointToClient(screenPosition);
+            var left = cursor.X <= ResizeBorderWidth;
+            var right = cursor.X >= ClientSize.Width - ResizeBorderWidth;
+            var top = cursor.Y <= ResizeBorderWidth;
+            var bottom = cursor.Y >= ClientSize.Height - ResizeBorderWidth;
+
+            return (left, right, top, bottom) switch
+            {
+                (true, _, true, _) => 13,
+                (_, true, true, _) => 14,
+                (true, _, _, true) => 16,
+                (_, true, _, true) => 17,
+                (true, _, _, _) => 10,
+                (_, true, _, _) => 11,
+                (_, _, true, _) => 12,
+                (_, _, _, true) => 15,
+                _ => HtClient
+            };
+        }
+
+        private static bool IsResizeHit(int hitTest) => hitTest is >= 10 and <= 17;
 
         private void Eft_ControlSettings(object? sender, ControlSettingsEventArgs e)
         {
@@ -858,6 +996,7 @@ namespace TarkovMonitor
 
         private void MainBlazorUI_Resize(object sender, EventArgs e)
         {
+            WindowStateChanged?.Invoke(this, EventArgs.Empty);
             try
             {
                 if (this.WindowState == FormWindowState.Minimized && Properties.Settings.Default.minimizeToTray)

--- a/TarkovMonitor/Splash.cs
+++ b/TarkovMonitor/Splash.cs
@@ -19,6 +19,8 @@ class Splash : Form
 
     private System.Timers.Timer splashTimer = new System.Timers.Timer();
 
+    [System.ComponentModel.Browsable(false)]
+    [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
     public new float Opacity
     {
         get

--- a/TarkovMonitor/Stats.cs
+++ b/TarkovMonitor/Stats.cs
@@ -1,176 +1,156 @@
-﻿using System.Data.SQLite;
-// do not upgrade to 1.0.118
-// newer version throws an error after being compiled as single file assembly
+using System.Data.SQLite;
+
+// System.Data.SQLite is retained until the dedicated dependency-migration phase.
+// The current package has historically required single-file publish verification.
 
 namespace TarkovMonitor
 {
-    internal class Stats
+    internal static class Stats
     {
         public static string DatabasePath => Path.Join(Application.UserAppDataPath, "..", "TarkovMonitor.db");
-        public static string ConnectionString => $"Data Source={DatabasePath};Version=3;";
-        private static SQLiteConnection Connection;
-        static Stats()
-        {
-			Connection = new SQLiteConnection(ConnectionString);
-            Connection.Open();
+        private static readonly Lazy<StatsDatabase> Database = new(() => new StatsDatabase(DatabasePath));
 
-            List<string> createTableCommands = new()
+        public static void ClearData() => Database.Value.ClearData();
+
+        public static void AddFleaSale(FleaSoldMessageLogContent e, Profile profile) =>
+            Database.Value.AddFleaSale(e, profile);
+
+        public static int GetTotalSales(string currency) => Database.Value.GetTotalSales(currency);
+
+        public static void AddRaid(RaidInfoEventArgs e) => Database.Value.AddRaid(e);
+
+        public static int GetTotalRaids(string mapNameId) => Database.Value.GetTotalRaids(mapNameId);
+
+        public static Dictionary<string, int> GetTotalRaidsPerMap(RaidType raidType) =>
+            Database.Value.GetTotalRaidsPerMap(raidType, TarkovDev.Maps);
+    }
+
+    internal sealed class StatsDatabase : IDisposable
+    {
+        private readonly SQLiteConnection connection;
+
+        internal StatsDatabase(string databasePath)
+        {
+            connection = new SQLiteConnection($"Data Source={databasePath};Version=3;");
+            connection.Open();
+            CreateTables();
+            UpdateDatabase();
+        }
+
+        public void Dispose()
+        {
+            connection.Dispose();
+        }
+
+        internal void ClearData()
+        {
+            var tableNames = new List<string>();
+            using (var command = CreateCommand("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"))
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    tableNames.Add(reader.GetString(0));
+                }
+            }
+
+            using var transaction = connection.BeginTransaction();
+            foreach (var tableName in tableNames)
+            {
+                using var command = CreateCommand($"DELETE FROM [{tableName}];", transaction);
+                command.ExecuteNonQuery();
+            }
+            transaction.Commit();
+        }
+
+        internal void AddFleaSale(FleaSoldMessageLogContent e, Profile profile)
+        {
+            const string sql = "INSERT INTO flea_sales(profile_id, item_id, buyer, count, currency, price) VALUES(@profile_id, @item_id, @buyer, @count, @currency, @price);";
+            var receivedItem = e.ReceivedItems.First();
+            ExecuteNonQuery(sql, new Dictionary<string, object?>
+            {
+                ["profile_id"] = profile.Id,
+                ["item_id"] = e.SoldItemId,
+                ["buyer"] = e.Buyer,
+                ["count"] = e.SoldItemCount,
+                ["currency"] = receivedItem.Key,
+                ["price"] = receivedItem.Value,
+            });
+        }
+
+        internal int GetTotalSales(string currency)
+        {
+            return ExecuteScalarInt(
+                "SELECT COALESCE(SUM(price), 0) FROM flea_sales WHERE currency = @currency;",
+                new Dictionary<string, object?> { ["currency"] = currency });
+        }
+
+        internal void AddRaid(RaidInfoEventArgs e)
+        {
+            const string sql = "INSERT INTO raids(profile_id, map, raid_type, queue_time, raid_id) VALUES (@profile_id, @map, @raid_type, @queue_time, @raid_id);";
+            ExecuteNonQuery(sql, new Dictionary<string, object?>
+            {
+                ["profile_id"] = e.Profile.Id,
+                ["map"] = e.RaidInfo.Map?.nameId,
+                ["raid_type"] = (int)e.RaidInfo.RaidType,
+                ["queue_time"] = e.RaidInfo.QueueTime,
+                ["raid_id"] = e.RaidInfo.RaidId,
+            });
+        }
+
+        internal int GetTotalRaids(string mapNameId)
+        {
+            return ExecuteScalarInt(
+                "SELECT COUNT(id) FROM raids WHERE map = @map;",
+                new Dictionary<string, object?> { ["map"] = mapNameId });
+        }
+
+        internal Dictionary<string, int> GetTotalRaidsPerMap(RaidType raidType, IEnumerable<TarkovDev.Map> maps)
+        {
+            var mapTotals = new Dictionary<string, int>();
+            using (var command = CreateCommand(
+                "SELECT map, COUNT(id) FROM raids WHERE raid_type = @raid_type GROUP BY map;",
+                parameters: new Dictionary<string, object?> { ["raid_type"] = (int)raidType }))
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    if (!reader.IsDBNull(0))
+                    {
+                        mapTotals[reader.GetString(0)] = reader.GetInt32(1);
+                    }
+                }
+            }
+
+            return maps.ToDictionary(
+                map => map.name,
+                map => mapTotals.TryGetValue(map.nameId, out var total) ? total : 0);
+        }
+
+        private void CreateTables()
+        {
+            var commands = new[]
             {
                 "CREATE TABLE IF NOT EXISTS flea_sales (id INTEGER PRIMARY KEY, profile_id VARCHAR(24), item_id CHAR(24), buyer VARCHAR(14), count INT, currency CHAR(24), price INT, time TIMESTAMP DEFAULT CURRENT_TIMESTAMP);",
                 "CREATE TABLE IF NOT EXISTS raids (id INTEGER PRIMARY KEY, profile_id VARCHAR(24), map VARCHAR(24), raid_type INT, queue_time DECIMAL(6,2), raid_id VARCHAR(24), time TIMESTAMP DEFAULT CURRENT_TIMESTAMP);",
             };
-            foreach (var commandText in createTableCommands)
+            foreach (var sql in commands)
             {
-                using var command = new SQLiteCommand(Connection);
-                command.CommandText = commandText;
-                command.ExecuteNonQuery();
+                ExecuteNonQuery(sql);
             }
-
-            UpdateDatabase();
         }
 
-        public static void ClearData()
+        private void UpdateDatabase()
         {
-            Query("PRAGMA foreign_keys=off;");
-            var reader = Query("SELECT name FROM sqlite_master WHERE type='table';");
-            while (reader.Read())
-            {
-                var tableName = reader.GetString(0);
-                Query($"DELETE FROM {tableName};");
-            }
-            Query("PRAGMA foreign_keys=on;");
-        }
-
-        private static SQLiteDataReader Query(string query, Dictionary<string,object> parameters)
-        {
-            using var command = new SQLiteCommand(Connection);
-            command.CommandText = query;
-            foreach (var parameter in parameters)
-            {
-                command.Parameters.AddWithValue($"@{parameter.Key}", parameter.Value);
-            }
-            return command.ExecuteReader();
-        }
-        private static SQLiteDataReader Query (string query)
-        {
-            return Query(query, new());
-        }
-
-        public static void AddFleaSale(FleaSoldMessageLogContent e, Profile profile)
-        {
-            var sql = "INSERT INTO flea_sales(profile_id, item_id, buyer, count, currency, price) VALUES(@profile_id, @item_id, @buyer, @count, @currency, @price);";
-            var parameters = new Dictionary<string, object>
-            {
-                {
-                    "profile_id", profile.Id
-                },
-                {
-                    "item_id", e.SoldItemId
-                },
-                {
-                    "buyer", e.Buyer
-                },
-                {
-                    "count", e.SoldItemCount
-                },
-                {
-                    "currency", e.ReceivedItems.ElementAt(0).Key
-                },
-                {
-                    "price", e.ReceivedItems.ElementAt(0).Value
-                },
-            };
-            Query(sql, parameters);
-        }
-        public static int GetTotalSales(string currency)
-        {
-            var reader = Query("SELECT SUM(price) as total FROM flea_sales WHERE currency = @currency", new() { { "currency", currency } });
-            while (reader.Read())
-            {
-                if (reader.IsDBNull(0))
-                {
-                    continue;
-                }
-                return reader.GetInt32(0);
-            }
-            return 0;
-		}
-        public static void AddRaid(RaidInfoEventArgs e)
-        {
-            var sql = "INSERT INTO raids(profile_id, map, raid_type, queue_time, raid_id) VALUES (@profile_id, @map, @raid_type, @queue_time, @raid_id);";
-            var parameters = new Dictionary<string, object> {
-                {
-                    "profile_id", e.Profile.Id
-                },
-                {
-                    "map", e.RaidInfo.Map
-                },
-                {
-                    "raid_type", e.RaidInfo.RaidType
-                },
-                {
-                    "queue_time", e.RaidInfo.QueueTime
-                },
-                {
-                    "raid_id", e.RaidInfo.RaidId
-                },
-            };
-            Query(sql, parameters);
-        }
-        public static int GetTotalRaids(string mapNameId)
-        {
-            var reader = Query("SELECT COUNT(id) as total FROM raids WHERE map = @map", new() { { "map", mapNameId } });
-            while (reader.Read())
-            {
-                if (reader.IsDBNull(0))
-                {
-                    continue;
-                }
-                return reader.GetInt32(0);
-            }
-            return 0;
-        }
-        public static Dictionary<string, int> GetTotalRaidsPerMap(RaidType raidType)
-        {
-            Dictionary<string, int> mapTotals = new();
-            var reader = Query("SELECT map, COUNT(id) as total FROM raids WHERE raid_type = @raid_type GROUP BY map", new() { { "raid_type", raidType } });
-            while (reader.Read())
-            {
-                if (reader.IsDBNull(1))
-                {
-                    mapTotals[reader.GetString(0)] = 0;
-                    continue;
-                }
-                mapTotals[reader.GetString(0)] = reader.GetInt32(1);
-            }
-            Dictionary<string, int> raidsPerMap = new();
-            foreach (var map in TarkovDev.Maps)
-            {
-                raidsPerMap[map.name] = 0;
-                if (mapTotals.ContainsKey(map.nameId))
-                {
-                    raidsPerMap[map.name] = mapTotals[map.nameId];
-                }
-            }
-            return raidsPerMap;
-        }
-
-        private static void UpdateDatabase()
-        {
-            List<string> db_tables = new() { "raids", "flea_sales" };
-            foreach (var tableName in db_tables)
+            foreach (var tableName in new[] { "raids", "flea_sales" })
             {
                 var profileIdFieldExists = false;
-                var result = Query($"PRAGMA table_info({tableName});");
-                while (result.Read())
+                using (var command = CreateCommand($"PRAGMA table_info([{tableName}]);"))
+                using (var reader = command.ExecuteReader())
                 {
-                    for (int i = 0; i < result.FieldCount; i++)
+                    while (reader.Read())
                     {
-                        if (result.GetName(i) != "name")
-                        {
-                            continue;
-                        }
-                        if (result.GetString(i) == "profile_id")
+                        if (reader.GetString(reader.GetOrdinal("name")) == "profile_id")
                         {
                             profileIdFieldExists = true;
                             break;
@@ -179,12 +159,39 @@ namespace TarkovMonitor
                 }
                 if (!profileIdFieldExists)
                 {
-                    using var command = new SQLiteCommand(Connection);
-                    command.CommandText = $"ALTER TABLE {tableName} ADD COLUMN profile_id VARCHAR(24)";
-                    command.ExecuteNonQuery();
+                    ExecuteNonQuery($"ALTER TABLE [{tableName}] ADD COLUMN profile_id VARCHAR(24);");
                 }
-
             }
+        }
+
+        private int ExecuteScalarInt(string sql, Dictionary<string, object?>? parameters = null)
+        {
+            using var command = CreateCommand(sql, parameters: parameters);
+            return Convert.ToInt32(command.ExecuteScalar());
+        }
+
+        private void ExecuteNonQuery(string sql, Dictionary<string, object?>? parameters = null)
+        {
+            using var command = CreateCommand(sql, parameters: parameters);
+            command.ExecuteNonQuery();
+        }
+
+        private SQLiteCommand CreateCommand(
+            string sql,
+            SQLiteTransaction? transaction = null,
+            Dictionary<string, object?>? parameters = null)
+        {
+            var command = connection.CreateCommand();
+            command.CommandText = sql;
+            command.Transaction = transaction;
+            if (parameters != null)
+            {
+                foreach (var parameter in parameters)
+                {
+                    command.Parameters.AddWithValue($"@{parameter.Key}", parameter.Value ?? DBNull.Value);
+                }
+            }
+            return command;
         }
     }
 }

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -28,8 +28,8 @@
     <PackageReference Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="MaterialSkin.2" Version="2.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="6.0.424" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.28" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.90" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.10" />
     <PackageReference Include="MudBlazor" Version="6.19.1" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/TarkovMonitor/wwwroot/css/app.css
+++ b/TarkovMonitor/wwwroot/css/app.css
@@ -1,3 +1,35 @@
-﻿body {
+html,
+body,
+#app {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+}
+
+body {
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkAgMAAAANjH3HAAAADFBMVEUtLS8uLjAvLzEsKy2xgXVgAAAASElEQVR4Ae3QoQ3AAAwDQa9Qmu1DX5kk6lAdoEbBJk8tn4qHdtHyMi7qpspFM+y6iKJxEcvgctm5/IlBDGIQgxjEIAYxiME/H1nLq0bNJikRAAAAAElFTkSuQmCC)
+}
+
+.mud-main-content.app-main-content {
+    padding-top: 8px !important;
+    padding-bottom: 8px !important;
+}
+
+.mud-paper.app-surface {
+    border: 1px solid rgba(143, 130, 95, 0.42);
+    border-radius: 8px;
+    background-color: rgba(25, 25, 24, 0.84);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(2px);
+}
+
+.dashboard-notification-surface {
+    min-height: calc(100% - 16px);
+    margin: 8px 16px;
+}
+
+.dashboard-page-grid,
+.dashboard-page-item {
+    height: 100%;
 }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.302",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Summary

This PR updated TarkovMonitor to .NET 10, improved statistics storage, and refreshed the desktop interface while preserving the application's existing behavior and saved user data.

## Changes

- Updated the application and GitHub Actions workflows to use .NET 10. The SDK version was pinned so local and automated builds used the same toolchain.  
  **Affected files:** `global.json`, `TarkovMonitor/TarkovMonitor.csproj`, `.github/workflows/build-dev.yml`, `.github/workflows/tag-release.yml`

- Reorganized statistics database access so connections, commands, readers, and transactions closed correctly. Parameterized queries were used, and statistics were cleared within a single transaction.  
  **Affected file:** `TarkovMonitor/Stats.cs`

- Replaced the standard Windows title bar with a custom title bar and window-control pill. Windows behavior was added for dragging, resizing, minimizing, maximizing, closing, rounded corners, and border colors.  
  **Affected files:** `TarkovMonitor/MainBlazorUI.Designer.cs`, `TarkovMonitor/MainBlazorUI.cs`, `TarkovMonitor/Blazor/AppLayout.razor`, `TarkovMonitor/Blazor/AppLayout.razor.css`

- Added reliable 4px resize zones around the edges and corners of the application window while keeping the visible border thin.  
  **Affected files:** `TarkovMonitor/MainBlazorUI.cs`, `TarkovMonitor/Blazor/AppLayout.razor`, `TarkovMonitor/Blazor/AppLayout.razor.css`

- Updated the navigation drawer, selected-page appearance, collapse behavior, page titles, and scrollbar styling.  
  **Affected files:** `TarkovMonitor/Blazor/AppLayout.razor`, `TarkovMonitor/Blazor/AppLayout.razor.css`

- Moved popup-notification handling into the main layout so the application could determine which page the user was viewing. Routine popups were suppressed while Messages was open, while warnings and errors remained visible.  
  **Affected files:** `TarkovMonitor/Blazor/AppLayout.razor`, `TarkovMonitor/Blazor/Components/MessageBoard.razor`

- Added a translucent panel around Dashboard messages and allowed it to fill the available window height while keeping messages aligned at the top.  
  **Affected files:** `TarkovMonitor/Blazor/Components/MessageBoard.razor`, `TarkovMonitor/Blazor/Pages/Dashboard/Dashboard.razor`, `TarkovMonitor/wwwroot/css/app.css`

- Added a shared translucent panel style and consistent 16px top and bottom gutters throughout the application.  
  **Affected files:** `TarkovMonitor/wwwroot/css/app.css`, `TarkovMonitor/Blazor/Pages/Settings/Settings.razor`, `TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor`, `TarkovMonitor/Blazor/Pages/Stats/Stats.razor`, `TarkovMonitor/Blazor/Pages/Timers/Timers.razor`, `TarkovMonitor/Blazor/Components/LogBoard.razor`

- Added designer metadata that prevented .NET 10 from incorrectly saving the custom splash-screen opacity property.  
  **Affected file:** `TarkovMonitor/Splash.cs`

## Validation

- Tested the Beta build throughout the application
- Confirmed that existing settings and data continued to load
- Tested navigation and scrolling across every page
- Tested window dragging, resizing, minimizing, maximizing, and closing
- Tested notification display and suppression
- Tested PMC and Scav raid behavior
- Completed a self-contained, single-file `win-x64` publish successfully

## Notes

Before submitting this PR for review, I asked Codex to perform a comprehensive review and analysis of the project. That review identified the following existing issues and areas for future improvement:

- `System.Data.SqlClient` 4.8.1 reported known moderate- and high-severity security advisories.
- `System.Drawing.Common` 4.7.0 reported a known critical-severity security advisory.
- `WindowsAPICodePack-Core` and `WindowsAPICodePack-Shell` targeted older .NET Framework versions and produced compatibility warnings under .NET 10.
- The build reported a version conflict between the WindowsBase reference provided by .NET 10 and the version expected by WebView2.
- Several existing models and events produced nullable-reference warnings.
- Some existing asynchronous calls started without being awaited.
- Several existing code paths were reported as unreachable.
- `Splash.cs` still used the obsolete `WebClient` API.
- `MainUI.razor` contained an `Error` element that Razor did not recognize as a registered component.
- These warnings did not prevent the application from building or publishing. The package and framework compatibility warnings should be addressed in a separate dependency-cleanup pass.
