### PR TITLE
feat: add customizable floating raid timer panel

### DIFF
--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -85,6 +85,15 @@
             <setting name="language" serializeAs="String">
                 <value>en</value>
             </setting>
+            <setting name="floatingTimerPanelEnabled" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="floatingTimerPanelShowTimeInRaid" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="floatingTimerPanelShowRunThrough" serializeAs="String">
+                <value>True</value>
+            </setting>
         </TarkovMonitor.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TarkovMonitor/Blazor/AppLayout.razor
+++ b/TarkovMonitor/Blazor/AppLayout.razor
@@ -9,6 +9,7 @@
 @inject MessageLog MessageLog
 @inject ISnackbar Snackbar
 @inject NavigationManager NavigationManager
+@inject TimersManager TimersManager
 
 <div style="width: 100%; height: 100%" class="tarkov-dev-bg">
 	<MudLayout>
@@ -48,6 +49,47 @@
 				@Body
 			</CascadingValue>
 		</MudMainContent>
+		@if (ShowFloatingTimerPanel)
+		{
+			<MudPaper id="floating-timer-panel" Class="@FloatingTimerPanelClass" Elevation="8">
+				<div class="floating-timer-panel__handle">
+					<MudIcon Icon="@Icons.Material.Filled.DragIndicator" Size="Size.Small" />
+					@if (floatingTimerPanelCollapsed)
+					{
+						<MudText Typo="Typo.subtitle2" Class="floating-timer-panel__compact-value">@CompactTimerValues</MudText>
+					}
+					else
+					{
+						<MudText Typo="Typo.subtitle2">Raid timers</MudText>
+						<MudIconButton Icon="@Icons.Material.Filled.Restore" Size="Size.Small" Color="Color.Inherit"
+							Title="Reset position" OnClick="ResetFloatingTimerPosition" />
+					}
+					<MudIconButton Icon="@(floatingTimerPanelCollapsed ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+						Size="Size.Small" Color="Color.Inherit"
+						Title="@(floatingTimerPanelCollapsed ? "Expand timer panel" : "Collapse timer panel")"
+						OnClick="ToggleFloatingTimerPanel" />
+				</div>
+				@if (!floatingTimerPanelCollapsed)
+				{
+				<div class="floating-timer-panel__timers">
+					@if (TimersManager.FloatingPanelShowTimeInRaid)
+					{
+						<div class="floating-timer-panel__timer">
+							<MudText Typo="Typo.caption">Elapsed Raid Time</MudText>
+							<MudText Typo="Typo.h5" Class="floating-timer-panel__value">@FormatTimer(timeInRaid)</MudText>
+						</div>
+					}
+					@if (TimersManager.FloatingPanelShowRunThrough)
+					{
+						<div class="floating-timer-panel__timer">
+							<MudText Typo="Typo.caption">@LocalizationService.GetString("RunthroughPeriod")</MudText>
+							<MudText Typo="Typo.h5" Class="floating-timer-panel__value">@FormatTimer(runThroughRemaining)</MudText>
+						</div>
+					}
+				</div>
+				}
+			</MudPaper>
+		}
 	</MudLayout>
 	@if (!WindowHost.IsMaximized)
 	{
@@ -67,12 +109,41 @@
 	bool drawerOpen = true;
 
 	public string CurrentPageTitle = "TarkovMonitor";
+	private TimeSpan timeInRaid;
+	private TimeSpan runThroughRemaining;
+	private bool isTimersPage;
+	private bool floatingTimerPanelCollapsed = true;
+
+	private bool ShowFloatingTimerPanel =>
+		TimersManager.FloatingPanelEnabled && TimersManager.IsRaidActive && !isTimersPage;
+
+	private static string FormatTimer(TimeSpan value) => value.ToString(@"hh\:mm\:ss");
+	private string FloatingTimerPanelClass => $"floating-timer-panel{(floatingTimerPanelCollapsed ? " floating-timer-panel--collapsed" : string.Empty)}";
+	private string CompactTimerValues => string.Join(" | ", new[]
+	{
+		TimersManager.FloatingPanelShowTimeInRaid ? $"ERT {FormatTimer(timeInRaid)}" : null,
+		TimersManager.FloatingPanelShowRunThrough ? $"RT {FormatTimer(runThroughRemaining)}" : null
+	}.Where(value => value is not null));
 
 	protected override void OnInitialized()
 	{
 		LocalizationService.LanguageChanged += OnLanguageChanged;
 		WindowHost.WindowStateChanged += OnWindowStateChanged;
 		MessageLog.newMessage += OnMessageAdded;
+		NavigationManager.LocationChanged += OnLocationChanged;
+		TimersManager.RaidTimerChanged += OnRaidTimerChanged;
+		TimersManager.RunThroughTimerChanged += OnRunThroughTimerChanged;
+		TimersManager.RaidActiveChanged += OnFloatingTimerStateChanged;
+		TimersManager.FloatingPanelSettingChanged += OnFloatingTimerStateChanged;
+		timeInRaid = TimersManager.TimeInRaid;
+		runThroughRemaining = TimersManager.RunThroughRemaining;
+		UpdateCurrentPage();
+	}
+
+	protected override async Task OnAfterRenderAsync(bool firstRender)
+	{
+		if (ShowFloatingTimerPanel)
+			await JSRuntime.InvokeVoidAsync("floatingTimerPanel.initialize", "floating-timer-panel");
 	}
 
 	public void SetTitle(string value) {
@@ -143,10 +214,58 @@
 		InvokeAsync(StateHasChanged);
 	}
 
+	private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
+	{
+		UpdateCurrentPage();
+		InvokeAsync(StateHasChanged);
+	}
+
+	private void UpdateCurrentPage()
+	{
+		var relativePath = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+		isTimersPage = relativePath.Split('?', '#')[0].Trim('/').Equals("timers", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private void OnRaidTimerChanged(object? sender, TimerChangedEventArgs e)
+	{
+		timeInRaid = e.TimerValue;
+		InvokeAsync(StateHasChanged);
+	}
+
+	private void OnFloatingTimerStateChanged(object? sender, EventArgs e)
+	{
+		if (!TimersManager.IsRaidActive)
+			floatingTimerPanelCollapsed = true;
+		timeInRaid = TimersManager.TimeInRaid;
+		runThroughRemaining = TimersManager.RunThroughRemaining;
+		InvokeAsync(StateHasChanged);
+	}
+
+	private void ToggleFloatingTimerPanel()
+	{
+		floatingTimerPanelCollapsed = !floatingTimerPanelCollapsed;
+	}
+
+	private void OnRunThroughTimerChanged(object? sender, TimerChangedEventArgs e)
+	{
+		runThroughRemaining = e.TimerValue;
+		InvokeAsync(StateHasChanged);
+	}
+
+	private async Task ResetFloatingTimerPosition()
+	{
+		await JSRuntime.InvokeVoidAsync("floatingTimerPanel.reset", "floating-timer-panel");
+	}
+
 	public void Dispose()
 	{
 		LocalizationService.LanguageChanged -= OnLanguageChanged;
 		WindowHost.WindowStateChanged -= OnWindowStateChanged;
 		MessageLog.newMessage -= OnMessageAdded;
+		NavigationManager.LocationChanged -= OnLocationChanged;
+		TimersManager.RaidTimerChanged -= OnRaidTimerChanged;
+		TimersManager.RunThroughTimerChanged -= OnRunThroughTimerChanged;
+		TimersManager.RaidActiveChanged -= OnFloatingTimerStateChanged;
+		TimersManager.FloatingPanelSettingChanged -= OnFloatingTimerStateChanged;
 	}
 }

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -7,6 +7,7 @@
 @inject MessageLog messageLog
 @inject IDialogService DialogService
 @inject LocalizationService LocalizationService
+@inject TimersManager timersManager
 @layout AppLayout
 @implements IDisposable
 
@@ -62,6 +63,18 @@
             <div>
                 <MudTextField @bind-Value="@RunthroughTime" Label="@LocalizationService.GetString("RunthroughTime")" Class="d-inline-flex" sx="3" />
             </div>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" />Timers</MudText>
+            <MudSwitch @bind-Value="@FloatingTimerPanelSwitch" Label="Show floating time-in-raid panel" Color="Color.Info" />
+            <MudText Typo="Typo.caption">Shows a movable timer inside Tarkov Monitor after deployment finishes. It is hidden while viewing the Timers tab.</MudText>
+            <MudText Typo="Typo.subtitle2" Class="mt-3">Displayed timers</MudText>
+            <MudSwitch @bind-Value="@FloatingTimerShowTimeInRaidSwitch" Label="Elapsed raid time" Color="Color.Info" Class="ml-4" />
+            <MudSwitch @bind-Value="@FloatingTimerShowRunThroughSwitch" Label="Run-through remaining" Color="Color.Info" Class="ml-4" />
+            <MudText Typo="Typo.caption">At least one timer must remain selected. Scav cooldown is not currently available in the floating panel.</MudText>
         </MudPaper>
     </MudItem>
 
@@ -282,6 +295,24 @@
             Properties.Settings.Default.raidStartAlert = value;
             Properties.Settings.Default.Save();
         }
+    }
+
+    public bool FloatingTimerPanelSwitch
+    {
+        get => timersManager.FloatingPanelEnabled;
+        set => timersManager.FloatingPanelEnabled = value;
+    }
+
+    public bool FloatingTimerShowTimeInRaidSwitch
+    {
+        get => timersManager.FloatingPanelShowTimeInRaid;
+        set => timersManager.FloatingPanelShowTimeInRaid = value;
+    }
+
+    public bool FloatingTimerShowRunThroughSwitch
+    {
+        get => timersManager.FloatingPanelShowRunThrough;
+        set => timersManager.FloatingPanelShowRunThrough = value;
     }
 
     public bool MatchFoundSwitch { 

--- a/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
+++ b/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
@@ -9,10 +9,17 @@
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" />@LocalizationService.GetString("Timers")</MudText>
+            <div class="d-flex align-center mt-2">
+                <MudText Class="mr-2">Floating timer panel:</MudText>
+                <MudChip T="string" Color="@(timersManager.FloatingPanelEnabled ? Color.Success : Color.Default)" Size="Size.Small">
+                    @(timersManager.FloatingPanelEnabled ? "Enabled" : "Disabled")
+                </MudChip>
+            </div>
+            <MudText Typo="Typo.caption">Displayed: @FloatingPanelTimerSummary</MudText>
             <MudList T="string">
-                <MudListItem>@LocalizationService.GetString("TimeInRaid"): @TimeInRaidTime</MudListItem>
-                <MudListItem>@LocalizationService.GetString("RunthroughPeriod"): @RunThroughRemainingTime</MudListItem>
-                <MudListItem>@LocalizationService.GetString("ScavCooldown"): @ScavCooldownTime</MudListItem>
+                <MudListItem>@LocalizationService.GetString("TimeInRaid"): @FormatTimer(TimeInRaidTime)</MudListItem>
+                <MudListItem>@LocalizationService.GetString("RunthroughPeriod"): @FormatTimer(RunThroughRemainingTime)</MudListItem>
+                <MudListItem>@LocalizationService.GetString("ScavCooldown"): @FormatTimer(ScavCooldownTime)</MudListItem>
             </MudList>
         </MudPaper>
     </MudItem>
@@ -26,6 +33,11 @@
     private TimeSpan RunThroughRemainingTime;
     private TimeSpan TimeInRaidTime;
     private TimeSpan ScavCooldownTime;
+    private string FloatingPanelTimerSummary => string.Join(", ", new[]
+    {
+        timersManager.FloatingPanelShowTimeInRaid ? "Elapsed raid time" : null,
+        timersManager.FloatingPanelShowRunThrough ? "Run-through remaining" : null
+    }.Where(value => value is not null));
 
     protected override void OnInitialized()
     {
@@ -35,8 +47,11 @@
         timersManager.RunThroughTimerChanged += TimersManager_RunThroughTimerChanged;
         timersManager.ScavCooldownTimerChanged += TimersManager_ScavCooldownTimerChanged;
 
+        TimeInRaidTime = timersManager.TimeInRaid;
         ScavCooldownTime = TimeSpan.FromSeconds(TarkovDev.ScavCooldownSeconds());
     }
+
+    private static string FormatTimer(TimeSpan value) => value.ToString(@"hh\:mm\:ss");
 
     private async void TimersManager_RaidTimerChanged(object? sender, TimerChangedEventArgs e)
     {

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -89,7 +89,7 @@ namespace TarkovMonitor
 
 			eft = new GameWatcher();
 
-            timersManager = new TimersManager(eft);
+            timersManager = new TimersManager(eft, messageLog);
 
             // Creates the dependency injection services which are the in-betweens for the Blazor interface and the rest of the C# application.
             var services = new ServiceCollection();

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -346,5 +346,41 @@ namespace TarkovMonitor.Properties {
                 this["pauseMediaOnRaid"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool floatingTimerPanelEnabled {
+            get {
+                return ((bool)(this["floatingTimerPanelEnabled"]));
+            }
+            set {
+                this["floatingTimerPanelEnabled"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool floatingTimerPanelShowTimeInRaid {
+            get {
+                return ((bool)(this["floatingTimerPanelShowTimeInRaid"]));
+            }
+            set {
+                this["floatingTimerPanelShowTimeInRaid"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool floatingTimerPanelShowRunThrough {
+            get {
+                return ((bool)(this["floatingTimerPanelShowRunThrough"]));
+            }
+            set {
+                this["floatingTimerPanelShowRunThrough"] = value;
+            }
+        }
     }
 }

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -83,5 +83,14 @@
     <Setting Name="pauseMediaOnRaid" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="floatingTimerPanelEnabled" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="floatingTimerPanelShowTimeInRaid" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="floatingTimerPanelShowRunThrough" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TarkovMonitor/TimersManager.cs
+++ b/TarkovMonitor/TimersManager.cs
@@ -12,20 +12,71 @@ namespace TarkovMonitor
         public event EventHandler<TimerChangedEventArgs> RaidTimerChanged;
         public event EventHandler<TimerChangedEventArgs> RunThroughTimerChanged;
         public event EventHandler<TimerChangedEventArgs> ScavCooldownTimerChanged;
+        public event EventHandler? RaidActiveChanged;
+        public event EventHandler? FloatingPanelSettingChanged;
 
         private TimeSpan RunThroughRemainingTime;
         private TimeSpan TimeInRaidTime;
         private TimeSpan ScavCooldownTime;
-        private DateTime? RaidStartTime;
+        private readonly Stopwatch raidStopwatch = new();
         private System.Threading.Timer timerRaid;
         private System.Threading.Timer timerRunThrough;
         private System.Threading.Timer timerScavCooldown;
         private CancellationTokenSource cancellationTokenSource = new();
         private readonly GameWatcher eft;
+        private readonly MessageLog messageLog;
 
-        public TimersManager(GameWatcher eft)
+        public bool IsRaidActive { get; private set; }
+        public TimeSpan TimeInRaid => TimeInRaidTime;
+        public TimeSpan RunThroughRemaining => RunThroughRemainingTime;
+        public bool FloatingPanelEnabled
+        {
+            get => Properties.Settings.Default.floatingTimerPanelEnabled;
+            set
+            {
+                if (Properties.Settings.Default.floatingTimerPanelEnabled == value)
+                    return;
+
+                Properties.Settings.Default.floatingTimerPanelEnabled = value;
+                Properties.Settings.Default.Save();
+                FloatingPanelSettingChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+        public bool FloatingPanelShowTimeInRaid
+        {
+            get => Properties.Settings.Default.floatingTimerPanelShowTimeInRaid;
+            set
+            {
+                if (!value && !FloatingPanelShowRunThrough)
+                    return;
+                SaveFloatingPanelTimerSetting(nameof(Properties.Settings.Default.floatingTimerPanelShowTimeInRaid), value);
+            }
+        }
+        public bool FloatingPanelShowRunThrough
+        {
+            get => Properties.Settings.Default.floatingTimerPanelShowRunThrough;
+            set
+            {
+                if (!value && !FloatingPanelShowTimeInRaid)
+                    return;
+                SaveFloatingPanelTimerSetting(nameof(Properties.Settings.Default.floatingTimerPanelShowRunThrough), value);
+            }
+        }
+
+        private void SaveFloatingPanelTimerSetting(string settingName, bool value)
+        {
+            if ((bool)Properties.Settings.Default[settingName] == value)
+                return;
+
+            Properties.Settings.Default[settingName] = value;
+            Properties.Settings.Default.Save();
+            FloatingPanelSettingChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public TimersManager(GameWatcher eft, MessageLog messageLog)
         {
             this.eft = eft;
+            this.messageLog = messageLog;
 
             // Get Scav cooldown time from TarkovTracker but ensuring the API has been called and hydrated at least once.
             // without this, the scav cooldown time will be 25.
@@ -55,6 +106,8 @@ namespace TarkovMonitor
 
             TimeInRaidTime = TimeSpan.Zero;
             RunThroughRemainingTime = Properties.Settings.Default.runthroughTime;
+            IsRaidActive = true;
+            raidStopwatch.Restart();
 
             timerRaid.Change(0, 1000);
             timerRunThrough.Change(0, 1000);
@@ -69,10 +122,17 @@ namespace TarkovMonitor
                 TimerValue = RunThroughRemainingTime
             });
 
+            RaidActiveChanged?.Invoke(this, EventArgs.Empty);
+
         }
 
         private void Eft_RaidEnded(object? sender, RaidInfoEventArgs e)
         {
+            var completedRaidTime = raidStopwatch.Elapsed;
+            var shouldRecordRaidTime = IsRaidActive;
+            IsRaidActive = false;
+            raidStopwatch.Stop();
+            TimeInRaidTime = completedRaidTime;
             RunThroughRemainingTime = TimeSpan.Zero;
             timerRunThrough.Change(Timeout.Infinite, Timeout.Infinite);
             timerRaid.Change(Timeout.Infinite, Timeout.Infinite);
@@ -93,6 +153,11 @@ namespace TarkovMonitor
             {
                 TimerValue = ScavCooldownTime
             });
+
+            RaidActiveChanged?.Invoke(this, EventArgs.Empty);
+
+            if (shouldRecordRaidTime)
+                messageLog.AddMessage($"Raid completed — total time in raid: {completedRaidTime:hh\\:mm\\:ss}.", "info");
         }
 
         private void TimerRaid_Elapsed(object state)
@@ -100,13 +165,19 @@ namespace TarkovMonitor
             if (cancellationTokenSource.IsCancellationRequested)
                 return;
 
-            TimeInRaidTime += TimeSpan.FromSeconds(1);
+            TimeInRaidTime = raidStopwatch.Elapsed;
 
             RaidTimerChanged?.Invoke(this, new TimerChangedEventArgs()
             {
                 TimerValue = TimeInRaidTime
             });
         }
+
+
+
+
+
+
 
         private void TimerRunThrough_Elapsed(object state)
         {

--- a/TarkovMonitor/wwwroot/css/app.css
+++ b/TarkovMonitor/wwwroot/css/app.css
@@ -33,3 +33,61 @@ body {
 .dashboard-page-item {
     height: 100%;
 }
+
+.floating-timer-panel {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    width: 190px;
+    z-index: 1300;
+    overflow: hidden;
+    user-select: none;
+}
+
+.floating-timer-panel--collapsed {
+    width: auto;
+    min-width: 150px;
+}
+
+.floating-timer-panel__handle {
+    align-items: center;
+    cursor: move;
+    display: flex;
+    gap: 4px;
+    padding: 2px 2px 2px 8px;
+    touch-action: none;
+}
+
+.floating-timer-panel__handle .mud-typography {
+    flex: 1;
+}
+
+.floating-timer-panel__compact-value {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.floating-timer-panel .mud-icon-button {
+    padding: 4px;
+}
+
+.floating-timer-panel__value {
+    font-variant-numeric: tabular-nums;
+}
+
+.floating-timer-panel__timers {
+    display: grid;
+    gap: 6px;
+    padding: 4px 10px 10px;
+}
+
+.floating-timer-panel__timer {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.floating-timer-panel__timer .mud-typography-h5 {
+    font-size: 1.1rem;
+}

--- a/TarkovMonitor/wwwroot/index.html
+++ b/TarkovMonitor/wwwroot/index.html
@@ -23,6 +23,7 @@
 
     <script src="_framework/blazor.webview.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="js/floating-timer-panel.js"></script>
 </body>
 
 </html>

--- a/TarkovMonitor/wwwroot/js/floating-timer-panel.js
+++ b/TarkovMonitor/wwwroot/js/floating-timer-panel.js
@@ -1,0 +1,72 @@
+window.floatingTimerPanel = (() => {
+    const initializedElements = new WeakSet();
+
+    function clamp(element, left, top) {
+        const maximumLeft = Math.max(0, window.innerWidth - element.offsetWidth);
+        const maximumTop = Math.max(0, window.innerHeight - element.offsetHeight);
+
+        return {
+            left: Math.min(Math.max(0, left), maximumLeft),
+            top: Math.min(Math.max(0, top), maximumTop)
+        };
+    }
+
+    function applyPosition(element, position) {
+        const bounded = clamp(element, position.left, position.top);
+        element.style.left = `${bounded.left}px`;
+        element.style.top = `${bounded.top}px`;
+        element.style.right = "auto";
+        element.style.bottom = "auto";
+    }
+
+    function initialize(elementId) {
+        const element = document.getElementById(elementId);
+        if (!element) return;
+
+        if (initializedElements.has(element)) return;
+        initializedElements.add(element);
+
+        const handle = element.querySelector(".floating-timer-panel__handle");
+        if (!handle) return;
+
+        handle.addEventListener("pointerdown", event => {
+            if (event.target.closest("button")) return;
+
+            const rectangle = element.getBoundingClientRect();
+            const offsetX = event.clientX - rectangle.left;
+            const offsetY = event.clientY - rectangle.top;
+            handle.setPointerCapture(event.pointerId);
+
+            const move = moveEvent => {
+                applyPosition(element, {
+                    left: moveEvent.clientX - offsetX,
+                    top: moveEvent.clientY - offsetY
+                });
+            };
+
+            const finish = finishEvent => {
+                handle.releasePointerCapture(finishEvent.pointerId);
+                handle.removeEventListener("pointermove", move);
+                handle.removeEventListener("pointerup", finish);
+                handle.removeEventListener("pointercancel", finish);
+
+            };
+
+            handle.addEventListener("pointermove", move);
+            handle.addEventListener("pointerup", finish);
+            handle.addEventListener("pointercancel", finish);
+        });
+    }
+
+    function reset(elementId) {
+        const element = document.getElementById(elementId);
+        if (!element) return;
+
+        element.style.left = "auto";
+        element.style.top = "auto";
+        element.style.right = "20px";
+        element.style.bottom = "20px";
+    }
+
+    return { initialize, reset };
+})();


### PR DESCRIPTION
## Summary

Adds a compact floating timer panel so raid timers remain visible while using other sections of Tarkov Monitor.

The panel appears after EFT reports that deployment has completed and the raid has started. It is part of the Tarkov Monitor window and does not draw over Escape from Tarkov.

This branch was rebuilt on current master after #182 merged. The timer feature now extends the merged desktop shell instead of carrying a separate copy of that UI work.

## What changed

- Added a floating raid timer panel to pages other than Timers.
- The panel starts collapsed in the bottom-right corner.
- Added expand, collapse, drag, and reset-position controls.
- Added support for Elapsed Raid Time and Run-through remaining.
- The collapsed labels use `ERT` and `RT`.
- Added Settings controls for enabling the panel and choosing its displayed timers.
- The panel and both timers are enabled by default for fresh installs.
- At least one timer must remain selected.
- Scav cooldown remains on the Timers page and is intentionally excluded from the floating panel.
- Added panel status and the selected-timer summary to the Timers page.
- Added a Messages record containing total elapsed raid time when a raid ends.

## Timer behavior

Elapsed Raid Time begins on EFT's `RaidStarted` event, after the deployment countdown completes.

Elapsed time uses a monotonic stopwatch instead of counting timer callbacks. This prevents delayed callbacks or Windows clock changes from affecting the measured raid duration.

The panel disappears when the raid ends and starts collapsed again for the next raid.

## Changelog

### Added

- Customizable floating raid timer panel.
- Elapsed Raid Time and Run-through remaining displays.
- Expanded and collapsed layouts.
- Drag and reset-position controls.
- Floating timer settings and Timers-page status.
- End-of-raid duration message.

### Changed

- Raid duration now uses stopwatch-based elapsed timing.
- Timer values consistently display as `HH:MM:SS`.
- The Timers page reads the current active duration immediately.
- Integrated the panel with the desktop shell merged through #182.

## Testing notes

- The .NET 10 release build and self-contained Windows publish completed successfully.
- `git diff --check` passed.
- The branch contains no local launchers, test projects, or generated test output.