### PR TITLE
feat: auto-zoom and viewRadius for tarkov.dev map remote

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -131,6 +131,18 @@
             <div>
                 <MudSwitch @bind-Value="@NavigateMapOnPositionUpdateSwitch" Label="@LocalizationService.GetString("SwitchToTarkovDevMapOnPositionUpdate")" Color="Color.Info" />
             </div>
+            <div style="margin-top: 8px;">
+                <MudSwitch @bind-Value="@autoZoomInput" Label="Zoom to player on screenshot" Color="Color.Info" />
+                <MudNumericField @bind-Value="@viewRadiusInput"
+                                 Label="View radius (meters)"
+                                 Min="50" Max="5000" Step="25"
+                                 Disabled="@(!autoZoomInput)"
+                                 Variant="Variant.Outlined"
+                                 Margin="Margin.Dense"
+                                 Adornment="Adornment.End" AdornmentText="m"
+                                 HelperText="Meters shown around your position on each new map (50 = very close, 1000 = wide area)"
+                                 Style="max-width: 200px; margin-top: 4px;" />
+            </div>
             <div>
                 <MudSwitch @bind-Value="@AutomaticallyDeleteScreenshotsAfterRaid" Label="@LocalizationService.GetString("AutomaticallyDeleteScreenshotsAfterRaid")" Color="Color.Info" />
             </div>
@@ -141,6 +153,9 @@
                     <MudSelectItem T="string" Value="@map.nameId">@map.name</MudSelectItem>
                 }
             </MudSelect>
+            <div style="margin-top: 16px;">
+                <MudButton @onclick="SaveRemoteSettings" Variant="Variant.Filled" Color="Color.Primary">Save Map &amp; Remote Settings</MudButton>
+            </div>
         </MudPaper>
     </MudItem>
 
@@ -182,12 +197,17 @@
         }
     }
 
+    private bool autoZoomInput;
+    private int viewRadiusInput;
+
     protected override void OnInitialized()
     {
         base.OnInitialized();
         PlaybackDevices = Sound.GetPlaybackDevices();
         AvailableLanguages = LocalizationService.GetAvailableLanguages();
         LocalizationService.LanguageChanged += OnLanguageChanged;
+        autoZoomInput = Properties.Settings.Default.autoZoomOnLocationUpdate;
+        viewRadiusInput = Properties.Settings.Default.viewRadiusOnLocationUpdate;
     }
 
     protected override void OnParametersSet()
@@ -702,5 +722,14 @@
 
     void SetDefaultLogFolder() {
         CustomLogsFolder = "";
+    }
+
+    private void SaveRemoteSettings()
+    {
+        Properties.Settings.Default.autoZoomOnLocationUpdate = autoZoomInput;
+        Properties.Settings.Default.viewRadiusOnLocationUpdate = viewRadiusInput;
+        Properties.Settings.Default.Save();
+        SocketClient.ResetLastMap();
+        messageLog.AddMessage("Remote settings saved successfully.", "success");
     }
 }

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -335,16 +335,19 @@ namespace TarkovMonitor
             {
                 return;
             }
+            // EFT writes the screenshot before the player has actually spawned, producing a
+            // bogus (0,0,0) origin on the first screenshot of every raid. Skip it so we don't
+            // send a false position and don't consume the "map changed" zoom trigger.
+            if (e.Position.X == 0 && e.Position.Y == 0 && e.Position.Z == 0)
+            {
+                return;
+            }
             messageLog.AddMessage($"Player position on {e.RaidInfo.Map.name}: x: {e.Position.X}, y: {e.Position.Y}, z: {e.Position.Z}");
-            List<JsonObject> socketMessages = new();
-            socketMessages.Add(SocketClient.GetPlayerPositionMessage(e));
-            //await SocketClient.UpdatePlayerPosition(e);
+            await SocketClient.SendPlayerPositionAndZoom(e);
             if (Properties.Settings.Default.navigateMapOnPositionUpdate)
             {
-                //SocketClient.NavigateToMap(map);
-                socketMessages.Add(SocketClient.GetNavigateToMapMessage(e.RaidInfo.Map));
+                await SocketClient.NavigateToMap(e.RaidInfo.Map);
             }
-            SocketClient.Send(socketMessages);
         }
 
         private void UpdateCheck_Error(object? sender, ExceptionEventArgs e)

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -346,5 +346,29 @@ namespace TarkovMonitor.Properties {
                 this["pauseMediaOnRaid"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool autoZoomOnLocationUpdate {
+            get {
+                return ((bool)(this["autoZoomOnLocationUpdate"]));
+            }
+            set {
+                this["autoZoomOnLocationUpdate"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("200")]
+        public int viewRadiusOnLocationUpdate {
+            get {
+                return ((int)(this["viewRadiusOnLocationUpdate"]));
+            }
+            set {
+                this["viewRadiusOnLocationUpdate"] = value;
+            }
+        }
     }
 }

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -83,5 +83,11 @@
     <Setting Name="pauseMediaOnRaid" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="autoZoomOnLocationUpdate" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="viewRadiusOnLocationUpdate" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">200</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TarkovMonitor/SocketClient.cs
+++ b/TarkovMonitor/SocketClient.cs
@@ -12,6 +12,7 @@ namespace TarkovMonitor
         private static ClientWebSocket socket;
         private static CancellationTokenSource cancellationToken;
         private static Task receiveTask;
+        private static string? _lastMapName;
         private static System.Timers.Timer idleTimer = new()
         {
             AutoReset = false,
@@ -132,6 +133,11 @@ namespace TarkovMonitor
             return Send(new List<JsonObject> { message });
         }
 
+        public static void ResetLastMap()
+        {
+            _lastMapName = null;
+        }
+
         public static async Task UpdatePlayerPosition(PlayerPositionEventArgs e)
         {
             if (e.RaidInfo.Map == null)
@@ -149,6 +155,33 @@ namespace TarkovMonitor
             }
         }
 
+        public static async Task SendPlayerPositionAndZoom(PlayerPositionEventArgs e)
+        {
+            if (e.RaidInfo.Map == null)
+            {
+                return;
+            }
+
+            bool mapChanged = e.RaidInfo.Map.normalizedName != _lastMapName;
+            _lastMapName = e.RaidInfo.Map.normalizedName;
+
+            int? viewRadius = null;
+            if (mapChanged && Properties.Settings.Default.autoZoomOnLocationUpdate)
+            {
+                viewRadius = Math.Clamp(Properties.Settings.Default.viewRadiusOnLocationUpdate, 50, 5000);
+            }
+
+            var message = GetPlayerPositionMessage(e, viewRadius);
+            try
+            {
+                await Send(message);
+            }
+            catch (Exception ex)
+            {
+                ExceptionThrown?.Invoke(message, new(ex, "sending player position and zoom"));
+            }
+        }
+
         public static async Task NavigateToMap(TarkovDev.Map map)
         {
             var payload = GetNavigateToMapMessage(map);
@@ -162,27 +195,32 @@ namespace TarkovMonitor
             }
         }
 
-        public static JsonObject GetPlayerPositionMessage(PlayerPositionEventArgs e)
+        public static JsonObject GetPlayerPositionMessage(PlayerPositionEventArgs e, int? viewRadius = null)
         {
             if (e.RaidInfo.Map == null)
             {
                 throw new Exception("Map not found");
             }
+            var data = new JsonObject
+            {
+                ["type"] = "playerPosition",
+                ["map"] = e.RaidInfo.Map.normalizedName,
+                ["position"] = new JsonObject
+                {
+                    ["x"] = e.Position.X,
+                    ["y"] = e.Position.Y,
+                    ["z"] = e.Position.Z,
+                },
+                ["rotation"] = e.Rotation,
+            };
+            if (viewRadius.HasValue)
+            {
+                data["viewRadius"] = viewRadius.Value;
+            }
             return new JsonObject
             {
                 ["type"] = "command",
-                ["data"] = new JsonObject
-                {
-                    ["type"] = "playerPosition",
-                    ["map"] = e.RaidInfo.Map.normalizedName,
-                    ["position"] = new JsonObject
-                    {
-                        ["x"] = e.Position.X,
-                        ["y"] = e.Position.Y,
-                        ["z"] = e.Position.Z,
-                    },
-                    ["rotation"] = e.Rotation,
-                }
+                ["data"] = data,
             };
         }
 


### PR DESCRIPTION
## Summary

Ports the auto-zoom / viewRadius feature from the UVB76 branch to master (without the multi-remote parsing changes, which are a separate concern).

- **New settings:** `autoZoomOnLocationUpdate` (bool, default off) and `viewRadiusOnLocationUpdate` (int, default 200 m)
- **Protocol change:** replaces the old `zoomLevel` Leaflet integer field with `viewRadius` in game-world meters — only sent on the first screenshot after a map change, so manual zoom within a raid is preserved
- **Skip bogus origin:** EFT writes the screenshot file before the player spawns, producing a (0,0,0) position on the first screenshot of every raid — this is now filtered out
- **`ResetLastMap()`:** saves trigger a map-reset so a new radius value takes effect on the next screenshot without waiting for a map change
- **Settings UI:** "Zoom to player on screenshot" switch + view radius numeric field (50–5000 m) + "Save Map & Remote Settings" button

## Test plan

- [ ] Build passes with zero errors
- [ ] Entering a raid and taking a screenshot sends `viewRadius` in the first position message when auto-zoom is on
- [ ] Subsequent screenshots on the same map do not include `viewRadius`
- [ ] Changing maps mid-session sends `viewRadius` again on the first screenshot of the new map
- [ ] Toggling auto-zoom off: position messages never include `viewRadius`
- [ ] Saving settings calls `ResetLastMap()` — next screenshot on the same map sends `viewRadius` as if the map changed
- [ ] The first screenshot of a raid (which EFT writes at position 0,0,0) is silently dropped and does not relay to tarkov.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)