### PR TITLE
bugfix(ui): restore MudBlazor 9 popovers and affected layouts

### DIFF
--- a/TarkovMonitor/Blazor/Components/LoadoutRecursor.razor
+++ b/TarkovMonitor/Blazor/Components/LoadoutRecursor.razor
@@ -1,5 +1,5 @@
 ﻿
-<MudItem Class="d-flex align-center flex-grow-1 gap-4" Elevation="0">
+<MudItem Class="d-flex align-center flex-grow-1 gap-4">
     <MudLink Href="@itemLink"><MudImage Src="@itemImageURL" Width="@imgWidth" Height="@imgHeight" Class="ma-2" title="@itemName" /></MudLink>
     @if (subItems.Length > 0)
     {

--- a/TarkovMonitor/Blazor/MainLayout.razor
+++ b/TarkovMonitor/Blazor/MainLayout.razor
@@ -1,6 +1,7 @@
 ﻿@inherits LayoutComponentBase
 @inject IJSRuntime JSRuntime;
 <MudThemeProvider Theme="currentTheme"/>
+<MudPopoverProvider/>
 <MudDialogProvider/>
 <MudSnackbarProvider/>
 

--- a/TarkovMonitor/Blazor/Pages/Group/Group.razor
+++ b/TarkovMonitor/Blazor/Pages/Group/Group.razor
@@ -13,10 +13,10 @@
         {
             <MudAlert Severity="Severity.Info">@LocalizationService.GetString("YouArentInAGroupOrHavePartyMembersYet")</MudAlert>
         }else{
-            <MudTabs Elevation="3" Rounded="true" Centered="true" PanelClass="pa-3">
+            <MudTabs Elevation="3" Rounded="true" Centered="true">
                 @foreach (KeyValuePair<string, GroupMember> member in groupManager.GroupMembers)
                 {
-                    <MudTabPanel Text="@member.Key" Icon="@Icons.Material.Filled.Person">
+                    <MudTabPanel Text="@member.Key" Icon="@Icons.Material.Filled.Person" PanelClass="pa-3">
                         <div class="d-flex justify-space-between align-center">
                             <div class="d-flex align-center"><LevelIcon Level="@member.Value.Loadout.Info.Level" Width="48" /><MudText Typo="Typo.h4">@member.Value.Loadout.Info.Level</MudText></div>
                             <div><MudText Typo="Typo.h4">@member.Value.Loadout.Info.Nickname</MudText></div>

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -10,7 +10,7 @@
 @layout AppLayout
 @implements IDisposable
 
-<MudGrid Class="pa-0" Spacing="0">
+<MudGrid Class="settings-grid pa-0" Spacing="0">
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Notifications" Class="mr-2" />@LocalizationService.GetString("Notifications")</MudText>

--- a/TarkovMonitor/wwwroot/css/app.css
+++ b/TarkovMonitor/wwwroot/css/app.css
@@ -19,9 +19,12 @@ body {
 .mud-paper.app-surface {
     border: 1px solid rgba(143, 130, 95, 0.42);
     border-radius: 8px;
-    background-color: rgba(25, 25, 24, 0.84);
+    background-color: rgba(25, 25, 24, 0.96);
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.24);
-    backdrop-filter: blur(2px);
+}
+
+.settings-grid {
+    align-content: flex-start;
 }
 
 .dashboard-notification-surface {


### PR DESCRIPTION
## Summary

Fixes #190, a MudBlazor 9 UI regression affecting overlays and card layouts.

In current master, the TarkovTracker service selector can receive focus but fail to open its dropdown, leaving the UI stuck on `.org`. Group tabs and Settings cards also show incorrect spacing and visual separation.

## Changes

- Add the required `MudPopoverProvider`.
- Move tab-panel styling to the MudBlazor 9-compatible location.
- Remove unsupported MudBlazor parameters.
- Restore consistent Settings-grid alignment and card surfaces.

Before/after screenshots are included in [Issue #190](https://github.com/the-hideout/TarkovMonitor/issues/190#issuecomment-5210612573).