### PR TITLE
feat(tracker): retire TarkovTracker.io runtime support

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -119,11 +119,6 @@
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/>@LocalizationService.GetString("TarkovTracker")</MudText>
-            <MudButton @onclick="OpenTrackerSettings" Disabled="@IsRetiredTrackerService" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
-            <MudButton @onclick="TestToken" Disabled="@(TestTokenButtonDisabled || IsRetiredTrackerService)" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
-            @LocalizationService.GetString("CurrentProfile"):
-            <MudLink Href="@($"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}")">@TarkovDev.GetPlayerName(GameWatcher.CurrentProfile) (@GameWatcher.CurrentProfile.Type)</MudLink>
-            <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Disabled="@IsRetiredTrackerService" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
             <MudSelect @bind-Value="@TarkovTrackerDomain" T="string" Label="@LocalizationService.GetString("TarkovTrackerService")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("TarkovTrackerServiceHelperText")" AnchorOrigin="Origin.BottomCenter" xs="3">
                 @foreach (var pair in TarkovTracker.Domains)
                 {
@@ -135,6 +130,14 @@
                 <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">
                     Support for TarkovTracker.io has been retired. Switch to <MudLink Href="https://tarkovtracker.org/settings/" Target="_blank">TarkovTracker.org</MudLink> for continued support.
                 </MudAlert>
+            }
+            @if (!IsRetiredTrackerService)
+            {
+                <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
+                <MudButton @onclick="TestToken" Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
+                <span>@LocalizationService.GetString("CurrentProfile"):</span>
+                <MudLink Href="@CurrentProfileUrl">@TarkovDev.GetPlayerName(GameWatcher.CurrentProfile) (@GameWatcher.CurrentProfile.Type)</MudLink>
+                <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
             }
         </MudPaper>
     </MudItem>
@@ -492,7 +495,7 @@
     {
         get
         {
-            return TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id).Length != 22;
+            return TarkovTracker.IsLegacyService || TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id).Length != 22;
         }
         set
         {
@@ -540,11 +543,14 @@
     {
         get
         {
-            return TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id);
+            return TarkovTracker.IsLegacyService ? "" : TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id);
         }
         set
         {
-            TarkovTracker.SetToken(GameWatcher.CurrentProfile.Id, value);
+            if (!TarkovTracker.IsLegacyService)
+            {
+                TarkovTracker.SetToken(GameWatcher.CurrentProfile.Id, value);
+            }
         }
     }
     public string TarkovTrackerDomain
@@ -560,9 +566,30 @@
                 return;
             }
             Properties.Settings.Default.tarkovTrackerDomain = value;
-            TarkovTrackerToken = "";
+            TarkovTracker.ResetActiveState();
             TarkovTracker.InitAPI();
             Properties.Settings.Default.Save();
+            if (!TarkovTracker.IsLegacyService)
+            {
+                _ = RevalidateTrackerProfile();
+            }
+        }
+    }
+
+    private async Task RevalidateTrackerProfile()
+    {
+        if (string.IsNullOrWhiteSpace(GameWatcher.CurrentProfile.Id))
+        {
+            return;
+        }
+
+        try
+        {
+            await TarkovTracker.SetProfile(GameWatcher.CurrentProfile.Id);
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage(ex.Message, "exception");
         }
     }
 
@@ -570,6 +597,9 @@
         TarkovTrackerDomain,
         "tarkovtracker.io",
         StringComparison.OrdinalIgnoreCase);
+
+    private string CurrentProfileUrl =>
+        $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}";
 
     void TokenShowClick()
     {

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -119,17 +119,23 @@
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/>@LocalizationService.GetString("TarkovTracker")</MudText>
-            <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
-            <MudButton @onclick="TestToken" @bind-Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
+            <MudButton @onclick="OpenTrackerSettings" Disabled="@IsRetiredTrackerService" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
+            <MudButton @onclick="TestToken" Disabled="@(TestTokenButtonDisabled || IsRetiredTrackerService)" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
             @LocalizationService.GetString("CurrentProfile"):
             <MudLink Href="@($"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}")">@TarkovDev.GetPlayerName(GameWatcher.CurrentProfile) (@GameWatcher.CurrentProfile.Type)</MudLink>
-            <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
+            <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Disabled="@IsRetiredTrackerService" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
             <MudSelect @bind-Value="@TarkovTrackerDomain" T="string" Label="@LocalizationService.GetString("TarkovTrackerService")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("TarkovTrackerServiceHelperText")" AnchorOrigin="Origin.BottomCenter" xs="3">
                 @foreach (var pair in TarkovTracker.Domains)
                 {
                     <MudSelectItem T="string" Value="@pair.Key">@pair.Value</MudSelectItem>
                 }
             </MudSelect>
+            @if (IsRetiredTrackerService)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">
+                    Support for TarkovTracker.io has been retired. Switch to <MudLink Href="https://tarkovtracker.org/settings/" Target="_blank">TarkovTracker.org</MudLink> for continued support.
+                </MudAlert>
+            }
         </MudPaper>
     </MudItem>
 
@@ -559,6 +565,11 @@
             Properties.Settings.Default.Save();
         }
     }
+
+    private bool IsRetiredTrackerService => string.Equals(
+        TarkovTrackerDomain,
+        "tarkovtracker.io",
+        StringComparison.OrdinalIgnoreCase);
 
     void TokenShowClick()
     {

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -34,6 +34,10 @@ namespace TarkovMonitor
 
         public static ProgressResponse Progress { get; private set; } = new();
         public static bool ValidToken { get; private set; } = false;
+        public static bool IsLegacyService => string.Equals(
+            Properties.Settings.Default.tarkovTrackerDomain,
+            "tarkovtracker.io",
+            StringComparison.OrdinalIgnoreCase);
         private static Dictionary<string, string> tokens = new();
         private static string currentProfile = "";
         public static string CurrentProfileId { get { return currentProfile; } }
@@ -80,6 +84,10 @@ namespace TarkovMonitor
             {
                 throw new Exception("No PVP or PVE profile initialized, please launch Escape from Tarkov first");
             }
+            if (IsLegacyService && !string.IsNullOrWhiteSpace(token))
+            {
+                return;
+            }
             tokens[profileId] = token;
             Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
             Properties.Settings.Default.Save();
@@ -89,6 +97,13 @@ namespace TarkovMonitor
         {
             if (profileId == "") {
                 throw new Exception("Can't set PVP or PVE profile, please launch Escape from Tarkov and then restart this application");
+            }
+
+            if (IsLegacyService)
+            {
+                ValidToken = false;
+                Progress = new();
+                return Progress;
             }
 
             if (currentProfile == profileId)
@@ -301,6 +316,11 @@ namespace TarkovMonitor
 
         public static async Task<TokenResponse> TestToken(string apiToken)
         {
+            if (IsLegacyService)
+            {
+                throw new InvalidOperationException(
+                    "Support for TarkovTracker.io has been retired. Switch to TarkovTracker.org.");
+            }
             try
             {
                 var response = await api.TestToken(apiToken);

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -69,6 +69,13 @@ namespace TarkovMonitor
             return api;
         }
 
+        public static void ResetActiveState()
+        {
+            currentProfile = "";
+            ValidToken = false;
+            Progress = new();
+        }
+
         public static string GetToken(string profileId)
         {
             if (!tokens.ContainsKey(profileId))
@@ -80,13 +87,13 @@ namespace TarkovMonitor
 
         public static void SetToken(string profileId, string token)
         {
+            if (IsLegacyService)
+            {
+                return;
+            }
             if (profileId == "")
             {
                 throw new Exception("No PVP or PVE profile initialized, please launch Escape from Tarkov first");
-            }
-            if (IsLegacyService && !string.IsNullOrWhiteSpace(token))
-            {
-                return;
             }
             tokens[profileId] = token;
             Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
@@ -95,15 +102,13 @@ namespace TarkovMonitor
 
         public static async Task<ProgressResponse> SetProfile(string profileId)
         {
-            if (profileId == "") {
-                throw new Exception("Can't set PVP or PVE profile, please launch Escape from Tarkov and then restart this application");
-            }
-
             if (IsLegacyService)
             {
-                ValidToken = false;
-                Progress = new();
+                ResetActiveState();
                 return Progress;
+            }
+            if (profileId == "") {
+                throw new Exception("Can't set PVP or PVE profile, please launch Escape from Tarkov and then restart this application");
             }
 
             if (currentProfile == profileId)
@@ -160,7 +165,7 @@ namespace TarkovMonitor
 
         public static async Task<string> SetTaskStatus(string questId, TaskStatus status)
         {
-            if (!ValidToken)
+            if (IsLegacyService || !ValidToken)
             {
                 throw new Exception("Invalid token");
             }
@@ -246,7 +251,7 @@ namespace TarkovMonitor
 
         public static async Task<string> SetTaskStatuses(Dictionary<string, TaskStatus> statuses)
         {
-			if (!ValidToken)
+			if (IsLegacyService || !ValidToken)
 			{
 				throw new Exception("Invalid token");
 			}
@@ -286,6 +291,11 @@ namespace TarkovMonitor
 
         public static async Task<ProgressResponse> GetProgress()
 		{
+			if (IsLegacyService)
+			{
+				ResetActiveState();
+				return Progress;
+			}
 			if (!ValidToken)
 			{
 				throw new Exception("Invalid token");


### PR DESCRIPTION
## Summary

Retains TarkovTracker.io in Settings only as a retired-service notice while isolating it from supported TarkovTracker.org operation.

## Changes

- Keeps .io selectable with a clear retirement warning and .org link.
- Prevents .io token edits, tracker reads, and tracker writes.
- Preserves .org credentials when switching services.
- Clears stale tracker state when switching domains.
- Revalidates the active EFT profile when returning to .org.
- Places the service selector at the top of the TarkovTracker settings card.
- Hides profile and token controls while .io is selected.

## Validation

- Launched and tested the client functionality.
- Reviewed for regressions; no findings.
