### PR TITLE
bugfix(settings): prevent Logs Folder picker crash on .NET 10

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -1,7 +1,6 @@
 ﻿@page "/settings"
 @using System.Diagnostics
 @using NAudio.Wave
-@using Microsoft.WindowsAPICodePack.Dialogs;
 @using System.Text.RegularExpressions;
 @inject GameWatcher eft
 @inject MessageLog messageLog
@@ -722,12 +721,25 @@
 
     void CustomLogsFolderClick()
     {
-        using CommonOpenFileDialog dialog = new CommonOpenFileDialog();
-        dialog.InitialDirectory = CustomLogsFolder;
-        dialog.IsFolderPicker = true;
-        if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
+        try
         {
-            CustomLogsFolder = dialog.FileName;
+            var currentFolder = CustomLogsFolder;
+            using var dialog = new System.Windows.Forms.FolderBrowserDialog
+            {
+                Description = "Select the Escape from Tarkov logs folder.",
+                UseDescriptionForTitle = true,
+                ShowNewFolderButton = false,
+                SelectedPath = Directory.Exists(currentFolder) ? currentFolder : "",
+            };
+
+            if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                CustomLogsFolder = dialog.SelectedPath;
+            }
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Error opening logs folder picker: {ex.Message}", "exception");
         }
     }
 

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Refit" Version="14.0.1" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageReference Include="Websocket.Client" Version="5.5.0" />
-    <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Fixes #195 by replacing the incompatible Windows API Code Pack picker with the supported WinForms `FolderBrowserDialog`.

## The Fix

- Removes the obsolete `WindowsAPICodePack-Shell` dependency.
- Preserves cancel behavior and selected-folder persistence.
- Prevents the .NET 10 Logs Folder `FileNotFoundException`.
- Adds contained error handling if the picker itself cannot open.

## Live Validation

Verified with release build, self-contained publish, and isolated open/cancel/reopen/select testing.
