### PR TITLE
feat(tracker): verify TarkovTracker.org tokens and Seasonal mode

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -119,17 +119,23 @@
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/>@LocalizationService.GetString("TarkovTracker")</MudText>
-            <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
-            <MudButton @onclick="TestToken" @bind-Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
+            <MudButton @onclick="OpenTrackerSettings" Disabled="@IsRetiredTrackerService" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
+            <MudButton @onclick="TestToken" Disabled="@(TestTokenButtonDisabled || IsRetiredTrackerService)" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
             @LocalizationService.GetString("CurrentProfile"):
             <MudLink Href="@($"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}")">@TarkovDev.GetPlayerName(GameWatcher.CurrentProfile) (@GameWatcher.CurrentProfile.Type)</MudLink>
-            <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
+            <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Disabled="@IsRetiredTrackerService" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
             <MudSelect @bind-Value="@TarkovTrackerDomain" T="string" Label="@LocalizationService.GetString("TarkovTrackerService")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("TarkovTrackerServiceHelperText")" AnchorOrigin="Origin.BottomCenter" xs="3">
                 @foreach (var pair in TarkovTracker.Domains)
                 {
                     <MudSelectItem T="string" Value="@pair.Key">@pair.Value</MudSelectItem>
                 }
             </MudSelect>
+            @if (IsRetiredTrackerService)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">
+                    Support for TarkovTracker.io has been retired. Switch to <MudLink Href="https://tarkovtracker.org/settings/" Target="_blank">TarkovTracker.org</MudLink> for continued support.
+                </MudAlert>
+            }
         </MudPaper>
     </MudItem>
 
@@ -559,6 +565,11 @@
             Properties.Settings.Default.Save();
         }
     }
+
+    private bool IsRetiredTrackerService => string.Equals(
+        TarkovTrackerDomain,
+        "tarkovtracker.io",
+        StringComparison.OrdinalIgnoreCase);
 
     void TokenShowClick()
     {

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -589,9 +589,9 @@
 
     private async void TestToken()
     {
-        if (!Regex.Match(TarkovTrackerToken, @"^(?:[A-Z]{3}_)?.{22}$").Success)
+        if (!TarkovTracker.IsSupportedOrgToken(TarkovTrackerToken))
         {
-            messageLog.AddMessage("You must enter a valid TarkovTracker API token.", "warning");
+            messageLog.AddMessage("Enter a PVE_, PVP_, or SZN_ TarkovTracker.org key followed by its 18-character hexadecimal identifier.", "warning");
             return;
         } else {
             try

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -50,9 +50,18 @@ namespace TarkovMonitor
             tokens = JsonSerializer.Deserialize<Dictionary<string, string>>(Properties.Settings.Default.tarkovTrackerTokens) ?? tokens;
         }
 
+        public static string GetApiBaseUrl(string trackerDomain)
+        {
+            if (trackerDomain == "tarkovtracker.org")
+            {
+                return "https://api.tarkovtracker.org/api/v2";
+            }
+            return $"https://{trackerDomain}/api/v2";
+        }
+
         public static ITarkovTrackerAPI InitAPI()
         {
-            api = RestService.For<ITarkovTrackerAPI>($"https://{Properties.Settings.Default.tarkovTrackerDomain}/api/v2",
+            api = RestService.For<ITarkovTrackerAPI>(GetApiBaseUrl(Properties.Settings.Default.tarkovTrackerDomain),
                 new RefitSettings {
                     AuthorizationHeaderValueGetter = (rq, cr) => {
                         return new ValueTask<string>(Task.Run<string>(() => {

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -34,6 +34,10 @@ namespace TarkovMonitor
 
         public static ProgressResponse Progress { get; private set; } = new();
         public static bool ValidToken { get; private set; } = false;
+        public static bool IsLegacyService => string.Equals(
+            Properties.Settings.Default.tarkovTrackerDomain,
+            "tarkovtracker.io",
+            StringComparison.OrdinalIgnoreCase);
         private static Dictionary<string, string> tokens = new();
         private static string currentProfile = "";
         public static string CurrentProfileId { get { return currentProfile; } }
@@ -89,6 +93,10 @@ namespace TarkovMonitor
             {
                 throw new Exception("No PVP or PVE profile initialized, please launch Escape from Tarkov first");
             }
+            if (IsLegacyService && !string.IsNullOrWhiteSpace(token))
+            {
+                return;
+            }
             tokens[profileId] = token;
             Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
             Properties.Settings.Default.Save();
@@ -98,6 +106,13 @@ namespace TarkovMonitor
         {
             if (profileId == "") {
                 throw new Exception("Can't set PVP or PVE profile, please launch Escape from Tarkov and then restart this application");
+            }
+
+            if (IsLegacyService)
+            {
+                ValidToken = false;
+                Progress = new();
+                return Progress;
             }
 
             if (currentProfile == profileId)
@@ -310,6 +325,11 @@ namespace TarkovMonitor
 
         public static async Task<TokenResponse> TestToken(string apiToken)
         {
+            if (IsLegacyService)
+            {
+                throw new InvalidOperationException(
+                    "Support for TarkovTracker.io has been retired. Switch to TarkovTracker.org.");
+            }
             try
             {
                 var response = await api.TestToken(apiToken);

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -90,6 +90,50 @@ namespace TarkovMonitor
             return true;
         }
 
+        private static string GetOrgTokenPrefix(string token)
+        {
+            var value = token.Trim();
+            return value[..3].ToUpperInvariant();
+        }
+
+        private static void VerifyOrgTokenResponse(string submittedToken, TokenResponse response)
+        {
+            var submitted = submittedToken.Trim();
+            if (!IsSupportedOrgToken(submitted))
+            {
+                throw new Exception("The TarkovTracker.org API key format is invalid.");
+            }
+
+            var returnedToken = response.token?.Trim();
+            if (!string.IsNullOrWhiteSpace(returnedToken))
+            {
+                if (!IsSupportedOrgToken(returnedToken)
+                    || !string.Equals(GetOrgTokenPrefix(submitted), GetOrgTokenPrefix(returnedToken), StringComparison.OrdinalIgnoreCase)
+                    || !string.Equals(submitted[4..], returnedToken[4..], StringComparison.Ordinal))
+                {
+                    throw new Exception("TarkovTracker returned a different API key than the one supplied.");
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(response.gameMode))
+            {
+                return;
+            }
+
+            var verifiedPrefix = response.gameMode.Trim().ToLowerInvariant() switch
+            {
+                "pve" => "PVE",
+                "pvp" or "regular" => "PVP",
+                "seasonal" or "pvpseason" or "sn1" => "SZN",
+                _ => throw new Exception("TarkovTracker returned an unsupported game mode for this API key."),
+            };
+            var submittedPrefix = GetOrgTokenPrefix(submitted);
+            if (!string.Equals(submittedPrefix, verifiedPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception($"This API key is {submittedPrefix}, but TarkovTracker verified it as {verifiedPrefix}.");
+            }
+        }
+
         public static ITarkovTrackerAPI InitAPI()
         {
             api = RestService.For<ITarkovTrackerAPI>(GetApiBaseUrl(Properties.Settings.Default.tarkovTrackerDomain),
@@ -390,6 +434,7 @@ namespace TarkovMonitor
                 var responseBody = await httpResponse.Content.ReadAsStringAsync();
                 var response = JsonSerializer.Deserialize<TokenResponse>(responseBody)
                     ?? throw new Exception("TarkovTracker returned an empty token response.");
+                VerifyOrgTokenResponse(apiToken, response);
                 if (response.permissions.Contains("WP"))
                 {
                     ValidToken = true;

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Transactions;
 using Refit;
@@ -13,10 +14,6 @@ namespace TarkovMonitor
         {
             HttpClient Client { get; }
 
-            [Get("/token")]
-            [Headers("Authorization: Bearer {token}")]
-            Task<TokenResponse> TestToken(string token);
-
             [Get("/progress")]
             [Headers("Authorization: Bearer")]
             Task<ProgressResponse> GetProgress();
@@ -30,6 +27,7 @@ namespace TarkovMonitor
             Task<string> SetTaskStatuses([Body] List<TaskStatusBody> body);
         }
 
+        private static readonly HttpClient tokenInspectionClient = new();
         private static ITarkovTrackerAPI api = InitAPI();
 
         public static ProgressResponse Progress { get; private set; } = new();
@@ -51,6 +49,7 @@ namespace TarkovMonitor
         };
 
         static TarkovTracker() {
+            tokenInspectionClient.DefaultRequestHeaders.UserAgent.TryParseAdd($"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name} {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
             tokens = JsonSerializer.Deserialize<Dictionary<string, string>>(Properties.Settings.Default.tarkovTrackerTokens) ?? tokens;
         }
 
@@ -330,13 +329,43 @@ namespace TarkovMonitor
                 throw new InvalidOperationException(
                     "Support for TarkovTracker.io has been retired. Switch to TarkovTracker.org.");
             }
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"{GetApiBaseUrl(Properties.Settings.Default.tarkovTrackerDomain).TrimEnd('/')}/token");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken.Trim());
+
+            HttpResponseMessage httpResponse;
             try
             {
-                var response = await api.TestToken(apiToken);
+                httpResponse = await tokenInspectionClient.SendAsync(request);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new Exception($"TarkovTracker API connection error: {ex.Message}");
+            }
+
+            using (httpResponse)
+            {
+                if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    InvalidTokenException();
+                }
+                if (httpResponse.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    throw new Exception("Rate limited by Tarkov Tracker API");
+                }
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    throw new Exception($"Invalid TarkovTracker API response code: {(int)httpResponse.StatusCode} {httpResponse.ReasonPhrase}");
+                }
+
+                var responseBody = await httpResponse.Content.ReadAsStringAsync();
+                var response = JsonSerializer.Deserialize<TokenResponse>(responseBody)
+                    ?? throw new Exception("TarkovTracker returned an empty token response.");
                 if (response.permissions.Contains("WP"))
                 {
                     ValidToken = true;
-                    GetProgress();
+                    await GetProgress();
                     TokenValidated?.Invoke(null, new EventArgs());
                 }
                 else
@@ -346,22 +375,6 @@ namespace TarkovMonitor
                     TokenInvalid?.Invoke(null, new EventArgs());
                 }
                 return response;
-            }
-            catch (ApiException ex)
-            {
-                if (ex.StatusCode == HttpStatusCode.Unauthorized)
-                {
-                    InvalidTokenException();
-                }
-                if (ex.StatusCode == HttpStatusCode.TooManyRequests)
-                {
-                    throw new Exception("Rate limited by Tarkov Tracker API");
-                }
-                throw new Exception($"Invalid TarkovTracker API response code: {ex.Message}");
-            }
-            catch (Exception ex)
-            {
-                throw new Exception($"TarkovTracker API error: {ex.Message}");
             }
         }
 
@@ -395,8 +408,10 @@ namespace TarkovMonitor
 
         public class TokenResponse
         {
-            public List<string> permissions { get; set; }
-            public string token { get; set; }
+            public bool success { get; set; }
+            public List<string> permissions { get; set; } = new();
+            public string? token { get; set; }
+            public string? gameMode { get; set; }
         }
 
         public class ProgressResponse

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -62,6 +62,34 @@ namespace TarkovMonitor
             return $"https://{trackerDomain}/api/v2";
         }
 
+        public static bool IsSupportedOrgToken(string? token)
+        {
+            var value = token?.Trim() ?? string.Empty;
+            if (value.Length != 22 || value[3] != '_')
+            {
+                return false;
+            }
+
+            var prefix = value[..3].ToUpperInvariant();
+            if (prefix is not ("PVE" or "PVP" or "SZN"))
+            {
+                return false;
+            }
+
+            for (var index = 4; index < value.Length; index++)
+            {
+                var character = value[index];
+                if (!((character >= '0' && character <= '9')
+                    || (character >= 'a' && character <= 'f')
+                    || (character >= 'A' && character <= 'F')))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public static ITarkovTrackerAPI InitAPI()
         {
             api = RestService.For<ITarkovTrackerAPI>(GetApiBaseUrl(Properties.Settings.Default.tarkovTrackerDomain),

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -54,7 +54,7 @@ namespace TarkovMonitor
         {
             if (trackerDomain == "tarkovtracker.org")
             {
-                return "https://api.tarkovtracker.org/api/v2";
+                return "https://api.tarkovtracker.org";
             }
             return $"https://{trackerDomain}/api/v2";
         }


### PR DESCRIPTION
## Summary

Adds the TarkovTracker.org API-subdomain and endpoint-verification sequence,
including Seasonal (`SZN_`) API-key acceptance and mode-aware token identity
checks.

## Changes

- Uses `api.tarkovtracker.org` for supported .org requests.
- Uses the API subdomain's route format without the legacy `/api/v2` prefix.
- Hardens token inspection with explicit HTTP status and response handling.
- Accepts PVE, PVP, and Seasonal (`SZN_`) .org key formats.
- Verifies that the returned token and reported mode match the submitted key.
- Keeps unsupported or mismatched modes from being accepted as valid keys.

## Merge order

PR #199 and this pull request touch overlapping tracker and Settings code.
Merge PR #199 first, then rebase this branch onto the updated master and drop
or reconcile this branch's duplicate legacy `.io` runtime commit while
retaining the API-subdomain, token-verification, and Seasonal changes. If this
pull request merges first, PR #199 can still merge, but the same overlap
requires manual conflict resolution.
