### PR TITLE
Detect in-place release asset re-uploads in update check

### DIFF
--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -94,6 +94,12 @@
             <setting name="floatingTimerPanelShowRunThrough" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="lastSeenReleaseTag" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="lastSeenReleaseAssetUpdatedAt" serializeAs="String">
+                <value />
+            </setting>
         </TarkovMonitor.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -382,5 +382,29 @@ namespace TarkovMonitor.Properties {
                 this["floatingTimerPanelShowRunThrough"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string lastSeenReleaseTag {
+            get {
+                return ((string)(this["lastSeenReleaseTag"]));
+            }
+            set {
+                this["lastSeenReleaseTag"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string lastSeenReleaseAssetUpdatedAt {
+            get {
+                return ((string)(this["lastSeenReleaseAssetUpdatedAt"]));
+            }
+            set {
+                this["lastSeenReleaseAssetUpdatedAt"] = value;
+            }
+        }
     }
 }

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -92,5 +92,11 @@
     <Setting Name="floatingTimerPanelShowRunThrough" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="lastSeenReleaseTag" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="lastSeenReleaseAssetUpdatedAt" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TarkovMonitor/UpdateCheck.cs
+++ b/TarkovMonitor/UpdateCheck.cs
@@ -12,6 +12,7 @@ namespace TarkovMonitor
         }
 
         private static readonly string repo = "the-hideout/TarkovMonitor";
+        private static readonly string releaseAssetName = "TarkovMonitor.zip";
         private static readonly System.Timers.Timer updateCheckTimer;
 
         private static readonly IGitHubAPI api = RestService.For<IGitHubAPI>($"https://api.github.com/repos/{repo}");
@@ -41,9 +42,28 @@ namespace TarkovMonitor
                 var release = await api.GetLatestRelease();
                 Version remoteVersion = new Version(release.tag_name);
                 Version localVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version ?? throw new Exception("Could not retrieve version from assembly");
-                //System.Diagnostics.Debug.WriteLine(localVersion.ToString());
+                string assetUpdatedAt = release.assets?.FirstOrDefault(asset => asset.name == releaseAssetName)?.updated_at ?? "";
 
-                if (localVersion.CompareTo(remoteVersion) == -1)
+                var settings = Properties.Settings.Default;
+                // An absent asset timestamp carries no information, so it must never read as a change.
+                bool assetUpdatedAtKnown = assetUpdatedAt != "";
+                bool sameReleaseAsLastCheck = settings.lastSeenReleaseTag == release.tag_name;
+                bool assetUpdatedAtChanged = assetUpdatedAtKnown && settings.lastSeenReleaseAssetUpdatedAt != assetUpdatedAt;
+
+                // Remember what the latest release looked like, so replacing its asset later is detectable.
+                if (assetUpdatedAtKnown && (!sameReleaseAsLastCheck || assetUpdatedAtChanged))
+                {
+                    settings.lastSeenReleaseTag = release.tag_name;
+                    settings.lastSeenReleaseAssetUpdatedAt = assetUpdatedAt;
+                    settings.Save();
+                }
+
+                // The download can be re-uploaded in place (a hotfix published under the same tag),
+                // which leaves the version unchanged; a changed asset timestamp means the build we
+                // are running was replaced. Only notified once, since there is nothing left to compare.
+                bool runningBuildWasReplaced = sameReleaseAsLastCheck && assetUpdatedAtChanged && localVersion == remoteVersion;
+
+                if (localVersion < remoteVersion || runningBuildWasReplaced)
                 {
                     NewVersion?.Invoke(null, new() { Version = remoteVersion, Uri = new(release.html_url) });
                 }
@@ -62,6 +82,13 @@ namespace TarkovMonitor
         {
             public string tag_name { get; set; }
             public string html_url { get; set; }
+            public List<ReleaseAsset>? assets { get; set; }
+        }
+
+        public class ReleaseAsset
+        {
+            public string? name { get; set; }
+            public string? updated_at { get; set; }
         }
     }
 


### PR DESCRIPTION
## Summary

A hotfix re-published under an existing release tag currently leaves users silently running a replaced build: the update check only compares version numbers, and an in-place asset re-upload does not change the tag. This PR makes the update check also detect when the `TarkovMonitor.zip` asset of the current release has been re-uploaded, so affected users get the existing "new version available" notification instead of nothing.

## Changes

- **`UpdateCheck.cs`** — the check now reads the release's `assets` payload and compares the `TarkovMonitor.zip` asset's `updated_at` against the last observed value. The baseline is seeded silently on first sighting, so fresh installs work. Notifies when:
  - the version is newer (unchanged behavior), **or**
  - the running build is the same version but its release asset was replaced in place
- **`Properties/Settings.settings` + `Properties/Settings.Designer.cs`** — two new user-scoped string settings: `lastSeenReleaseTag` and `lastSeenReleaseAssetUpdatedAt`
- **`App.config`** — mirrors the new settings under `<userSettings>` so the settings designer does not produce an unrelated regeneration diff

## Behavior notes

- **Fresh installs work**: the baseline is seeded on the first check without notifying; a later re-upload is then detected.
- **Notification fires once** for a same-version re-upload: since the version does not change, there is no way to tell whether the user acted on it, so re-nagging would be inescapable. Documented in the code.
- **Degrades gracefully**: a missing/empty `assets` payload never reads as a change and never poisons the stored baseline — the check falls back to the original version-only behavior.
- `Settings.Save()` is only called when the observed state actually changed (no daily redundant disk writes for users on an old version).

## Scope

4 files, +65/−2. No version bump, no new dependencies, no changes outside the update check.

## Verification

- `dotnet build -t:Rebuild`: 0 errors; the 4 pre-existing CS8618 warnings in `UpdateCheck.cs` are untouched and the new code adds none
- Decision logic exercised through a 14-case harness (fresh install, re-upload detection and once-only semantics, daily nag while outdated, no spurious toast after updating, missing-assets glitches, dev build newer than release, new tag mid-flight, save gating): all pass; harness not committed
- Confirmed the release workflow's `-p:Version=<tag>` override makes `localVersion == remoteVersion` hold exactly for real releases
