### PR TITLE
feat(tracker): add profile-bound API key management and overhaul Settings UI

### DIFF
--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -80,7 +80,7 @@
                 <value>{}</value>
             </setting>
             <setting name="tarkovTrackerOrgTokenStore" serializeAs="String">
-                <value>{"version":4,"keys":[],"accounts":[],"profiles":[]}</value>
+                <value>{"version":6,"keys":[],"accounts":[],"profiles":[]}</value>
             </setting>
             <setting name="lastTarkovSessionMode" serializeAs="String">
                 <value />

--- a/TarkovMonitor/App.config
+++ b/TarkovMonitor/App.config
@@ -73,6 +73,18 @@
             <setting name="tarkovTrackerTokens" serializeAs="String">
                 <value>{}</value>
             </setting>
+            <setting name="tarkovTrackerModeTokens" serializeAs="String">
+                <value>{}</value>
+            </setting>
+            <setting name="tarkovTrackerVerifiedModeTokenHashes" serializeAs="String">
+                <value>{}</value>
+            </setting>
+            <setting name="tarkovTrackerOrgTokenStore" serializeAs="String">
+                <value>{"version":4,"keys":[],"accounts":[],"profiles":[]}</value>
+            </setting>
+            <setting name="lastTarkovSessionMode" serializeAs="String">
+                <value />
+            </setting>
             <setting name="runthroughTime" serializeAs="String">
                 <value>00:07:10</value>
             </setting>

--- a/TarkovMonitor/Blazor/AppLayout.razor
+++ b/TarkovMonitor/Blazor/AppLayout.razor
@@ -21,11 +21,11 @@
 			</div>
 			<div class="window-controls" aria-label="Window controls">
 				<MudIconButton Class="window-control" Icon="@Icons.Material.Filled.Remove" Color="Color.Inherit" Size="Size.Small" OnClick="MinimizeWindow" aria-label="Minimize" />
-				<MudIconButton Class="window-control" Icon="@(WindowHost.IsMaximized ? Icons.Material.Filled.FilterNone : Icons.Material.Filled.CropSquare)" Color="Color.Inherit" Size="Size.Small" OnClick="ToggleMaximizeWindow" aria-label="@(WindowHost.IsMaximized ? "Restore" : "Maximize")" />
+				<MudIconButton Class="window-control" Icon="@(isWindowMaximized ? Icons.Material.Filled.FilterNone : Icons.Material.Filled.CropSquare)" Color="Color.Inherit" Size="Size.Small" OnClick="ToggleMaximizeWindow" aria-label="@(isWindowMaximized ? "Restore" : "Maximize")" />
 				<MudIconButton Class="window-control window-control-close" Icon="@Icons.Material.Filled.Close" Color="Color.Inherit" Size="Size.Small" OnClick="CloseWindow" aria-label="Close" />
 			</div>
 		</MudAppBar>
-		<MudDrawer Class="navigation-drawer" @bind-Open="@drawerOpen" Elevation="1" Anchor="Anchor.Left" Variant="@DrawerVariant.Responsive">
+		<MudDrawer Class="navigation-drawer" @bind-Open="@drawerOpen" Elevation="1" Anchor="Anchor.Left" Variant="@DrawerVariant.Responsive" Breakpoint="Breakpoint.None">
 			<MudDrawerHeader Class="navigation-drawer-header">
 				<button class="navigation-brand" type="button" @onclick="@ToggleDrawer" aria-label="Collapse navigation">
 					<div class="navigation-brand-copy">
@@ -44,7 +44,7 @@
 				<MudNavLink Href="/timers" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Timer">@LocalizationService.GetString("Timers")</MudNavLink>
 			</MudNavMenu>
 		</MudDrawer>
-		<MudMainContent Class="app-main-content" Style="box-sizing: border-box;">
+		<MudMainContent Class="@MainContentClass" Style="box-sizing: border-box;">
 			<CascadingValue Name="AppLayout" Value="this">
 				@Body
 			</CascadingValue>
@@ -62,11 +62,11 @@
 					{
 						<MudText Typo="Typo.subtitle2">Raid timers</MudText>
 						<MudIconButton Icon="@Icons.Material.Filled.Restore" Size="Size.Small" Color="Color.Inherit"
-							Title="Reset position" OnClick="ResetFloatingTimerPosition" />
+							Title="Reset timer position" OnClick="ResetFloatingTimerPosition" />
 					}
 					<MudIconButton Icon="@(floatingTimerPanelCollapsed ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
 						Size="Size.Small" Color="Color.Inherit"
-						Title="@(floatingTimerPanelCollapsed ? "Expand timer panel" : "Collapse timer panel")"
+						Title="@(floatingTimerPanelCollapsed ? "Expand the timer panel" : "Collapse the timer panel")"
 						OnClick="ToggleFloatingTimerPanel" />
 				</div>
 				@if (!floatingTimerPanelCollapsed)
@@ -75,7 +75,7 @@
 					@if (TimersManager.FloatingPanelShowTimeInRaid)
 					{
 						<div class="floating-timer-panel__timer">
-							<MudText Typo="Typo.caption">Elapsed Raid Time</MudText>
+						<MudText Typo="Typo.caption">Elapsed raid time</MudText>
 							<MudText Typo="Typo.h5" Class="floating-timer-panel__value">@FormatTimer(timeInRaid)</MudText>
 						</div>
 					}
@@ -106,13 +106,19 @@
 
 @code {
 
-	bool drawerOpen = true;
+	// Keep the drawer under explicit user control. Automatic responsive drawer
+	// transitions can reopen it when a resize crosses a card-layout breakpoint.
+	bool drawerOpen = false;
 
-	public string CurrentPageTitle = "TarkovMonitor";
+	public string CurrentPageTitle = "Tarkov Monitor";
+	private bool isWindowMaximized;
 	private TimeSpan timeInRaid;
 	private TimeSpan runThroughRemaining;
 	private bool isTimersPage;
 	private bool floatingTimerPanelCollapsed = true;
+	private string MainContentClass => isWindowMaximized
+		? "app-main-content"
+		: "app-main-content app-main-content--restored";
 
 	private bool ShowFloatingTimerPanel =>
 		TimersManager.FloatingPanelEnabled && TimersManager.IsRaidActive && !isTimersPage;
@@ -135,6 +141,7 @@
 		TimersManager.RunThroughTimerChanged += OnRunThroughTimerChanged;
 		TimersManager.RaidActiveChanged += OnFloatingTimerStateChanged;
 		TimersManager.FloatingPanelSettingChanged += OnFloatingTimerStateChanged;
+		isWindowMaximized = WindowHost.IsMaximized;
 		timeInRaid = TimersManager.TimeInRaid;
 		runThroughRemaining = TimersManager.RunThroughRemaining;
 		UpdateCurrentPage();
@@ -142,6 +149,11 @@
 
 	protected override async Task OnAfterRenderAsync(bool firstRender)
 	{
+		if (firstRender)
+		{
+			WindowHost.MarkUiReady();
+		}
+
 		if (ShowFloatingTimerPanel)
 			await JSRuntime.InvokeVoidAsync("floatingTimerPanel.initialize", "floating-timer-panel");
 	}
@@ -156,7 +168,21 @@
 		drawerOpen = !drawerOpen;
 	}
 
-	private void BeginWindowDrag() => WindowHost.BeginWindowDrag();
+	private void BeginWindowDrag(MouseEventArgs eventArgs)
+	{
+		if (eventArgs.Button != 0)
+		{
+			return;
+		}
+
+		if (eventArgs.Detail == 2)
+		{
+			ToggleMaximizeWindow();
+			return;
+		}
+
+		WindowHost.BeginWindowDrag();
+	}
 
 	private void BeginWindowResize(int hitTest) => WindowHost.BeginWindowResize(hitTest);
 
@@ -168,6 +194,13 @@
 
 	private void OnWindowStateChanged(object? sender, EventArgs e)
 	{
+		var nextMaximizedState = WindowHost.IsMaximized;
+		if (isWindowMaximized == nextMaximizedState)
+		{
+			return;
+		}
+
+		isWindowMaximized = nextMaximizedState;
 		InvokeAsync(StateHasChanged);
 	}
 

--- a/TarkovMonitor/Blazor/AppLayout.razor.css
+++ b/TarkovMonitor/Blazor/AppLayout.razor.css
@@ -8,8 +8,13 @@
     padding-top: 8px !important;
     overflow-x: hidden;
     overflow-y: auto;
-    scrollbar-color: #8f825f #252522;
+    scrollbar-color: auto;
+    scrollbar-gutter: stable;
     scrollbar-width: auto;
+}
+
+::deep .app-main-content--restored {
+    margin-right: 4px;
 }
 
 ::deep .app-main-content::-webkit-scrollbar {

--- a/TarkovMonitor/Blazor/Components/LogBoard.razor
+++ b/TarkovMonitor/Blazor/Components/LogBoard.razor
@@ -1,9 +1,10 @@
 ﻿@using Humanizer
+@implements IDisposable
 @inject LogRepository logRepository
-<MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Stretch" Class="ma-2" Style="min-width: 0;">
+<MudStack Justify="Justify.FlexStart" AlignItems="AlignItems.Stretch" Class="ma-2" Style="min-width: 0;">
     @if (logRepository.Logs.Count == 0)
     {
-        <MudAlert Severity="Severity.Info">No new logs have been seen since launching the monitor.</MudAlert>
+        <MudAlert Severity="Severity.Info">No new log entries since Tarkov Monitor started.</MudAlert>
     }else{
         @foreach (LogLine line in logRepository.Logs)
         {
@@ -34,5 +35,10 @@
     private void LogAdded(object? sender, NewLogLineArgs e)
     {
         InvokeAsync(() => StateHasChanged());
+    }
+
+    public void Dispose()
+    {
+        logRepository.newLog -= LogAdded;
     }
 }

--- a/TarkovMonitor/Blazor/Components/MessageBoard.razor
+++ b/TarkovMonitor/Blazor/Components/MessageBoard.razor
@@ -1,28 +1,61 @@
 ﻿@using Humanizer;
 @using System.Diagnostics;
 @using System.Threading
+@implements IDisposable
 @inject MessageLog messageLog
 @inject IDialogService DialogService
 @inject LocalizationService LocalizationService
+@inject NavigationManager NavManager
 <MudPaper Class="app-surface dashboard-notification-surface" Elevation="3">
 <MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Center" Class="pa-3">
-    @if (messageLog.Messages.Count == 0)
+    @if (messages.Count == 0)
     {
         <MudAlert Severity="Severity.Info">@LocalizationService.GetString("ThereArentAnyMessagesYet")</MudAlert>
     }else{
-        @foreach (MonitorMessage message in messageLog.Messages.ToList())
+        @foreach (MonitorMessage message in messages)
         {
-            <div class="">
-                <div class="d-block">
-                    <MudPaper Class="align-center py-2 px-3 mud-theme-secondary" Elevation="3">
-                        <div class="d-flex align-center">
+            <div class="dashboard-message">
+                <div class="d-block dashboard-message__paper">
+                    <MudPaper Class="align-center py-2 px-3 mud-theme-secondary dashboard-message__paper" Elevation="3">
+                        <div class="d-flex align-start dashboard-message__row">
                             <MudIcon Icon="@GetTypeIcon(message.Type)" Title="@GetTypeTitle(message.Type)" Class="mr-2"/>
-                            <span class="" @onclick="() => OpenURL(message.Url)" style="@GetMessageStyle(message.Url)">
-                                @message.Message
-                            </span>
+                            <div class="dashboard-message__content">
+                                @if (string.IsNullOrWhiteSpace(message.LinkText))
+                                {
+                                    <span class="dashboard-message__text" @onclick="() => OpenURL(message.Url)" style="@GetMessageStyle(message.Url)">@message.Message</span>
+                                }
+                                else if (message.Message.Contains(message.LinkText, StringComparison.Ordinal))
+                                {
+                                    var linkStart = message.Message.IndexOf(message.LinkText, StringComparison.Ordinal);
+                                    var linkEnd = linkStart + message.LinkText.Length;
+                                    <span class="dashboard-message__text">@(message.Message[..linkStart])<span @onclick="() => OpenURL(message.Url)" style="@GetMessageStyle(message.Url)">@message.LinkText</span>@(message.Message[linkEnd..])</span>
+                                }
+                                else
+                                {
+                                    <span class="dashboard-message__text">@message.Message</span>
+                                    <span class="ml-1 dashboard-message__text" @onclick="() => OpenURL(message.Url)" style="@GetMessageStyle(message.Url)">@message.LinkText</span>
+                                }
+                                @if (message.ProtectedValues.Count > 0)
+                                {
+                                    <div class="dashboard-message__protected-values">
+                                        @foreach (var protectedValue in message.ProtectedValues)
+                                        {
+                                            <span class="dashboard-message__protected-detail">
+                                                <span class="dashboard-message__protected-label">@protectedValue.Label</span>
+                                                 <span class="dashboard-message__protected-value"
+                                                       tabindex="0"
+                                                       aria-label="@($"{protectedValue.Label}: {protectedValue.Value}. Protected value revealed on focus.")">
+                                                     <span class="dashboard-message__protected-mask" aria-hidden="true">Hidden - hover to reveal</span>
+                                                     <span class="dashboard-message__protected-reveal" aria-hidden="true">@protectedValue.Value</span>
+                                                 </span>
+                                            </span>
+                                        }
+                                    </div>
+                                }
+                            </div>
                         </div>
                         <div class="d-flex align-center">
-                            @foreach (MonitorMessageSelect select in message.Selects)
+                            @foreach (MonitorMessageSelect select in message.Selects.GetSnapshot())
                             {
 
                                 <MudSelect T="MonitorMessageSelectOption" Placeholder="@select.Placeholder" SelectedValuesChanged="@((e) => MessageSelectChanged(select, e) )">
@@ -32,7 +65,7 @@
                                     }
                                 </MudSelect>
                             }
-                            @foreach (MonitorMessageButton button in message.Buttons)
+                            @foreach (MonitorMessageButton button in message.Buttons.GetSnapshot())
                             {
                                 <MudButton Variant="Variant.Filled" Color="@button.Color" StartIcon="@button.Icon" OnClick="@((e) => MessageButtonClick(button) )">@button.Text</MudButton>
                             }
@@ -50,14 +83,31 @@
 </MudPaper>
 
 @code {
-    // Force refresh every minute to update timestamps
+    // Refresh once per minute to update relative timestamps.
     Timer? timer;  
+    IReadOnlyList<MonitorMessage> messages = Array.Empty<MonitorMessage>();
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
 
-        timer = new Timer(RefreshCallback, null, 1000, 1000);
+        // Messages can arrive from EFT log watchers and API callbacks between the
+        // timestamp refreshes. Listen to the source directly so the card redraws
+        // as soon as a message is recorded.
+        messageLog.newMessage += MessageLog_NewMessage;
+        messages = messageLog.GetSnapshot();
+        timer = new Timer(RefreshCallback, null, 60000, 60000);
+    }
+
+    private void MessageLog_NewMessage(object source, NewLogMessageArgs e)
+    {
+        // Log callbacks are not guaranteed to run on Blazor's renderer thread.
+        // InvokeAsync safely schedules the redraw on the correct dispatcher.
+        _ = InvokeAsync(() =>
+        {
+            messages = messageLog.GetSnapshot();
+            StateHasChanged();
+        });
     }
 
     private string GetTypeIcon(string type)
@@ -101,12 +151,17 @@
     private string GetMessageStyle(string url)
     {
         if (url.Length == 0) return ""; 
-        return "cursor: pointer;";
+        return "cursor: pointer; text-decoration: underline;";
     }
 
     private void OpenURL(string url)
     {
         if (url.Length == 0) return;
+        if (url.StartsWith('/'))
+        {
+            NavManager.NavigateTo(url);
+            return;
+        }
         var psi = new ProcessStartInfo
 		{
             FileName = url,
@@ -156,5 +211,11 @@
         {
             messageLog.AddMessage($"Error in message select: ${ex.Message} {ex.StackTrace}", "exception");
         }
+    }
+
+    public void Dispose()
+    {
+        messageLog.newMessage -= MessageLog_NewMessage;
+        timer?.Dispose();
     }
 }

--- a/TarkovMonitor/Blazor/Components/MessageBoard.razor
+++ b/TarkovMonitor/Blazor/Components/MessageBoard.razor
@@ -1,5 +1,6 @@
 ﻿@using Humanizer;
 @using System.Diagnostics;
+@using System.Collections.Specialized;
 @using System.Threading
 @implements IDisposable
 @inject MessageLog messageLog
@@ -87,6 +88,7 @@
     // Refresh once per minute to update relative timestamps.
     Timer? timer;  
     IReadOnlyList<MonitorMessage> messages = Array.Empty<MonitorMessage>();
+    private readonly HashSet<MonitorMessage> subscribedMessages = new();
 
     protected override void OnInitialized()
     {
@@ -97,6 +99,7 @@
         // as soon as a message is recorded.
         messageLog.newMessage += MessageLog_NewMessage;
         messages = PrepareForReverseStack(messageLog.GetSnapshot());
+        SubscribeToMessageActions(messages);
         timer = new Timer(RefreshCallback, null, 60000, 60000);
     }
 
@@ -104,6 +107,27 @@
     {
         // Log callbacks are not guaranteed to run on Blazor's renderer thread.
         // InvokeAsync safely schedules the redraw on the correct dispatcher.
+        _ = InvokeAsync(() =>
+        {
+            messages = PrepareForReverseStack(messageLog.GetSnapshot());
+            SubscribeToMessageActions(messages);
+            StateHasChanged();
+        });
+    }
+
+    private void SubscribeToMessageActions(IEnumerable<MonitorMessage> snapshot)
+    {
+        foreach (var message in snapshot)
+        {
+            if (subscribedMessages.Add(message))
+            {
+                message.Buttons.CollectionChanged += MessageActions_CollectionChanged;
+            }
+        }
+    }
+
+    private void MessageActions_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
         _ = InvokeAsync(() =>
         {
             messages = PrepareForReverseStack(messageLog.GetSnapshot());
@@ -217,8 +241,19 @@
         var startedUtc = DateTime.UtcNow;
         try
         {
+            if (button.IsExpired)
+            {
+                button.Expire();
+                return;
+            }
+
             if (button.ResultAction != null)
             {
+                if (button.IsExpired)
+                {
+                    button.Expire();
+                    return;
+                }
                 var copyResult = button.ResultAction();
                 Snackbar.Add(copyResult.Message, copyResult.Succeeded ? Severity.Success : Severity.Error);
                 return;
@@ -237,6 +272,11 @@
             );
             if (result != null)
             {
+                if (button.IsExpired)
+                {
+                    button.Expire();
+                    return;
+                }
                 button.OnClick?.Invoke();
             }
         }
@@ -267,6 +307,11 @@
     public void Dispose()
     {
         messageLog.newMessage -= MessageLog_NewMessage;
+        foreach (var message in subscribedMessages)
+        {
+            message.Buttons.CollectionChanged -= MessageActions_CollectionChanged;
+        }
+        subscribedMessages.Clear();
         timer?.Dispose();
     }
 }

--- a/TarkovMonitor/Blazor/Components/MessageBoard.razor
+++ b/TarkovMonitor/Blazor/Components/MessageBoard.razor
@@ -54,11 +54,11 @@
                                 }
                             </div>
                         </div>
-                        <div class="d-flex align-center">
+                        <div class="tm-message-actions">
                             @foreach (MonitorMessageSelect select in message.Selects.GetSnapshot())
                             {
 
-                                <MudSelect T="MonitorMessageSelectOption" Placeholder="@select.Placeholder" SelectedValuesChanged="@((e) => MessageSelectChanged(select, e) )">
+                                <MudSelect T="MonitorMessageSelectOption" Placeholder="@select.Placeholder" aria-label="@select.Placeholder" RelativeWidth="DropdownWidth.Adaptive" PopoverFixed="false" Modal="false" MaxHeight="280" SelectedValuesChanged="@((e) => MessageSelectChanged(select, e) )" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--compact tm-message-select" PopoverClass="tm-select-popover" ListClass="tm-select-list">
                                     @foreach (MonitorMessageSelectOption option in select.Options)
                                     {
                                         <MudSelectItem Value="@option">@option.Text</MudSelectItem>
@@ -95,7 +95,7 @@
         // timestamp refreshes. Listen to the source directly so the card redraws
         // as soon as a message is recorded.
         messageLog.newMessage += MessageLog_NewMessage;
-        messages = messageLog.GetSnapshot();
+        messages = PrepareForReverseStack(messageLog.GetSnapshot());
         timer = new Timer(RefreshCallback, null, 60000, 60000);
     }
 
@@ -105,9 +105,45 @@
         // InvokeAsync safely schedules the redraw on the correct dispatcher.
         _ = InvokeAsync(() =>
         {
-            messages = messageLog.GetSnapshot();
+            messages = PrepareForReverseStack(messageLog.GetSnapshot());
             StateHasChanged();
         });
+    }
+
+    private static IReadOnlyList<MonitorMessage> PrepareForReverseStack(IReadOnlyList<MonitorMessage> snapshot)
+    {
+        if (snapshot.Count < 2)
+        {
+            return snapshot;
+        }
+
+        var displayItems = new List<MonitorMessage>(snapshot.Count);
+        for (var index = 0; index < snapshot.Count;)
+        {
+            var message = snapshot[index];
+            if (!message.PreserveDisplayBatchOrder || message.DisplayBatchId == null)
+            {
+                displayItems.Add(message);
+                index++;
+                continue;
+            }
+
+            var batchEnd = index + 1;
+            while (batchEnd < snapshot.Count
+                && snapshot[batchEnd].PreserveDisplayBatchOrder
+                && snapshot[batchEnd].DisplayBatchId == message.DisplayBatchId)
+            {
+                batchEnd++;
+            }
+
+            for (var batchIndex = batchEnd - 1; batchIndex >= index; batchIndex--)
+            {
+                displayItems.Add(snapshot[batchIndex]);
+            }
+            index = batchEnd;
+        }
+
+        return displayItems;
     }
 
     private string GetTypeIcon(string type)
@@ -197,19 +233,24 @@
         }
         catch (Exception ex)
         {
-            messageLog.AddMessage($"Error in message button: ${ex.Message} {ex.StackTrace}", "exception");
+            messageLog.AddMessage($"Could not activate the message button: {ex.Message} {ex.StackTrace}", "exception");
         }
     }
 
-    private async void MessageSelectChanged(MonitorMessageSelect select, IEnumerable<MonitorMessageSelectOption> selected)
+    private void MessageSelectChanged(MonitorMessageSelect select, IEnumerable<MonitorMessageSelectOption>? selected)
     {
         try
         {
-            select.ChangeSelection(selected.First());
+            MonitorMessageSelectOption? option = selected?.FirstOrDefault();
+            if (option == null)
+            {
+                return;
+            }
+            select.ChangeSelection(option);
         }
         catch (Exception ex)
         {
-            messageLog.AddMessage($"Error in message select: ${ex.Message} {ex.StackTrace}", "exception");
+            messageLog.AddMessage($"Could not update the message selection: {ex.Message} {ex.StackTrace}", "exception");
         }
     }
 

--- a/TarkovMonitor/Blazor/Pages/RawLogs/CustomLogDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/RawLogs/CustomLogDialog.razor
@@ -3,13 +3,13 @@
 
 <MudDialog>
     <DialogContent>
-        <MudSelect @bind-Value="gameLogType" Label="Log type" HelperText="This changes the GameWatcher monitor used to process the log" OpenIcon="@Icons.Material.Filled.TextSnippet" AdornmentColor="Color.Secondary">
+        <MudSelect @bind-Value="gameLogType" Label="Log type" RelativeWidth="DropdownWidth.Adaptive" HelperText="Choose which GameWatcher monitor should process this log" OpenIcon="@Icons.Material.Filled.TextSnippet" AdornmentColor="Color.Secondary" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--dialog" PopoverClass="tm-select-popover" ListClass="tm-select-list">
             @foreach (GameLogType item in Enum.GetValues(typeof(GameLogType)))
             {
                 <MudSelectItem Value="@item">@item</MudSelectItem>
             }
         </MudSelect>
-        <MudTextField Immediate="true" @bind-Value="@sampleText" T="string" Label="Log Data" Variant="Variant.Outlined" Lines="5" Class="mt-4"/>
+        <MudTextField Immediate="true" @bind-Value="@sampleText" T="string" Label="Log data" Variant="Variant.Outlined" Lines="5" Class="mt-4"/>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel">@LocalizationService.GetString("Cancel")</MudButton>

--- a/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
@@ -130,6 +130,7 @@
                 Id = GameWatcher.CurrentProfile.Id,
                 Type = GameWatcher.CurrentProfile.Type,
                 AccountId = GameWatcher.CurrentProfile.AccountId,
+                SessionMode = GameWatcher.CurrentProfile.SessionMode,
             };
             customWatcher.ProcessLogsFromBreakpoint(selectedBreakpoint);
             GameWatcher.CurrentProfile = currentProfile;

--- a/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
@@ -81,9 +81,6 @@
         }
     }
     List<LogDetails>? breakpoints;
-    Dictionary<string, TarkovMonitor.TaskStatus> TaskStatuses = new();
-    Dictionary<string, int> TaskSequence = new();
-    int nextTaskSequence;
     bool SubmitDisabled { get; set; } = true;
     bool IsProcessing { get; set; }
 
@@ -180,6 +177,11 @@
         var updateTasks = new Dictionary<string, TarkovMonitor.TaskStatus>();
         var totalTasks = 0;
         var startedUtc = DateTime.UtcNow;
+        var observedTaskStatuses = new Dictionary<string, TarkovMonitor.TaskStatus>();
+        var observedTaskSequence = new Dictionary<string, int>();
+        var observedTaskLock = new object();
+        var nextObservedTaskSequence = 0;
+        EventHandler<LogContentEventArgs<TaskStatusMessageLogContent>>? taskHandler = null;
         IsProcessing = true;
         SubmitDisabled = true;
         await InvokeAsync(StateHasChanged);
@@ -196,21 +198,41 @@
                     return;
                 }
 
+                var historicalTasks = await TarkovDev.GetTasks(breakpoint.Profile.Type);
                 GameWatcher.ReadingPastLogs = true;
-                TaskStatuses.Clear();
-                TaskSequence.Clear();
-                nextTaskSequence = 0;
-                customWatcher.TaskModified += UpdateTaskStatus;
-                handlerAttached = true;
-                customWatcher.ProcessLogsFromBreakpoint(breakpoint);
+                taskHandler = (_, e) =>
+                {
+                    if (!string.Equals(e.Profile.AccountId, breakpoint.Profile.AccountId, StringComparison.Ordinal)
+                        || !string.Equals(e.Profile.Id, breakpoint.Profile.Id, StringComparison.Ordinal)
+                        || e.Profile.SessionMode != breakpoint.Profile.SessionMode)
+                    {
+                        return;
+                    }
 
-                foreach (var kvp in TaskStatuses.OrderBy(item => TaskSequence[item.Key]))
+                    lock (observedTaskLock)
+                    {
+                        observedTaskStatuses[e.LogContent.TaskId] = e.LogContent.Status;
+                        observedTaskSequence[e.LogContent.TaskId] = nextObservedTaskSequence++;
+                    }
+                };
+                customWatcher.TaskModified += taskHandler;
+                handlerAttached = true;
+                await Task.Run(() => customWatcher.ProcessLogsFromBreakpoint(breakpoint));
+
+                KeyValuePair<string, TarkovMonitor.TaskStatus>[] observedTasks;
+                lock (observedTaskLock)
+                {
+                    observedTasks = observedTaskStatuses
+                        .OrderBy(item => observedTaskSequence[item.Key])
+                        .ToArray();
+                }
+                foreach (var kvp in observedTasks)
                 {
                     if (kvp.Value == TarkovMonitor.TaskStatus.Started)
                     {
                         continue;
                     }
-                    var task = TarkovDev.Tasks.Find((t) => t.id == kvp.Key);
+                    var task = historicalTasks.Find((t) => t.id == kvp.Key);
                     if (task == null)
                     {
                         continue;
@@ -257,7 +279,10 @@
             GameWatcher.ReadingPastLogs = false;
             if (handlerAttached)
             {
-                customWatcher.TaskModified -= UpdateTaskStatus;
+                if (taskHandler != null)
+                {
+                    customWatcher.TaskModified -= taskHandler;
+                }
                 handlerAttached = false;
             }
 
@@ -289,7 +314,10 @@
         {
             if (handlerAttached)
             {
-                customWatcher.TaskModified -= UpdateTaskStatus;
+                if (taskHandler != null)
+                {
+                    customWatcher.TaskModified -= taskHandler;
+                }
             }
             GameWatcher.ReadingPastLogs = false;
             if (trackerLease != null)
@@ -302,18 +330,6 @@
         }
     }
 
-    private void UpdateTaskStatus(object? sender, LogContentEventArgs<TaskStatusMessageLogContent> e)
-    {
-        if (selectedBreakpoint == null
-            || !string.Equals(e.Profile.AccountId, selectedBreakpoint.Profile.AccountId, StringComparison.Ordinal)
-            || !string.Equals(e.Profile.Id, selectedBreakpoint.Profile.Id, StringComparison.Ordinal)
-            || e.Profile.SessionMode != selectedBreakpoint.Profile.SessionMode)
-        {
-            return;
-        }
-        TaskStatuses[e.LogContent.TaskId] = e.LogContent.Status;
-        TaskSequence[e.LogContent.TaskId] = nextTaskSequence++;
-    }
     private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == "customLogsPath")

--- a/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
@@ -1,25 +1,40 @@
 ﻿@using System.ComponentModel
 @using Humanizer
+@implements IDisposable
+@inject GameWatcher eft
 @inject MessageLog messageLog
 @inject LocalizationService LocalizationService
 
-<MudDialog>
+<MudDialog Class="tm-dialog-shell tm-dialog-shell--read-past" TitleClass="tm-dialog-title" ContentClass="tm-dialog-content tm-dialog-content--read-past" ActionsClass="tm-dialog-actions">
     <DialogContent>
         <MudText>
             @LocalizationService.GetString("CurrentProfile"):
-            <MudLink Href="@($"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}")">@CurrentProfileName (@GameWatcher.CurrentProfile.Type)</MudLink>
+            @if (HasCurrentProfileRoute)
+            {
+                <MudLink Class="tm-profile-link" Href="@CurrentProfileUrl">@CurrentProfileName (@GetProfileTypeDisplayName(GameWatcher.CurrentProfile.Type))</MudLink>
+            }
+            else
+            {
+                <span>No EFT profile detected.</span>
+            }
         </MudText>
         <MudText>
             @LocalizationService.GetString("IfYouWantToUpdateProgressForDifferentProfile")
         </MudText>
+        @if (eft.IsGameRunning)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">
+                Read Past Logs is unavailable while Escape from Tarkov is running. Close EFT before importing historical task updates.
+            </MudAlert>
+        }
         @if (customWatcher.LogsPath != "")
         {
             if (breakpoints != null)
             {
-                <MudSelect @bind-Value="selectedBreakpoint" Label="@LocalizationService.GetString("ReadPreviousLogsLabel")" HelperText="@LocalizationService.GetString("ChooseStartingPointHelperText")" OpenIcon="@Icons.Material.Filled.TextSnippet" AdornmentColor="Color.Secondary">
+                <MudSelect @bind-Value="selectedBreakpoint" Label="@LocalizationService.GetString("ReadPreviousLogsLabel")" RelativeWidth="DropdownWidth.Adaptive" HelperText="@LocalizationService.GetString("ChooseStartingPointHelperText")" OpenIcon="@Icons.Material.Filled.TextSnippet" AdornmentColor="Color.Secondary" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--dialog" PopoverClass="tm-select-popover" ListClass="tm-select-list">
                     @foreach (LogDetails breakpoint in breakpoints)
                     {
-                        <MudSelectItem Value="@breakpoint">@breakpoint.Version | @breakpoint.Date.ToLongDateString() - @breakpoint.Date.Humanize()</MudSelectItem>
+                        <MudSelectItem Value="@breakpoint">@breakpoint.Profile.DisplayName | @breakpoint.Version | @breakpoint.Date.ToLongDateString() - @breakpoint.Date.Humanize()</MudSelectItem>
                     }
                 </MudSelect>
                 <p>@LocalizationService.GetString("SelectStartingPointDescription")</p>
@@ -37,14 +52,22 @@
         }
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="Cancel">@LocalizationService.GetString("Cancel")</MudButton>
-        <MudButton Color="Color.Primary" OnClick="Submit" Disabled="@SubmitDisabled">@LocalizationService.GetString("Ok")</MudButton>
+        <MudButton OnClick="Cancel" Disabled="@IsProcessing">@LocalizationService.GetString("Cancel")</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit" Disabled="@(SubmitDisabled || IsProcessing || eft.IsGameRunning)">@LocalizationService.GetString("Ok")</MudButton>
     </DialogActions>
 </MudDialog>
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; }
 
-    internal GameWatcher customWatcher = new();
+    private static string GetProfileTypeDisplayName(ProfileType profileType) => profileType switch
+    {
+        ProfileType.PVE => "PVE",
+        ProfileType.Regular => "PVP",
+        ProfileType.PvpSeason => "Seasonal PVP",
+        _ => profileType.ToString(),
+    };
+
+    internal GameWatcher customWatcher = new(historicalReplay: true);
     LogDetails? _selectedBreakpoint;
     LogDetails? selectedBreakpoint {
         get
@@ -59,9 +82,18 @@
     }
     List<LogDetails>? breakpoints;
     Dictionary<string, TarkovMonitor.TaskStatus> TaskStatuses = new();
+    Dictionary<string, int> TaskSequence = new();
+    int nextTaskSequence;
     bool SubmitDisabled { get; set; } = true;
+    bool IsProcessing { get; set; }
 
-    private string currentProfileName = GameWatcher.CurrentProfile.AccountId;
+    private string currentProfileName = GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
+        ? GameWatcher.CurrentProfile.AccountId
+        : "";
+    private bool HasCurrentProfileRoute => GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute;
+    private string CurrentProfileUrl => HasCurrentProfileRoute
+        ? $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.TarkovDevPlayerMode}/{GameWatcher.CurrentProfile.AccountId}"
+        : "";
     private string CurrentProfileName
     {
         get
@@ -69,32 +101,33 @@
             return currentProfileName;
         }
     }
-    private Task UpdateProfileName()
+    private async Task UpdateProfileName()
     {
-        return TarkovDev.GetPlayerName(GameWatcher.CurrentProfile).ContinueWith(t =>
+        var profile = GameWatcher.CurrentProfile.Snapshot();
+        if (!profile.HasTarkovDevPlayerRoute)
         {
-            if (!t.IsCompletedSuccessfully)
-            {
-                return;
-            }
-            currentProfileName = t.Result;
-        });
+            currentProfileName = "";
+            return;
+        }
+
+        currentProfileName = profile.AccountId;
+        var profileName = await TarkovDev.GetPlayerName(profile);
+        if (GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
+            && string.Equals(GameWatcher.CurrentProfile.AccountId, profile.AccountId, StringComparison.Ordinal)
+            && string.Equals(GameWatcher.CurrentProfile.Id, profile.Id, StringComparison.Ordinal)
+            && GameWatcher.CurrentProfile.SessionMode == profile.SessionMode)
+        {
+            currentProfileName = profileName;
+        }
     }
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
         Task.Run(GetBreakPoints);
-        UpdateProfileName();
+        _ = UpdateProfileName();
 
-        Properties.Settings.Default.PropertyChanged += (object? sender, PropertyChangedEventArgs e) =>
-        {
-            if (e.PropertyName == "customLogsPath")
-            {
-                customWatcher.LogsPath = Properties.Settings.Default.customLogsPath;
-                Task.Run(GetBreakPoints);
-            }
-        };
+        Properties.Settings.Default.PropertyChanged += Settings_PropertyChanged;
     }
 
     private void GetBreakPoints()
@@ -105,52 +138,83 @@
 
     void Cancel() => MudDialog.Cancel();
 
-    public async void Submit()
+    private async Task Submit()
     {
-        // Check if a path was selected, and if so, load the logs from that path
-        if (selectedBreakpoint == null)
+        var breakpoint = selectedBreakpoint;
+        if (breakpoint == null || IsProcessing)
         {
             return;
         }
-        if (!TarkovTracker.ValidToken)
+        if (eft.IsGameRunning)
         {
-            messageLog.AddMessage("You must have a valid Tarkov Tracker API token to read past logs.", "exception");
+            messageLog.AddMessage(
+                "Read Past Logs was not started because Escape from Tarkov is running. Close EFT before importing historical task updates.",
+                "warning");
+            return;
         }
-        SubmitDisabled = true;
-        GameWatcher.ReadingPastLogs = true;
-        TaskStatuses.Clear();
+        if (!breakpoint.Profile.HasIdentity || !breakpoint.Profile.SupportsTarkovTrackerWrites)
+        {
+            messageLog.AddMessage(
+                $"Tarkov Tracker does not support {breakpoint.Profile.DisplayName} historical task updates. No updates were sent.",
+                "warning");
+            return;
+        }
+        if (TarkovTracker.IsLegacyService)
+        {
+            messageLog.AddMessage(
+                "Read Past Logs requires TarkovTracker.org. Switch the Tarkov Tracker service in Settings and try again.",
+                "warning");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(TarkovTracker.GetTokenForProfile(breakpoint.Profile)))
+        {
+            messageLog.AddMessage(
+                $"A verified {breakpoint.Profile.DisplayName} TarkovTracker.org API key assigned to this exact EFT profile is required to read past logs.",
+                "warning");
+            return;
+        }
+
+        TarkovTracker.ProfileActivationLease? trackerLease = null;
+        var handlerAttached = false;
+        var taskMessages = new List<MonitorMessage>();
+        var updateTasks = new Dictionary<string, TarkovMonitor.TaskStatus>();
         var totalTasks = 0;
-        Dictionary<string, TarkovMonitor.TaskStatus> updateTasks = new();
+        IsProcessing = true;
+        SubmitDisabled = true;
+        await InvokeAsync(StateHasChanged);
         try
         {
-            //eft.ProcessLogs(selectedPath);
-            customWatcher.TaskModified += UpdateTaskStatus;
-            Profile currentProfile = new()
+            trackerLease = await TarkovTracker.AcquireProfileLease(breakpoint.Profile);
+            if (eft.IsGameRunning)
             {
-                Id = GameWatcher.CurrentProfile.Id,
-                Type = GameWatcher.CurrentProfile.Type,
-                AccountId = GameWatcher.CurrentProfile.AccountId,
-                SessionMode = GameWatcher.CurrentProfile.SessionMode,
-            };
-            customWatcher.ProcessLogsFromBreakpoint(selectedBreakpoint);
-            GameWatcher.CurrentProfile = currentProfile;
-            customWatcher.TaskModified -= UpdateTaskStatus;
-            foreach (var kvp in TaskStatuses)
+                messageLog.AddMessage(
+                    "Read Past Logs was cancelled because Escape from Tarkov started before historical processing began.",
+                    "warning");
+                return;
+            }
+
+            GameWatcher.ReadingPastLogs = true;
+            TaskStatuses.Clear();
+            TaskSequence.Clear();
+            nextTaskSequence = 0;
+            customWatcher.TaskModified += UpdateTaskStatus;
+            handlerAttached = true;
+            customWatcher.ProcessLogsFromBreakpoint(breakpoint);
+
+            foreach (var kvp in TaskStatuses.OrderBy(item => TaskSequence[item.Key]))
             {
                 if (kvp.Value == TarkovMonitor.TaskStatus.Started)
                 {
-                    // don't update task status if started
                     continue;
                 }
                 var task = TarkovDev.Tasks.Find((t) => t.id == kvp.Key);
                 if (task == null)
                 {
-                    // probably a daily
                     continue;
                 }
                 totalTasks++;
                 TarkovMonitor.TaskStatus savedTaskStatus = TarkovMonitor.TaskStatus.None;
-                var taskProgress = TarkovTracker.Progress.data.tasksProgress.Find((prog) => prog.id == kvp.Key);
+                var taskProgress = trackerLease.Progress.data.tasksProgress.Find((prog) => prog.id == kvp.Key);
                 if (taskProgress != null)
                 {
                     if (taskProgress.failed)
@@ -164,40 +228,83 @@
                 }
                 if (kvp.Value == savedTaskStatus)
                 {
-                    // status matches, so don't update
                     continue;
                 }
                 updateTasks.Add(kvp.Key, kvp.Value);
-                //System.Diagnostics.Debug.WriteLine($"Task {kvp.Key} should be {kvp.Value}");
-                messageLog.AddMessage($"{kvp.Value} task {task.name}", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
+                taskMessages.Add(new MonitorMessage(
+                    $"{kvp.Value} task: {task.name}.",
+                    "quest",
+                    $"https://tarkov.dev/task/{task.normalizedName}"));
             }
-        }
-        catch (Exception ex)
-        {
-            messageLog.AddMessage($"Error compiling task updates: {ex.Message}", "exception");
-            return;
-        }
-        finally
-        {
-            GameWatcher.ReadingPastLogs = false;
-        }
-        try
-        {
+
+            if (eft.IsGameRunning)
+            {
+                messageLog.AddMessage(
+                    "Read Past Logs was cancelled because Escape from Tarkov started before task updates were sent.",
+                    "warning");
+                return;
+            }
             if (updateTasks.Count > 0)
             {
-                await TarkovTracker.SetTaskStatuses(updateTasks);
+                await TarkovTracker.SetTaskStatuses(updateTasks, trackerLease);
+                messageLog.AddMessages(taskMessages, preserveDisplayOrder: true);
+                messageLog.AddMessage(
+                    $"Updated {updateTasks.Count} of {totalTasks} tasks found in the selected logs.",
+                    "info");
             }
-            messageLog.AddMessage($"Of {totalTasks} tasks found in logs, {updateTasks.Count} require status updates in Tarkov Tracker.", "info");
+            else
+            {
+                messageLog.AddMessage(
+                    $"Checked {totalTasks} tasks in the selected logs. Tarkov Tracker was already up to date.",
+                    "info");
+            }
             MudDialog.Close(DialogResult.Ok(true));
         }
         catch (Exception ex)
         {
-            messageLog.AddMessage($"Error updating tasks: {ex.Message}", "exception");
+            messageLog.AddMessage($"Could not read past logs: {ex.Message}", "exception");
+        }
+        finally
+        {
+            if (handlerAttached)
+            {
+                customWatcher.TaskModified -= UpdateTaskStatus;
+            }
+            GameWatcher.ReadingPastLogs = false;
+            if (trackerLease != null)
+            {
+                TarkovTracker.ReleaseProfileLease(trackerLease);
+            }
+            IsProcessing = false;
+            SubmitDisabled = selectedBreakpoint == null;
+            await InvokeAsync(StateHasChanged);
         }
     }
 
     private void UpdateTaskStatus(object? sender, LogContentEventArgs<TaskStatusMessageLogContent> e)
     {
+        if (selectedBreakpoint == null
+            || !string.Equals(e.Profile.AccountId, selectedBreakpoint.Profile.AccountId, StringComparison.Ordinal)
+            || !string.Equals(e.Profile.Id, selectedBreakpoint.Profile.Id, StringComparison.Ordinal)
+            || e.Profile.SessionMode != selectedBreakpoint.Profile.SessionMode)
+        {
+            return;
+        }
         TaskStatuses[e.LogContent.TaskId] = e.LogContent.Status;
+        TaskSequence[e.LogContent.TaskId] = nextTaskSequence++;
+    }
+
+    private void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == "customLogsPath")
+        {
+            customWatcher.LogsPath = Properties.Settings.Default.customLogsPath;
+            Task.Run(GetBreakPoints);
+        }
+    }
+
+    public void Dispose()
+    {
+        Properties.Settings.Default.PropertyChanged -= Settings_PropertyChanged;
     }
 }

--- a/TarkovMonitor/Blazor/Pages/RawLogs/RawLogs.razor
+++ b/TarkovMonitor/Blazor/Pages/RawLogs/RawLogs.razor
@@ -16,10 +16,10 @@
     </MudItem>
     @if (DebugMode() || LogsFolderSet())
     {
-        <div class="ma-2" style="position:fixed; bottom: 0px; right: 16px;">
-            <MudMenu AnchorOrigin="Origin.TopLeft" TransformOrigin="Origin.BottomRight">
+        <div class="tm-menu-host">
+            <MudMenu AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.BottomRight" RelativeWidth="DropdownWidth.Adaptive" PopoverFixed="false" Modal="false" Dense="true" MaxHeight="280" Class="tm-menu" PopoverClass="tm-menu-popover" ListClass="tm-menu-list">
                 <ActivatorContent>
-                    <MudFab Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" />
+                    <MudFab Color="Color.Secondary" StartIcon="@Icons.Material.Filled.Add" Size="Size.Small" Class="tm-menu-activator" aria-label="Log actions" />
                 </ActivatorContent>
                 <ChildContent>
                     @if(DebugMode())
@@ -46,13 +46,13 @@
     private void OpenCustomDialog()
     {
         var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
-        DialogService.ShowAsync<CustomLogDialog>("Process Custom Log Data", options);
+        DialogService.ShowAsync<CustomLogDialog>("Process custom log data", options);
     }
 
     private void OpenForceReadDialog()
     {
-        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
-        DialogService.ShowAsync<ForceReadDialog>("Read Past Log Files", options);
+        var options = new DialogOptions { CloseOnEscapeKey = false, BackdropClick = false, MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
+        DialogService.ShowAsync<ForceReadDialog>("Read past log files", options);
     }
 
     private void OpenLogsFolder()

--- a/TarkovMonitor/Blazor/Pages/Settings/AssignTarkovTrackerKeyDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/AssignTarkovTrackerKeyDialog.razor
@@ -1,0 +1,246 @@
+@inject GameWatcher eft
+
+<MudDialog Class="tracker-assignment-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note @(RequiresVerification ? "tracker-dialog-note--warning" : "")" role="note">
+            <MudIcon Icon="@(RequiresVerification ? Icons.Material.Filled.GppMaybe : Icons.Material.Filled.AccountTree)" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>@(IsReassign ? "Choose another EFT profile." : "Choose an EFT profile.")</strong>
+                <span>@(RequiresVerification
+                    ? "This recovered key must be verified before you can assign it."
+                    : "Only saved profiles for this key's game mode are shown.")</span>
+            </span>
+        </div>
+
+        <div class="tracker-profile-guidance" role="note">
+            @if (IsReassign)
+            {
+                <span class="tracker-profile-guidance-item"><b>Move key</b><span>No key assigned</span></span>
+                <span class="tracker-profile-guidance-item"><b>Swap keys</b><span>Key already assigned</span></span>
+            }
+            else
+            {
+                <span class="tracker-profile-guidance-item"><b>Available</b><span>No key assigned</span></span>
+                <span class="tracker-profile-guidance-item"><b>Unavailable</b><span>Key already assigned</span></span>
+            }
+        </div>
+
+        @if (selectedProfile != null)
+        {
+            <div class="tracker-profile-confirm">
+                <MudText Typo="Typo.subtitle2" Class="tracker-profile-confirm-title">Review assignment</MudText>
+                <dl class="tracker-profile-confirm-grid">
+                    <dt>Account</dt>
+                    <dd>@AccountLabel(selectedProfile)</dd>
+                    <dt>Account ID</dt>
+                    <dd>@selectedProfile.AccountId</dd>
+                    <dt>Mode</dt>
+                    <dd>@selectedProfile.DisplayName</dd>
+                    <dt>Last played</dt>
+                    <dd>@LastPlayedValue(selectedProfile)</dd>
+                    <dt>Profile</dt>
+                    <dd>@ShortProfileId(selectedProfile.ProfileId)</dd>
+                </dl>
+                <MudAlert Severity="@(WillSwap ? Severity.Warning : Severity.Info)" Dense="true" Class="mt-3">
+                    @(WillSwap
+                        ? "This profile already has a key. Confirming will swap the two keys; neither key will become unassigned. Profile nicknames move with their keys."
+                        : IsReassign
+                            ? $"This key will move to the selected profile.{(string.IsNullOrWhiteSpace(ProfileNickname) ? "" : " Its profile nickname will move with it.")}"
+                            : "This key will be assigned to the selected profile.")
+                </MudAlert>
+            </div>
+        }
+        else if (scanning)
+        {
+            <div class="tracker-profile-scan-state">
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                <MudText Typo="Typo.body2">Scanning past EFT logs...</MudText>
+            </div>
+        }
+        else if (MatchingProfiles.Count == 0)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true">
+                @NoMatchingProfilesLead Select
+                <button type="button"
+                        class="tracker-inline-scan-action"
+                        aria-label="Scan profiles from past EFT logs"
+                        @onclick="ScanProfiles">Scan profiles</button>
+                to check past EFT logs, or launch EFT with the profile you want to use.
+            </MudAlert>
+        }
+        else
+        {
+            <div class="tracker-profile-picker">
+                @foreach (var profile in MatchingProfiles)
+                {
+                    var disabled = !IsReassign && profile.HasBoundKey;
+                    var stateLabel = disabled
+                        ? "Already assigned"
+                        : profile.HasBoundKey
+                            ? "Swap"
+                            : IsReassign
+                                ? "Move"
+                                : "Select";
+                    <button type="button"
+                            class="tracker-profile-choice @(disabled ? "tracker-profile-choice--disabled" : "")"
+                            disabled="@disabled"
+                            aria-label="@($"{AccountLabel(profile)}, Account ID {profile.AccountId}, {profile.DisplayName}, {stateLabel}")"
+                            @onclick="@(() => Select(profile))">
+                        <span class="tracker-profile-choice-main">
+                            <span class="tracker-profile-choice-title">@AccountLabel(profile)</span>
+                            <span class="tracker-profile-choice-id">Account ID: @profile.AccountId</span>
+                            <span class="tracker-profile-choice-meta">
+                                <span class="tracker-profile-mode">@profile.DisplayName</span>
+                                <span>@LastPlayed(profile)</span>
+                                <span>@ShortProfileId(profile.ProfileId)</span>
+                            </span>
+                        </span>
+                        <span class="tracker-profile-choice-state">
+                            @if (profile.IsCurrent)
+                            {
+                                <span class="tracker-profile-state tracker-profile-state--current">Current</span>
+                            }
+                            <span class="tracker-profile-state @(profile.HasBoundKey ? "tracker-profile-state--bound" : "tracker-profile-state--available")">@stateLabel</span>
+                        </span>
+                    </button>
+                }
+            </div>
+        }
+
+        @if (selectedProfile == null && !string.IsNullOrWhiteSpace(scanMessage))
+        {
+            <MudText Typo="Typo.caption" Class="mt-2">@scanMessage</MudText>
+        }
+    </DialogContent>
+    <DialogActions>
+        @if (selectedProfile == null)
+        {
+            <MudButton OnClick="Cancel" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Cancel</MudButton>
+            <MudTooltip Text="Reads account, profile, mode, and last-played details from past EFT logs. It does not replay tasks.">
+                <span><MudButton Color="Color.Info" Variant="Variant.Outlined" OnClick="ScanProfiles" Disabled="@scanning" StartIcon="@Icons.Material.Filled.Search" Class="tracker-dialog-footer-button">
+                    Scan profiles
+                </MudButton></span>
+            </MudTooltip>
+        }
+        else
+        {
+            <MudButton OnClick="Back" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ArrowBack" Class="tracker-dialog-footer-button">Back</MudButton>
+            <MudButton Color="Color.Info" Variant="Variant.Filled" OnClick="Confirm" StartIcon="@Icons.Material.Filled.CheckCircle" Class="tracker-dialog-footer-button">@ActionLabel</MudButton>
+        }
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string KeyPrefix { get; set; } = "";
+    [Parameter] public string KeyDisplayName { get; set; } = "";
+    [Parameter] public bool KeyIsBound { get; set; }
+    [Parameter] public bool RequiresVerification { get; set; }
+    [Parameter] public string BoundAccountId { get; set; } = "";
+    [Parameter] public string BoundProfileId { get; set; } = "";
+    [Parameter] public EftSessionMode BoundSessionMode { get; set; }
+    [Parameter] public string ProfileNickname { get; set; } = "";
+    [Parameter] public bool IsReassign { get; set; }
+
+    private bool scanning;
+    private string scanMessage = "";
+    private TarkovTracker.OrgProfileSummary? selectedProfile;
+    private IReadOnlyList<TarkovTracker.OrgProfileSummary> profiles = Array.Empty<TarkovTracker.OrgProfileSummary>();
+
+    private List<TarkovTracker.OrgProfileSummary> MatchingProfiles => profiles
+        .Where(profile => string.Equals(
+            KeyPrefix,
+            TarkovTracker.GetPrefixForSessionMode(profile.SessionMode),
+            StringComparison.OrdinalIgnoreCase))
+        .Where(profile => !IsReassign
+            || !KeyIsBound
+            || !string.Equals(profile.AccountId, BoundAccountId, StringComparison.Ordinal)
+            || !string.Equals(profile.ProfileId, BoundProfileId, StringComparison.Ordinal)
+            || profile.SessionMode != BoundSessionMode)
+        .OrderByDescending(profile => profile.IsCurrent)
+        .ThenByDescending(profile => profile.LastSeenUtc)
+        .ToList();
+
+    protected override void OnInitialized()
+    {
+        ReloadProfiles();
+    }
+
+    private void ReloadProfiles()
+    {
+        profiles = TarkovTracker.GetKnownOrgProfiles();
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Select(TarkovTracker.OrgProfileSummary profile)
+    {
+        selectedProfile = profile;
+    }
+
+    private void Back() => selectedProfile = null;
+
+    private void Confirm()
+    {
+        if (selectedProfile != null)
+        {
+            MudDialog.Close(DialogResult.Ok(selectedProfile));
+        }
+    }
+
+    private bool WillSwap => IsReassign && selectedProfile?.HasBoundKey == true;
+
+    private string NoMatchingProfilesLead =>
+        $"{(IsReassign ? "No other" : "No")} saved {KeyDisplayName} profiles are available.";
+
+    private string ActionLabel => WillSwap ? "Swap" : IsReassign ? "Reassign" : "Assign";
+
+    private async Task ScanProfiles()
+    {
+        scanning = true;
+        scanMessage = "";
+        try
+        {
+            var discovered = await Task.Run(eft.DiscoverProfiles);
+            var changed = TarkovTracker.SaveDiscoveredOrgProfiles(discovered);
+            ReloadProfiles();
+            scanMessage = discovered.Count == 0
+                ? "No EFT profiles were found in past logs."
+                : $"Found {discovered.Count} profile{(discovered.Count == 1 ? "" : "s")} and updated {changed} saved entr{(changed == 1 ? "y" : "ies")}.";
+        }
+        catch (Exception ex)
+        {
+            scanMessage = $"Could not scan profiles: {ex.Message}";
+        }
+        finally
+        {
+            scanning = false;
+        }
+    }
+
+    private static string AccountLabel(TarkovTracker.OrgProfileSummary profile)
+    {
+        return string.IsNullOrWhiteSpace(profile.AccountNickname)
+            ? $"Account {profile.AccountId}"
+            : profile.AccountNickname;
+    }
+
+    private static string LastPlayed(TarkovTracker.OrgProfileSummary profile)
+    {
+        return $"Last played: {LastPlayedValue(profile)}";
+    }
+
+    private static string LastPlayedValue(TarkovTracker.OrgProfileSummary profile)
+    {
+        return profile.LastSeenUtc is { } lastSeen
+            ? lastSeen.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+            : "Unknown";
+    }
+
+    private static string ShortProfileId(string profileId)
+    {
+        var suffix = profileId.Length <= 6 ? profileId : profileId[^6..];
+        return $"Profile …{suffix}";
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/AssignTarkovTrackerKeyDialog.razor.css
+++ b/TarkovMonitor/Blazor/Pages/Settings/AssignTarkovTrackerKeyDialog.razor.css
@@ -1,0 +1,218 @@
+.tracker-profile-scan-state {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-height: 5rem;
+    justify-content: center;
+}
+
+.tracker-inline-scan-action {
+    appearance: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    color: var(--mud-palette-info);
+    background: transparent;
+    font: inherit;
+    text-decoration: underline;
+    text-underline-offset: 0.12em;
+    cursor: pointer;
+}
+
+.tracker-inline-scan-action:hover {
+    text-decoration-thickness: 2px;
+}
+
+.tracker-inline-scan-action:focus-visible {
+    border-radius: 2px;
+    outline: 1px solid currentColor;
+    outline-offset: 2px;
+}
+
+.tracker-profile-picker {
+    display: flex;
+    max-height: clamp(12rem, 46vh, 21rem);
+    flex-direction: column;
+    gap: 0.45rem;
+    overflow-y: auto;
+    padding: 0.2rem 0.35rem 0.2rem 0.2rem;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 11px;
+    background: rgba(0, 0, 0, 0.12);
+    scrollbar-color: rgba(120, 174, 251, 0.72) rgba(255, 255, 255, 0.04);
+    scrollbar-width: thin;
+}
+
+.tracker-profile-guidance {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.42rem;
+    margin-bottom: 0.65rem;
+}
+
+.tracker-profile-guidance-item {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.02rem;
+    padding: 0.38rem 0.52rem;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.55);
+    background: rgba(255, 255, 255, 0.02);
+    font-size: 0.67rem;
+    line-height: 1.25;
+}
+
+.tracker-profile-guidance-item b {
+    color: rgba(255, 255, 255, 0.83);
+    font-size: 0.7rem;
+}
+
+.tracker-profile-confirm {
+    padding: 0.25rem 0;
+}
+
+.tracker-profile-confirm-title {
+    margin-bottom: 0.65rem;
+    color: rgba(255, 255, 255, 0.88);
+}
+
+.tracker-profile-confirm-grid {
+    display: grid;
+    grid-template-columns: 6.5rem minmax(0, 1fr);
+    gap: 0.34rem 0.75rem;
+    margin: 0;
+    padding: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.025);
+}
+
+.tracker-profile-confirm-grid dt {
+    color: rgba(255, 255, 255, 0.57);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.tracker-profile-confirm-grid dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 0.8rem;
+    font-weight: 650;
+}
+
+.tracker-profile-choice {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 10px;
+    color: inherit;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015));
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.tracker-profile-choice:not(:disabled):hover,
+.tracker-profile-choice:not(:disabled):focus-visible {
+    border-color: rgba(104, 164, 255, 0.6);
+    background-color: rgba(104, 164, 255, 0.08);
+    outline: none;
+}
+
+.tracker-profile-choice--disabled {
+    cursor: not-allowed;
+    opacity: 0.64;
+}
+
+.tracker-profile-choice-main {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+}
+
+.tracker-profile-choice-title {
+    overflow: hidden;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tracker-profile-choice-id,
+.tracker-profile-choice-meta {
+    color: rgba(255, 255, 255, 0.62);
+    font-size: 0.72rem;
+}
+
+.tracker-profile-choice-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.65rem;
+    margin-top: 0.16rem;
+}
+
+.tracker-profile-mode {
+    color: #acd0ff;
+    font-weight: 700;
+}
+
+.tracker-profile-choice-state {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+}
+
+.tracker-profile-state {
+    padding: 0.08rem 0.38rem;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
+    font-size: 0.65rem;
+    font-weight: 700;
+}
+
+.tracker-profile-state--current {
+    border-color: rgba(87, 194, 142, 0.46);
+    color: #8ce0b8;
+    background: rgba(48, 146, 99, 0.14);
+}
+
+.tracker-profile-state--bound {
+    border-color: rgba(212, 148, 255, 0.4);
+    color: #deb0ff;
+    background: rgba(139, 74, 180, 0.14);
+}
+
+.tracker-profile-state--available {
+    border-color: rgba(111, 166, 255, 0.42);
+    color: #a9cbff;
+    background: rgba(61, 112, 194, 0.13);
+}
+
+@media (max-width: 500px) {
+    .tracker-profile-guidance {
+        grid-template-columns: 1fr;
+    }
+
+    .tracker-profile-choice {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .tracker-profile-choice-state {
+        flex-direction: row;
+    }
+
+    .tracker-profile-confirm-grid {
+        grid-template-columns: 5.5rem minmax(0, 1fr);
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/ConfirmTarkovTrackerKeyActionDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/ConfirmTarkovTrackerKeyActionDialog.razor
@@ -1,0 +1,60 @@
+<MudDialog Class="tracker-settings-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note @(IsDestructive ? "tracker-dialog-note--danger" : "tracker-dialog-note--warning")" role="note">
+            <MudIcon Icon="@Icon" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>@Heading</strong>
+                <span>@Message</span>
+            </span>
+        </div>
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.Key" Size="Size.Small" />
+            <span>API key</span>
+        </div>
+        <dl class="tracker-dialog-detail-card">
+            <div class="tracker-dialog-detail-row">
+                <dt>Mode</dt>
+                <dd><span class="tracker-dialog-mode-badge @ModeBadgeClass">@Mode</span></dd>
+            </div>
+            <div class="tracker-dialog-detail-row">
+                <dt>API key</dt>
+                <dd>@MaskedToken</dd>
+            </div>
+            <div class="tracker-dialog-detail-row">
+                <dt>Account ID</dt>
+                <dd>@AccountId</dd>
+            </div>
+        </dl>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Cancel</MudButton>
+        <MudButton OnClick="Confirm"
+                   Variant="Variant.Filled"
+                   Color="@(IsDestructive ? Color.Error : Color.Warning)"
+                   StartIcon="@Icon"
+                   Class="tracker-dialog-footer-button">@ConfirmLabel</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string Heading { get; set; } = "Confirm this change";
+    [Parameter] public string Message { get; set; } = "Check the API key details before continuing.";
+    [Parameter] public string Mode { get; set; } = "";
+    [Parameter] public string MaskedToken { get; set; } = "";
+    [Parameter] public string AccountId { get; set; } = "";
+    [Parameter] public string ConfirmLabel { get; set; } = "Confirm";
+    [Parameter] public string Icon { get; set; } = Icons.Material.Filled.Warning;
+    [Parameter] public bool IsDestructive { get; set; }
+
+    private string ModeBadgeClass => Mode.Contains("PVE", StringComparison.OrdinalIgnoreCase)
+        ? "tracker-dialog-mode-badge--pve"
+        : Mode.Contains("Seasonal", StringComparison.OrdinalIgnoreCase)
+            ? "tracker-dialog-mode-badge--seasonal"
+            : "";
+
+    private void Cancel() => MudDialog.Cancel();
+    private void Confirm() => MudDialog.Close(DialogResult.Ok(true));
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/EditTarkovTrackerKeyDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/EditTarkovTrackerKeyDialog.razor
@@ -1,0 +1,131 @@
+<MudDialog Class="tracker-settings-dialog tracker-edit-key-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note tracker-dialog-note--assigned" role="note">
+            <MudIcon Icon="@Icons.Material.Filled.VerifiedUser" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>Linked to this EFT profile.</strong>
+                <span>Tarkov Monitor uses this key when the account, profile, and game mode below are active.</span>
+            </span>
+        </div>
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.Badge" Size="Size.Small" />
+            <span>Binding details</span>
+        </div>
+        <div class="tracker-key-binding-grid" role="group" aria-label="API key binding details">
+            <div class="tracker-key-binding-item">
+                <span class="tracker-key-binding-label">Mode</span>
+                <span class="tracker-key-binding-value"><span class="tracker-dialog-mode-badge @ModeBadgeClass">@Mode</span></span>
+            </div>
+            <div class="tracker-key-binding-item">
+                <span class="tracker-key-binding-label">Account ID</span>
+                <span class="tracker-key-binding-value">@AccountId</span>
+            </div>
+            <div class="tracker-key-binding-item">
+                <span class="tracker-key-binding-label">API key</span>
+                <span class="tracker-key-binding-value tracker-key-edit-token">@MaskedToken</span>
+            </div>
+            <div class="tracker-key-binding-item">
+                <span class="tracker-key-binding-label">Last played</span>
+                <span class="tracker-key-binding-value">@LastPlayed</span>
+            </div>
+            <div class="tracker-key-binding-item tracker-key-binding-item--wide">
+                <span class="tracker-key-binding-label">Profile ID</span>
+                <span class="tracker-key-binding-value">@ProfileId</span>
+            </div>
+            <div class="tracker-key-binding-item tracker-key-binding-item--wide tracker-key-nickname-item">
+                <span class="tracker-key-binding-label">Profile nickname</span>
+                <span class="tracker-key-nickname-value">
+                    <span class="tracker-key-binding-value @(HasProfileNickname ? "" : "tracker-key-binding-value--muted")">
+                        @(HasProfileNickname ? ProfileNickname : "Character name")
+                    </span>
+                    <MudButton OnClick="SetProfileNickname" Variant="Variant.Text" Color="Color.Info" Size="Size.Small" Class="tracker-profile-nickname-button" Disabled="@KeyChangesDisabled">
+                        @(HasProfileNickname ? "Rename" : "Set name")
+                    </MudButton>
+                </span>
+            </div>
+        </div>
+        @if (IsQuarantined)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-3">
+                This key has conflicting or invalid profile information. Remove it and import it again before assigning it.
+            </MudAlert>
+        }
+        @if (KeyChangesDisabled)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-3">@KeyChangesDisabledReason</MudAlert>
+        }
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.Tune" Size="Size.Small" />
+            <span>Manage key</span>
+        </div>
+        <div class="tracker-key-action-grid">
+            <button type="button" class="tracker-key-action" @onclick="Reassign" disabled="@(IsQuarantined || KeyChangesDisabled)" title="@ReassignTitle">
+                <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Size="Size.Small" Class="tracker-key-action__icon" />
+                <span class="tracker-key-action__copy">
+                    <span class="tracker-key-action__title">Reassign</span>
+                <span class="tracker-key-action__description">Move this key and its nickname, or swap it with the key already there.</span>
+                </span>
+            </button>
+            <button type="button" class="tracker-key-action tracker-key-action--warning" @onclick="Unbind" disabled="@KeyChangesDisabled" title="@(KeyChangesDisabled ? KeyChangesDisabledReason : "Keep this key saved, but stop using it")">
+                <MudIcon Icon="@Icons.Material.Filled.LinkOff" Size="Size.Small" Class="tracker-key-action__icon" />
+                <span class="tracker-key-action__copy">
+                    <span class="tracker-key-action__title">Unbind</span>
+                    <span class="tracker-key-action__description">Keep the key saved, but stop using it.</span>
+                </span>
+            </button>
+            <button type="button" class="tracker-key-action tracker-key-action--danger" @onclick="Remove" disabled="@KeyChangesDisabled" title="@(KeyChangesDisabled ? KeyChangesDisabledReason : "Delete this saved key from this PC")">
+                <MudIcon Icon="@Icons.Material.Filled.DeleteOutline" Size="Size.Small" Class="tracker-key-action__icon" />
+                <span class="tracker-key-action__copy">
+                    <span class="tracker-key-action__title">Remove</span>
+                    <span class="tracker-key-action__description">Delete this saved key from this PC.</span>
+                </span>
+            </button>
+        </div>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    public enum KeyAction
+    {
+        Reassign,
+        SetProfileNickname,
+        Unbind,
+        Remove,
+    }
+
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string Mode { get; set; } = "";
+    [Parameter] public string MaskedToken { get; set; } = "";
+    [Parameter] public string AccountId { get; set; } = "";
+    [Parameter] public string ProfileId { get; set; } = "";
+    [Parameter] public string ProfileNickname { get; set; } = "";
+    [Parameter] public string LastPlayed { get; set; } = "Unknown";
+    [Parameter] public bool IsQuarantined { get; set; }
+    [Parameter] public bool KeyChangesDisabled { get; set; }
+    [Parameter] public string KeyChangesDisabledReason { get; set; } = "Saved key storage must be repaired before this action is available.";
+
+    private string ModeBadgeClass => Mode.Contains("PVE", StringComparison.OrdinalIgnoreCase)
+        ? "tracker-dialog-mode-badge--pve"
+        : Mode.Contains("Seasonal", StringComparison.OrdinalIgnoreCase)
+            ? "tracker-dialog-mode-badge--seasonal"
+            : "";
+
+    private bool HasProfileNickname => !string.IsNullOrWhiteSpace(ProfileNickname);
+    private string ReassignTitle => KeyChangesDisabled
+        ? KeyChangesDisabledReason
+        : IsQuarantined
+            ? "Repair or remove this invalid binding before reassigning it"
+            : "Move this key to another saved profile, or swap it with a key already assigned there";
+
+    private void Close() => MudDialog.Close();
+    private void Reassign() => MudDialog.Close(DialogResult.Ok(KeyAction.Reassign));
+    private void SetProfileNickname() => MudDialog.Close(DialogResult.Ok(KeyAction.SetProfileNickname));
+    private void Unbind() => MudDialog.Close(DialogResult.Ok(KeyAction.Unbind));
+    private void Remove() => MudDialog.Close(DialogResult.Ok(KeyAction.Remove));
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/EditTarkovTrackerKeyDialog.razor.css
+++ b/TarkovMonitor/Blazor/Pages/Settings/EditTarkovTrackerKeyDialog.razor.css
@@ -1,0 +1,91 @@
+.tracker-key-binding-grid {
+    display: grid;
+    overflow: hidden;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin: 0;
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 11px;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.038), rgba(0, 0, 0, 0.11));
+}
+
+.tracker-key-binding-item {
+    display: flex;
+    min-width: 0;
+    min-height: 1.68rem;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0;
+    padding: 0.08rem 0.5rem;
+    border-right: 1px solid rgba(255, 255, 255, 0.065);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.065);
+}
+
+.tracker-key-binding-item:nth-child(2n) {
+    border-right: 0;
+}
+
+.tracker-key-binding-item--wide {
+    grid-column: 1 / -1;
+    border-right: 0;
+    border-bottom: 0;
+}
+
+.tracker-key-binding-label {
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.64rem;
+    font-weight: 650;
+}
+
+.tracker-key-binding-value {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 0.73rem;
+    font-weight: 650;
+}
+
+.tracker-key-binding-value--muted {
+    color: rgba(255, 255, 255, 0.46);
+    font-weight: 500;
+}
+
+.tracker-key-nickname-item {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.tracker-key-nickname-value {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+}
+
+.tracker-key-edit-token {
+    font-family: Consolas, monospace;
+    letter-spacing: 0.03em;
+}
+
+@media (max-width: 440px) {
+    .tracker-key-binding-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .tracker-key-binding-item,
+    .tracker-key-binding-item:nth-child(2n) {
+        grid-column: 1;
+        border-right: 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.065);
+    }
+
+    .tracker-key-binding-item--wide {
+        border-bottom: 0;
+    }
+
+    .tracker-key-nickname-item {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/ImportTarkovTrackerKeyDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/ImportTarkovTrackerKeyDialog.razor
@@ -1,0 +1,165 @@
+@implements IDisposable
+@inject MessageLog MessageLog
+
+<MudDialog Class="tracker-settings-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note" role="note">
+            <MudIcon Icon="@Icons.Material.Filled.Key" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>Add a TarkovTracker.org API key.</strong>
+                <span>Tarkov Monitor verifies the key and identifies its game mode before saving it as Unassigned.</span>
+            </span>
+        </div>
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.VpnKey" Size="Size.Small" />
+            <span>API key</span>
+        </div>
+        <div class="tracker-dialog-form-card">
+            <MudTextField @bind-Value="apiKey"
+                          Immediate="true"
+                          Label="TarkovTracker.org API key"
+                          InputType="@passwordInput"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          Disabled="@(saving || cooldownSeconds > 0)"
+                          Adornment="Adornment.End"
+                          AdornmentIcon="@passwordIcon"
+                          OnAdornmentClick="ToggleKeyVisibility" />
+            <span class="tracker-dialog-field-help">Paste the full key exactly as copied from TarkovTracker.org.</span>
+        </div>
+        @if (!string.IsNullOrWhiteSpace(errorMessage))
+        {
+            <MudAlert Severity="@messageSeverity" Dense="true" Class="mt-2">@errorMessage</MudAlert>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Disabled="@saving" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Cancel</MudButton>
+        <MudButton Color="Color.Info" Variant="Variant.Filled" OnClick="Save" Disabled="@(saving || cooldownSeconds > 0 || string.IsNullOrWhiteSpace(apiKey))" StartIcon="@Icons.Material.Filled.Verified" Class="tracker-dialog-footer-button">
+            @if (saving)
+            {
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                <span>Verifying</span>
+            }
+            else if (cooldownSeconds > 0)
+            {
+                <span>@($"Try again in {cooldownSeconds}s")</span>
+            }
+            else
+            {
+                <span>Verify and save</span>
+            }
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+    [Parameter] public string InitialApiKey { get; set; } = "";
+
+    private string apiKey = "";
+    private string errorMessage = "";
+    private Severity messageSeverity = Severity.Error;
+    private bool saving;
+    private int cooldownSeconds;
+    private CancellationTokenSource? cooldownCancellation;
+    private bool showKey;
+    private InputType passwordInput = InputType.Password;
+    private string passwordIcon = Icons.Material.Filled.VisibilityOff;
+
+    protected override void OnInitialized()
+    {
+        apiKey = InitialApiKey;
+        StartCooldownCountdown();
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void ToggleKeyVisibility()
+    {
+        showKey = !showKey;
+        passwordInput = showKey ? InputType.Text : InputType.Password;
+        passwordIcon = showKey ? Icons.Material.Filled.Visibility : Icons.Material.Filled.VisibilityOff;
+    }
+
+    private async Task Save()
+    {
+        saving = true;
+        errorMessage = "";
+        messageSeverity = Severity.Error;
+        try
+        {
+            var importedToken = await TarkovTracker.ImportOrgToken(apiKey);
+            MudDialog.Close(DialogResult.Ok(importedToken));
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+            messageSeverity = ex is TarkovTracker.DuplicateImportedTokenException
+                ? Severity.Info
+                : Severity.Error;
+            StartCooldownCountdown();
+            if (cooldownSeconds > 0)
+            {
+                var report = string.Join(Environment.NewLine,
+                    "TarkovTracker.org API key validation failed.",
+                    $"UTC time: {DateTimeOffset.UtcNow:O}",
+                    $"Tarkov Monitor version: {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}",
+                    "Operation: Verify and save TarkovTracker.org API key",
+                    "Endpoint: GET https://api.tarkovtracker.org/token",
+                    $"Key type: {TarkovTracker.GetPrefixDisplayName(TarkovTracker.GetTokenPrefix(apiKey))}",
+                    $"Error type: {ex.GetType().Name}",
+                    $"Error: {ex.Message}",
+                    "The API key was intentionally excluded from this report.");
+                MessageLog.AddMessage(report, "exception");
+                errorMessage += " A sanitized error report was added to Messages so you can copy it when reporting the problem.";
+            }
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private void StartCooldownCountdown()
+    {
+        cooldownSeconds = TarkovTracker.GetImportValidationCooldownSeconds();
+        if (cooldownSeconds <= 0 || cooldownCancellation is { IsCancellationRequested: false })
+        {
+            return;
+        }
+
+        cooldownCancellation = new CancellationTokenSource();
+        _ = RunCooldownCountdown(cooldownCancellation.Token);
+    }
+
+    private async Task RunCooldownCountdown(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                cooldownSeconds = TarkovTracker.GetImportValidationCooldownSeconds();
+                await InvokeAsync(StateHasChanged);
+                if (cooldownSeconds <= 0)
+                {
+                    break;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            cooldownCancellation?.Dispose();
+            cooldownCancellation = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        cooldownCancellation?.Cancel();
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/SetTarkovTrackerAccountNicknameDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/SetTarkovTrackerAccountNicknameDialog.razor
@@ -1,0 +1,67 @@
+<MudDialog Class="tracker-settings-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note" role="note">
+            <MudIcon Icon="@Icons.Material.Filled.ManageAccounts" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>@(HasNickname ? "Change this account's nickname." : "Set a nickname for this EFT account.")</strong>
+                <span>This nickname identifies Account ID @AccountId and appears on every profile assigned to the account. It does not change your EFT display name.</span>
+            </span>
+        </div>
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" />
+            <span>Account nickname</span>
+        </div>
+        <div class="tracker-dialog-form-card">
+            <MudTextField @bind-Value="nickname"
+                          Immediate="true"
+                          Label="Account nickname"
+                          Placeholder="Main account"
+                          MaxLength="32"
+                          Counter="32"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          AutoFocus="true" />
+            <span class="tracker-dialog-field-help">Use 1-32 characters. You can change it later.</span>
+        </div>
+        @if (!string.IsNullOrWhiteSpace(errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@errorMessage</MudAlert>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Cancel</MudButton>
+        <MudButton Color="Color.Info" Variant="Variant.Filled" OnClick="Save" Disabled="@string.IsNullOrWhiteSpace(nickname)" StartIcon="@Icons.Material.Filled.Save" Class="tracker-dialog-footer-button">
+            @(HasNickname ? "Save name" : "Set name")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string ExistingNickname { get; set; } = "";
+    [Parameter] public string AccountId { get; set; } = "";
+
+    private string nickname = "";
+    private string errorMessage = "";
+    private bool HasNickname => !string.IsNullOrWhiteSpace(ExistingNickname);
+
+    protected override void OnInitialized()
+    {
+        nickname = ExistingNickname;
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Save()
+    {
+        var normalizedNickname = nickname.Trim();
+        if (normalizedNickname.Length is < 1 or > 32 || normalizedNickname.Any(char.IsControl))
+        {
+            errorMessage = "Enter a name between 1 and 32 characters.";
+            return;
+        }
+        MudDialog.Close(DialogResult.Ok(normalizedNickname));
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/SetTarkovTrackerProfileNicknameDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/SetTarkovTrackerProfileNicknameDialog.razor
@@ -1,0 +1,67 @@
+<MudDialog Class="tracker-settings-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note tracker-dialog-note--assigned" role="note">
+            <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>@(HasNickname ? $"Change this {Mode} profile's nickname." : $"Set a nickname for this {Mode} profile.")</strong>
+                <span>If you reassign this API key, the nickname moves with it. Unbinding the key clears the nickname. It does not change your EFT character name.</span>
+            </span>
+        </div>
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" />
+            <span>Profile nickname</span>
+        </div>
+        <div class="tracker-dialog-form-card">
+            <MudTextField @bind-Value="nickname"
+                          Immediate="true"
+                          Label="Profile nickname"
+                          Placeholder="Character name"
+                          MaxLength="32"
+                          Counter="32"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          AutoFocus="true" />
+            <span class="tracker-dialog-field-help">Use 1-32 characters. You can change it while the key remains assigned.</span>
+        </div>
+        @if (!string.IsNullOrWhiteSpace(errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-2">@errorMessage</MudAlert>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Cancel</MudButton>
+        <MudButton Color="Color.Info" Variant="Variant.Filled" OnClick="Save" Disabled="@string.IsNullOrWhiteSpace(nickname)" StartIcon="@Icons.Material.Filled.Save" Class="tracker-dialog-footer-button">
+            @(HasNickname ? "Save name" : "Set name")
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string ExistingNickname { get; set; } = "";
+    [Parameter] public string Mode { get; set; } = "";
+
+    private string nickname = "";
+    private string errorMessage = "";
+    private bool HasNickname => !string.IsNullOrWhiteSpace(ExistingNickname);
+
+    protected override void OnInitialized()
+    {
+        nickname = ExistingNickname;
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void Save()
+    {
+        var normalizedNickname = nickname.Trim();
+        if (normalizedNickname.Length is < 1 or > 32 || normalizedNickname.Any(char.IsControl))
+        {
+            errorMessage = "Enter a name between 1 and 32 characters.";
+            return;
+        }
+        MudDialog.Close(DialogResult.Ok(normalizedNickname));
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -135,7 +135,7 @@
             @if (!IsRetiredTrackerService)
             {
                 <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
-                <span>@LocalizationService.GetString("CurrentProfile"):</span>
+                <span>@LocalizationService.GetString("CurrentProfile"):&nbsp;</span>
                 @if (HasCurrentProfileRoute)
                 {
                     <MudLink Href="@CurrentProfileUrl" Class="tm-profile-link">@CurrentProfileName (@GetProfileTypeDisplayName(GameWatcher.CurrentProfile.Type))</MudLink>

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -6,6 +6,7 @@
 @inject MessageLog messageLog
 @inject IDialogService DialogService
 @inject LocalizationService LocalizationService
+@inject MainBlazorUI WindowHost
 @inject TimersManager timersManager
 @layout AppLayout
 @implements IDisposable
@@ -134,10 +135,197 @@
             @if (!IsRetiredTrackerService)
             {
                 <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
-                <MudButton @onclick="TestToken" Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
                 <span>@LocalizationService.GetString("CurrentProfile"):</span>
                 <MudLink Href="@CurrentProfileUrl">@CurrentProfileName (@GameWatcher.CurrentProfile.Type)</MudLink>
-                <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
+                <MudText Typo="Typo.body2" Class="tracker-key-intro">Add a TarkovTracker.org API key. Tarkov Monitor verifies the key and its game mode before it can be assigned to an EFT profile.</MudText>
+                @foreach (var warning in TrackerStorageWarnings)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">@warning</MudAlert>
+                }
+                <div class="tracker-key-toolbar">
+                    @if (CanImportOrgKey)
+                    {
+                        <MudButton @onclick="OpenImportTrackerKey" Variant="Variant.Filled" Color="Color.Info" StartIcon="@Icons.Material.Filled.Add" Class="tracker-toolbar-button">Import API Key</MudButton>
+                    }
+                    else
+                    {
+                        <MudTooltip Text="@OrgImportBlockedReason">
+                            <span><MudButton Disabled="true" Variant="Variant.Filled" Color="Color.Info" StartIcon="@Icons.Material.Filled.Add" Class="tracker-toolbar-button">Import API Key</MudButton></span>
+                        </MudTooltip>
+                    }
+                    <MudTooltip Text="@OrgProfileScanHelpText">
+                        <span><MudButton @onclick="ScanOrgProfiles" Variant="Variant.Text" Color="Color.Info" StartIcon="@Icons.Material.Filled.Search" Disabled="@(scanningOrgProfiles || !OrgKeyChangesEnabled)" Class="tracker-toolbar-button">Scan profiles</MudButton></span>
+                    </MudTooltip>
+                </div>
+
+                <div class="tracker-key-manager">
+                    <div class="tracker-state-note tracker-manager-warning" role="note">
+                        <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Size="Size.Small" Class="tracker-state-note-icon" />
+                        <span><b>Tarkov Monitor manages API keys automatically.</b> Only change an assignment if you understand how EFT profiles and game modes are linked.</span>
+                    </div>
+
+                    <div class="tracker-drawer mb-1">
+                        <button type="button" class="tracker-drawer-toggle tracker-drawer-toggle--primary" @onclick="TogglePendingDrawer" aria-expanded="@pendingDrawerExpanded.ToString().ToLowerInvariant()">
+                            <MudIcon Icon="@(pendingDrawerExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Class="tracker-chevron" />
+                            <span class="tracker-drawer-title">Unassigned</span>
+                            <span class="tracker-count-badge">@PendingOrgKeys.Count</span>
+                        </button>
+                        <MudCollapse Expanded="@pendingDrawerExpanded">
+                            <div class="tracker-drawer-content">
+                                <div class="tracker-state-note" role="note">
+                                    <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Class="tracker-state-note-icon" />
+                                    <span><b>Verified, but unassigned.</b> Tarkov Monitor assigns a key automatically when it is the only unassigned key for the active game mode. Otherwise, click Assign to choose the correct EFT profile.</span>
+                                </div>
+                                @if (PendingOrgKeys.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" Class="tracker-empty-state">No unassigned API key is stored.</MudText>
+                                }
+                                @foreach (var key in PendingOrgKeys)
+                                {
+                                    <div class="tracker-pending-card">
+                                        <div class="tracker-key-main">
+                                            <div class="tracker-key-copy">
+                                                <div class="d-flex align-center flex-wrap gap-2">
+                                                    <span class="tracker-mode-badge @ModeBadgeClass(key)">@key.DisplayName</span>
+                                                    <MudText Typo="Typo.body2"><b>Not assigned</b></MudText>
+                                                    <span class="tracker-verification-badge @(key.IsVerified ? "tracker-verification-badge--verified" : "tracker-verification-badge--pending")">
+                                                        @(key.IsVerified ? "Verified" : "Verify on assign")
+                                                    </span>
+                                                </div>
+                                                <MudText Typo="Typo.caption" Class="tracker-token">@key.MaskedToken</MudText>
+                                                @if (key.IsLegacyRecovery)
+                                                {
+                                                    <MudText Typo="Typo.caption">Previously saved TarkovTracker.org key</MudText>
+                                                }
+                                            </div>
+                                            <div class="tracker-key-actions">
+                                                @if (!OrgKeyChangesEnabled || key.IsQuarantined)
+                                                {
+                                                    <MudTooltip Text="@PendingAssignBlockedReason(key)">
+                                                        <span><MudButton Disabled="true" Variant="Variant.Text" Size="Size.Small">Assign</MudButton></span>
+                                                    </MudTooltip>
+                                                }
+                                                else
+                                                {
+                                                    <MudButton @onclick="@(async () => await OpenAssignOrgKey(key, false))" Variant="Variant.Text" Color="Color.Info" Size="Size.Small">Assign</MudButton>
+                                                }
+                                                @if (OrgKeyChangesEnabled)
+                                                {
+                                                    <MudButton @onclick="@(async () => await RemoveOrgKey(key))" Variant="Variant.Text" Color="Color.Error" Size="Size.Small">Remove</MudButton>
+                                                }
+                                                else
+                                                {
+                                                    <MudTooltip Text="@OrgKeyChangesBlockedReason">
+                                                        <span><MudButton Disabled="true" Variant="Variant.Text" Size="Size.Small">Remove</MudButton></span>
+                                                    </MudTooltip>
+                                                }
+                                            </div>
+                                        </div>
+                                        @if (key.HasPendingConflict || key.IsQuarantined)
+                                        {
+                                            <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">@PendingKeyIssue(key)</MudAlert>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        </MudCollapse>
+                    </div>
+
+                    <div class="tracker-drawer">
+                        <button type="button" class="tracker-drawer-toggle tracker-drawer-toggle--primary" @onclick="ToggleBoundDrawer" aria-expanded="@boundDrawerExpanded.ToString().ToLowerInvariant()">
+                            <MudIcon Icon="@(boundDrawerExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Class="tracker-chevron" />
+                            <span class="tracker-drawer-title">Assigned</span>
+                            <span class="tracker-count-badge">@BoundOrgKeys.Count</span>
+                        </button>
+                        <MudCollapse Expanded="@boundDrawerExpanded">
+                            <div class="tracker-drawer-content">
+                                <div class="tracker-state-note" role="note">
+                                    <MudIcon Icon="@Icons.Material.Filled.VerifiedUser" Size="Size.Small" Class="tracker-state-note-icon tracker-state-note-icon--bound" />
+                                    <span><b>Verified and assigned.</b> Nothing else is required. Tarkov Monitor uses the key linked to your active EFT account, profile, and game mode. If it was assigned incorrectly—such as when using multiple EFT accounts—open Edit and choose Reassign. Set or rename account and profile nicknames as needed.</span>
+                                </div>
+                                @if (BoundOrgKeys.Count == 0)
+                                {
+                                    <MudText Typo="Typo.body2" Class="tracker-empty-state">No TarkovTracker.org API keys are assigned.</MudText>
+                                }
+                                else
+                                {
+                                    @if (BoundKeyFilterEnabled)
+                                    {
+                                        <MudTextField @bind-Value="boundKeyFilter" Immediate="true" Label="Filter by nickname or Account ID" Variant="Variant.Outlined" Margin="Margin.Dense" Class="tracker-filter" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+                                    }
+                                    <div class="tracker-account-list">
+                                        @if (BoundOrgKeyGroups.Count == 0)
+                                        {
+                                            <MudText Typo="Typo.body2" Class="tracker-empty-state">No accounts match this filter.</MudText>
+                                        }
+                                        @foreach (var accountGroup in BoundOrgKeyGroups)
+                                        {
+                                            <div class="tracker-account-drawer mb-1">
+                                                <div class="tracker-account-heading">
+                                                    <button type="button" class="tracker-account-toggle" @onclick="@(() => ToggleAccountDrawer(accountGroup.AccountId))" aria-expanded="@IsAccountDrawerExpanded(accountGroup.AccountId).ToString().ToLowerInvariant()">
+                                                        <MudIcon Icon="@(IsAccountDrawerExpanded(accountGroup.AccountId) ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)" Class="tracker-chevron" />
+                                                        <span class="tracker-account-copy">
+                                                            <span class="tracker-account-title">@AccountDrawerTitle(accountGroup)</span>
+                                                            <span class="tracker-account-subtitle">Account ID: @accountGroup.AccountId @CurrentAccountMarker(accountGroup.AccountId)</span>
+                                                        </span>
+                                                    </button>
+                                                    <span class="tracker-mode-summary">
+                                                        @foreach (var key in accountGroup.Keys.OrderBy(key => key.DisplayName, StringComparer.Ordinal))
+                                                        {
+                                                            <span class="tracker-mode-badge @ModeBadgeClass(key)" title="@key.DisplayName" aria-label="@key.DisplayName">@ModeBadgeShortLabel(key)</span>
+                                                        }
+                                                    </span>
+                                                    <div class="tracker-account-actions">
+                                                        <span class="tracker-account-action-slot">
+                                                            <MudButton @onclick="@(async () => await ShowOrgAccountDetails(accountGroup))" Variant="Variant.Text" Size="Size.Small">Details</MudButton>
+                                                        </span>
+                                                        <span class="tracker-account-action-slot">
+                                                            @if (OrgKeyChangesEnabled && CanSetAccountNickname(accountGroup))
+                                                            {
+                                                                <MudButton @onclick="@(async () => await SetOrgAccountNickname(accountGroup))" Variant="Variant.Text" Color="Color.Info" Size="Size.Small">@AccountNicknameAction(accountGroup)</MudButton>
+                                                            }
+                                                            else
+                                                            {
+                                                                <MudTooltip Text="@AccountNicknameBlockedReason(accountGroup)">
+                                                                    <span><MudButton Disabled="true" Variant="Variant.Text" Size="Size.Small">@AccountNicknameAction(accountGroup)</MudButton></span>
+                                                                </MudTooltip>
+                                                            }
+                                                        </span>
+                                                    </div>
+                                                </div>
+                                                <MudCollapse Expanded="@IsAccountDrawerExpanded(accountGroup.AccountId)">
+                                                    <div class="tracker-profile-list">
+                                                        @foreach (var key in accountGroup.Keys.OrderBy(key => key.DisplayName, StringComparer.Ordinal))
+                                                        {
+                                                            <div class="tracker-profile-row">
+                                                                <div class="tracker-key-main">
+                                                                    <div class="tracker-key-copy">
+                                                                        <div class="tracker-profile-identity">
+                                                                            <span class="tracker-mode-badge @ModeBadgeClass(key)">@key.DisplayName</span>
+                                                                            <MudText Typo="Typo.body2"><b>@ProfileRowLabel(key)</b></MudText>
+                                                                            <MudText Typo="Typo.caption" Class="tracker-token">@key.MaskedToken</MudText>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="tracker-key-actions">
+                                                                        <MudButton @onclick="@(async () => await EditOrgKey(key))" Variant="Variant.Text" Color="Color.Info" Size="Size.Small">Edit</MudButton>
+                                                                    </div>
+                                                                </div>
+                                                                @if (key.IsQuarantined)
+                                                                {
+                                                                    <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">This key is inactive because its saved record is ambiguous or invalid.</MudAlert>
+                                                                }
+                                                            </div>
+                                                        }
+                                                    </div>
+                                                </MudCollapse>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        </MudCollapse>
+                    </div>
+                </div>
             }
         </MudPaper>
     </MudItem>
@@ -195,6 +383,18 @@
 
     private Dictionary<int, string> PlaybackDevices;
     private List<(string Code, string Name)> AvailableLanguages = new();
+    private bool BoundKeyFilterEnabled => false;
+    private string boundKeyFilter = "";
+    // Drawer state survives navigation within this process, but is never persisted.
+    private static bool pendingDrawerExpanded;
+    private static bool boundDrawerExpanded;
+    private bool scanningOrgProfiles;
+    private static readonly HashSet<string> expandedAccountIds = new(StringComparer.Ordinal);
+
+    private sealed record OrgAccountGroup(
+        string AccountId,
+        string Nickname,
+        List<TarkovTracker.OrgKeySummary> Keys);
     private TarkovDev.Trader? TraderFence
     {
         get
@@ -511,19 +711,6 @@
         }
     }
 
-    //public bool TestTokenButtonDisabled { get; set; }
-    public bool TestTokenButtonDisabled
-    {
-        get
-        {
-            return TarkovTracker.IsLegacyService || TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id).Length != 22;
-        }
-        set
-        {
-
-        }
-    }
-
     public TimeSpan RunthroughTime
     {
         get
@@ -557,23 +744,6 @@
     }
 
     private string trackerIcon = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg enable-background=\"new 0 0 512.8 512.8\" version=\"1.1\" viewBox=\"0 0 512.8 512.8\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"m101.7 199.7c6.6-11.1 13.6-22 19.8-33.4 2-3.6 3.1-8.3 2.8-12.3-0.6-9.1-2.4-18-3.8-28 9.6 2.5 18.1 5.1 26.9 6.9 2.7 0.6 6.4-0.1 8.5-1.6 16.4-12.1 34.4-20.9 53.9-26.9 2.5-0.8 5.4-3.4 6.4-5.8 12.5-29.3 24.6-58.7 36.9-88 1.1-2.6 2.2-5.1 4-9.3 18.4 44.2 36.3 87.1 53.9 129.3-13.5-2.9-26.6-7.2-40-8.5-53.7-5.2-97.3 14.2-130.1 56.9-5.4 7.1-11.1 12.3-19.5 15.1-6.1 2-11.9 4.8-17.9 7.3-0.6-0.7-1.2-1.2-1.8-1.7z\" fill=\"#818181\"/><path d=\"m1.2 256.9c41.7-17.3 81.9-34 123.3-51.3-0.9 2.7-1.3 4.3-1.9 5.9-26.2 67.8 1.8 143.4 65.7 178 3 1.6 5.7 4.9 7.3 8.1 3.5 7.1 6.2 14.6 10.1 24-8.8-3.6-15.9-6.5-22.9-9.6-4.2-1.9-8.9-3.7-12.2-6.8-10.5-9.9-22.2-10.1-34.9-5.9-3.4 1.1-7.1 1.4-11.5 2.3 1.8-9 3.7-17.2 5-25.5 0.4-2.6-0.3-6-1.9-8-16.3-20.4-27.4-43.2-33.4-68.7-0.6-2.3-3.3-5-5.6-6-26.1-11-52.3-21.8-78.5-32.7-2.3-1-4.7-2.1-8.6-3.8z\" fill=\"#818181\"/><path d=\"m512.8 257.1c-41.1 17.2-80.8 33.7-120.7 50.3 1.8-10.5 4.2-20.3 5-30.3 4.3-54.7-16.3-98.2-60.3-130.5-6-4.4-10.2-9-12.6-15.8-2.3-6.6-5.3-13.1-6.5-21.3 10.3 5.9 20.5 11.8 31 17.5 2.6 1.4 5.9 2.4 8.6 2.1 12.2-1.4 24.3-3.3 37.6-5.3-3 11.3-6 21.6-8.3 32.1-0.6 2.9 0.4 6.6 1.7 9.4 7.7 15.4 15.7 30.7 23.9 45.9 1.3 2.5 3.6 5.3 6.1 6.3 28.3 12.1 56.8 23.8 85.3 35.7 2.6 1 5.1 2.1 9.2 3.9z\" fill=\"#818181\"/><path d=\"m398.3 396.8c-11.1-2.3-21.2-4.6-31.3-6.2-2.6-0.4-6.1 0.3-8.1 1.9-18.2 14.2-38.4 24.5-60.6 30.8-2.4 0.7-5.1 3.2-6.1 5.5-10.7 25.1-21.1 50.4-31.6 75.6-0.9 2.3-2 4.5-3.7 8.4-16-38.5-31.5-75.6-47.2-113.1 10.7 2 20.3 4.4 30.1 5.4 60 6 113.4-22.8 142.3-75.8 1.8-3.4 5.6-6.3 9.1-8.1 6.6-3.4 13.7-5.9 22.3-9.4-2.3 6.2-3.9 10.9-5.8 15.6-1.5 3.7-2.6 7.9-5.1 10.8-13 15.2-11.8 31.9-6.2 49.3 1 2.5 1.2 5.3 1.9 9.3z\" fill=\"#818181\"/><path d=\"m254.2 130.3c73.9 0.3 132.3 59.7 132 134.1-0.3 72-60 130.8-132.4 130.6-73.4-0.2-132.2-59.7-131.9-133.3 0.3-72.4 60.1-131.8 132.3-131.4zm-101.2 212.8c2.3 2.8 4.5 5.8 7.1 8.4 31 31.5 68.6 45.1 112.4 39.2 34.3-4.6 62.3-21.1 83.6-48.7 20.3-25.3 29-54.4 27.2-86.6-5.2-96.2-110.4-153-193.8-104.8-68.5 39.6-86.5 134.4-36.5 192.5z\" fill=\"#818181\"/><path d=\"m153 343.1c9.4 1.7 12.1-2.4 11.3-11.5-0.5-6-3.1-13.5 5.5-17.1 0.9-0.4 1.1-3.3 1.1-5 0.1-11.2-0.1-22.3 0.2-33.5 0-2 2-5.7 2.3-5.6 4.9 1.3 7.4-11.1 13.4-2.4 0.2 0.2 0.6 0.5 0.8 0.5 11.8-0.2 9.3 8.4 9.4 15.3 0.1 10 0 19.9 0 29.9 1 0 2 0.1 3 0.1 1-13.6 1.9-27.2 3.1-40.8 0.2-1.9 1.4-4.8 2.8-5.2 5.2-1.7 5.5-5.3 5.4-9.8-0.1-22-0.2-44 0-66 0.1-6.6 0.9-13.2 2-19.7 0.2-1.3 2.8-2.8 4.5-3.1 4.2-0.7 8.4-0.7 13-1 2.8 9.4 5.9 19.5 8.8 29.7 0.6 2 0.6 4.3 0.6 6.4 0 21 0 42 0.1 63 0 1.7 1.1 3.5 1.7 5.2 0.8-1.8 2.1-3.5 2.2-5.3 0.9-13.4 1.5-26.8 2.2-40.2 0.3-4.6 1.2-8.4 7.5-8.2 6.2 0.3 5.3 4.7 6.1 8.4 2.3 10.1 4.7 20.3 7.2 31.1 0.3-2.2 0.7-4 0.7-5.8 0.1-11.3-0.1-22.7 0.2-34 0.1-2.1 2.3-4 3.4-6.1 1-1.9 2.1-3.9 2.4-6 0.7-5 3.5-5.9 7.3-3.7 4.8 2.7 9.6 5.7 13.9 9.1 1.4 1.1 1.7 4.2 1.7 6.3 0.1 38.3 0 76.6 0.1 115 0 2.1 1.1 4.1 1.7 6.2 0.7-2.1 2.1-4.2 2.1-6.3 0.2-22.3 0.1-44.6 0.1-68.2 6.8 0 13-0.3 19.2 0.2 1.7 0.1 4.4 3 4.4 4.7 0.4 21.3 0.2 42.6 0.5 63.9 0 2 2 4 3.1 6.1 0.9-2 2.6-4 2.7-6 0.2-13.3-0.1-26.7 0.4-40 0.1-2 3-5.4 5.1-5.7 19.8-3.1 19.8-3 19.8 16.9v37c-21.2 27.6-49.3 44.1-83.6 48.7-43.8 5.9-81.4-7.7-112.4-39.2-2.5-2.5-4.7-5.5-7-8.3z\" fill=\"#B4B4B4\"/></svg>";
-    bool tokenShow;
-    InputType PasswordInput = InputType.Password;
-    string PasswordInputIcon = Icons.Material.Filled.VisibilityOff;
-    public string TarkovTrackerToken
-    {
-        get
-        {
-            return TarkovTracker.IsLegacyService ? "" : TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id);
-        }
-        set
-        {
-            if (!TarkovTracker.IsLegacyService)
-            {
-                TarkovTracker.SetToken(GameWatcher.CurrentProfile.Id, value);
-            }
-        }
-    }
     public string TarkovTrackerDomain
     {
         get
@@ -582,35 +752,74 @@
         }
         set
         {
-            if (Properties.Settings.Default.tarkovTrackerDomain == value)
+            var previousDomain = Properties.Settings.Default.tarkovTrackerDomain;
+            var previousServiceName = TarkovTracker.Domains.TryGetValue(previousDomain, out var serviceName)
+                ? serviceName
+                : previousDomain;
+            if (previousDomain == value)
             {
                 return;
             }
-            Properties.Settings.Default.tarkovTrackerDomain = value;
-            TarkovTracker.ResetActiveState();
-            TarkovTracker.InitAPI();
-            Properties.Settings.Default.Save();
-            if (!TarkovTracker.IsLegacyService)
+
+            WindowHost.BeginTrackerStatusTransition();
+            var switchSucceeded = false;
+            try
             {
-                _ = RevalidateTrackerProfile();
+                TarkovTracker.ResetActiveProfile();
+                Properties.Settings.Default.tarkovTrackerDomain = value;
+                TarkovTracker.InitAPI();
+                Properties.Settings.Default.Save();
+                switchSucceeded = true;
+            }
+            catch (Exception switchError)
+            {
+                Properties.Settings.Default.tarkovTrackerDomain = previousDomain;
+                try
+                {
+                    TarkovTracker.InitAPI();
+                    Properties.Settings.Default.Save();
+                    messageLog.AddMessage(
+                        $"Tarkov Tracker service change was canceled and {previousServiceName} was restored: {switchError.Message}",
+                        "warning");
+                }
+                catch (Exception rollbackError)
+                {
+                    TarkovTracker.ResetActiveProfile();
+                    messageLog.AddMessage(
+                        $"Tarkov Tracker service change failed and could not be fully restored. Restart Tarkov Monitor before using Tarkov Tracker. Change error: {switchError.Message} Restore error: {rollbackError.Message}",
+                        "exception");
+                    return;
+                }
+            }
+            finally
+            {
+                WindowHost.CompleteTrackerStatusTransition();
+            }
+
+            if (switchSucceeded || Properties.Settings.Default.tarkovTrackerDomain == previousDomain)
+            {
+                _ = ReactivateCurrentTrackerProfile();
             }
         }
     }
 
-    private async Task RevalidateTrackerProfile()
+    private async Task ReactivateCurrentTrackerProfile()
     {
-        if (string.IsNullOrWhiteSpace(GameWatcher.CurrentProfile.Id))
+        if (!eft.IsGameRunning
+            || !GameWatcher.CurrentProfile.SupportsTarkovTrackerWrites
+            || string.IsNullOrWhiteSpace(GameWatcher.CurrentProfile.Id))
         {
+            TarkovTracker.DeactivateProfile();
             return;
         }
 
         try
         {
-            await TarkovTracker.SetProfile(GameWatcher.CurrentProfile.Id);
+            await TarkovTracker.SetProfile(GameWatcher.CurrentProfile);
         }
         catch (Exception ex)
         {
-            messageLog.AddMessage(ex.Message, "exception");
+            messageLog.AddMessage($"Error changing Tarkov Tracker service: {ex.Message}", "exception");
         }
     }
 
@@ -619,48 +828,522 @@
         "tarkovtracker.io",
         StringComparison.OrdinalIgnoreCase);
 
-    private string CurrentProfileUrl =>
-        $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}";
+    private string CurrentProfileUrl => $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}";
 
-    void TokenShowClick()
+    private IReadOnlyList<TarkovTracker.OrgKeySummary> OrgKeys => TarkovTracker.GetOrgKeys();
+    private IReadOnlyList<string> TrackerStorageWarnings => TarkovTracker.GetStorageWarnings();
+    private bool OrgKeyChangesEnabled => TarkovTracker.CanChangeOrgKeyStorage;
+    private List<TarkovTracker.OrgKeySummary> PendingOrgKeys => OrgKeys.Where(key => !key.IsBound).ToList();
+    private List<TarkovTracker.OrgKeySummary> BoundOrgKeys => OrgKeys.Where(key => key.IsBound).ToList();
+    private const string OrgKeyChangesBlockedReason = "TarkovTracker.org key storage must be repaired before saved keys or profiles can be changed.";
+    private bool CanImportOrgKey => OrgKeyChangesEnabled
+        && (!PendingOrgKeys.Any(key => string.Equals(key.Prefix, "PVE", StringComparison.OrdinalIgnoreCase))
+            || !PendingOrgKeys.Any(key => string.Equals(key.Prefix, "PVP", StringComparison.OrdinalIgnoreCase))
+            || !PendingOrgKeys.Any(key => string.Equals(key.Prefix, "SZN", StringComparison.OrdinalIgnoreCase)));
+    private string OrgImportBlockedReason => OrgKeyChangesEnabled
+        ? "PVE, Regular (PVP), and Seasonal already have unassigned keys."
+        : OrgKeyChangesBlockedReason;
+    private string OrgProfileScanHelpText => OrgKeyChangesEnabled
+        ? "Reads account, profile, mode, and last-played information from past EFT logs. It does not replay tasks."
+        : OrgKeyChangesBlockedReason;
+    private List<OrgAccountGroup> BoundOrgKeyGroups
     {
-        if (tokenShow)
+        get
         {
-            tokenShow = false;
-            PasswordInputIcon = Icons.Material.Filled.VisibilityOff;
-            PasswordInput = InputType.Password;
-        }
-        else
-        {
-            tokenShow = true;
-            PasswordInputIcon = Icons.Material.Filled.Visibility;
-            PasswordInput = InputType.Text;
+            var filter = boundKeyFilter.Trim();
+            return BoundOrgKeys
+                .GroupBy(key => key.AccountId, StringComparer.Ordinal)
+                .Select(group => new OrgAccountGroup(
+                    group.Key,
+                    group.Select(key => key.AccountNickname).FirstOrDefault(nickname => !string.IsNullOrWhiteSpace(nickname)) ?? "",
+                    group.ToList()))
+                .Where(group => string.IsNullOrWhiteSpace(filter)
+                    || group.AccountId.Contains(filter, StringComparison.OrdinalIgnoreCase)
+                    || group.Nickname.Contains(filter, StringComparison.OrdinalIgnoreCase)
+                    || group.Keys.Any(key => key.ProfileNickname.Contains(filter, StringComparison.OrdinalIgnoreCase)))
+                .OrderByDescending(group => string.Equals(group.AccountId, GameWatcher.CurrentProfile.AccountId, StringComparison.Ordinal))
+                .ThenBy(group => group.AccountId, StringComparer.Ordinal)
+                .ToList();
         }
     }
 
-    private async void TestToken()
-    {
-        if (!TarkovTracker.IsSupportedOrgToken(TarkovTrackerToken))
-        {
-            messageLog.AddMessage("Enter a PVE_, PVP_, or SZN_ TarkovTracker.org key followed by its 18-character hexadecimal identifier.", "warning");
-            return;
-        } else {
-            try
-            {
-                var tokenResponse = await TarkovTracker.TestToken(TarkovTrackerToken);
-                if (!tokenResponse.permissions.Contains("WP"))
-                {
-                    messageLog.AddMessage("You do not have write permissions with this token.", "warning");
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                messageLog.AddMessage(ex.Message, "exception");
+    private void TogglePendingDrawer() => pendingDrawerExpanded = !pendingDrawerExpanded;
 
-            }
+    private string PendingAssignBlockedReason(TarkovTracker.OrgKeySummary key)
+    {
+        return OrgKeyChangesEnabled
+            ? "This saved record must be removed or repaired before assignment."
+            : OrgKeyChangesBlockedReason;
+    }
+
+    private static string PendingKeyIssue(TarkovTracker.OrgKeySummary key)
+    {
+        return key.HasPendingConflict
+            ? $"Manual assignment required: more than one {key.DisplayName} key is waiting. Automatic assignment is paused for this mode."
+            : "This key is inactive because its saved record is ambiguous or invalid.";
+    }
+
+    private void ToggleBoundDrawer() => boundDrawerExpanded = !boundDrawerExpanded;
+
+    private void ToggleAccountDrawer(string accountId)
+    {
+        if (!expandedAccountIds.Add(accountId))
+        {
+            expandedAccountIds.Remove(accountId);
+        }
+    }
+
+    private bool IsAccountDrawerExpanded(string accountId)
+    {
+        return !string.IsNullOrWhiteSpace(boundKeyFilter) || expandedAccountIds.Contains(accountId);
+    }
+
+    private static string AccountDrawerTitle(OrgAccountGroup accountGroup)
+    {
+        return string.IsNullOrWhiteSpace(accountGroup.Nickname)
+            ? "No nickname"
+            : accountGroup.Nickname;
+    }
+
+    private static string AccountNicknameAction(OrgAccountGroup accountGroup)
+    {
+        return string.IsNullOrWhiteSpace(accountGroup.Nickname) ? "Set name" : "Rename";
+    }
+
+    private static bool CanSetAccountNickname(OrgAccountGroup accountGroup)
+    {
+        return accountGroup.Keys.Any(key => !key.IsQuarantined);
+    }
+
+    private string AccountNicknameBlockedReason(OrgAccountGroup accountGroup)
+    {
+        return OrgKeyChangesEnabled
+            ? "Repair or remove invalid profile bindings before naming this account."
+            : OrgKeyChangesBlockedReason;
+    }
+
+    private static string ModeBadgeClass(TarkovTracker.OrgKeySummary key)
+    {
+        return key.Prefix.ToUpperInvariant() switch
+        {
+            "PVE" => "tracker-mode-badge--pve",
+            "PVP" => "tracker-mode-badge--pvp",
+            "SZN" => "tracker-mode-badge--seasonal",
+            _ => "tracker-mode-badge--unknown",
+        };
+    }
+
+    private static string ModeBadgeShortLabel(TarkovTracker.OrgKeySummary key)
+    {
+        return key.Prefix.ToUpperInvariant() switch
+        {
+            "PVE" => "PVE",
+            "PVP" => "PVP",
+            "SZN" => "Seasonal",
+            _ => "?",
+        };
+    }
+
+    private async Task OpenImportTrackerKey()
+    {
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<ImportTarkovTrackerKeyDialog>("Import TarkovTracker.org API key", options);
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: TarkovTracker.ImportedToken importedToken })
+        {
+            messageLog.AddMessage(
+                $"Imported and verified the {importedToken.DisplayName} TarkovTracker.org API key. It is ready to assign.",
+                "update");
+            await ReactivateCurrentTrackerProfile();
+            StateHasChanged();
+        }
+    }
+
+    private async Task ScanOrgProfiles()
+    {
+        scanningOrgProfiles = true;
+        try
+        {
+            var discovered = await Task.Run(eft.DiscoverProfiles);
+            var updated = TarkovTracker.SaveDiscoveredOrgProfiles(discovered);
+            messageLog.AddMessage(discovered.Count == 0
+                ? "No EFT profiles were found in past logs. Launch EFT once, then scan again."
+                : $"Found {discovered.Count} EFT profile{(discovered.Count == 1 ? "" : "s")} in past logs and updated {updated} saved profile record{(updated == 1 ? "" : "s")}.",
+                discovered.Count == 0 ? "warning" : "update");
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Could not scan EFT profiles: {ex.Message}", "exception");
+        }
+        finally
+        {
+            scanningOrgProfiles = false;
+        }
+        StateHasChanged();
+    }
+
+    private async Task OpenAssignOrgKey(TarkovTracker.OrgKeySummary key, bool reassign)
+    {
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var parameters = new DialogParameters
+        {
+            [nameof(AssignTarkovTrackerKeyDialog.KeyPrefix)] = key.Prefix,
+            [nameof(AssignTarkovTrackerKeyDialog.KeyDisplayName)] = key.DisplayName,
+            [nameof(AssignTarkovTrackerKeyDialog.KeyIsBound)] = key.IsBound,
+            [nameof(AssignTarkovTrackerKeyDialog.RequiresVerification)] = !key.IsVerified,
+            [nameof(AssignTarkovTrackerKeyDialog.BoundAccountId)] = key.AccountId,
+            [nameof(AssignTarkovTrackerKeyDialog.BoundProfileId)] = key.ProfileId,
+            [nameof(AssignTarkovTrackerKeyDialog.BoundSessionMode)] = key.SessionMode,
+            [nameof(AssignTarkovTrackerKeyDialog.ProfileNickname)] = key.ProfileNickname,
+            [nameof(AssignTarkovTrackerKeyDialog.IsReassign)] = reassign,
+        };
+        var dialog = await DialogService.ShowAsync<AssignTarkovTrackerKeyDialog>(
+            $"{(reassign ? "Reassign" : "Assign")} {key.DisplayName} API key",
+            parameters,
+            options);
+        var result = await dialog.Result;
+        if (result is not { Canceled: false, Data: TarkovTracker.OrgProfileSummary profile })
+        {
+            return;
         }
 
+        var willSwap = reassign && profile.HasBoundKey;
+        var action = willSwap ? "Swap" : reassign ? "Reassign" : "Assign";
+        try
+        {
+            TarkovTracker.OrgKeySummary assignedKey;
+            if (reassign)
+            {
+                var reassignment = TarkovTracker.ReassignOrgKey(key.Id, profile.AccountId, profile.ProfileId, profile.SessionMode);
+                assignedKey = reassignment.Key;
+                if (reassignment.SwappedKey == null)
+                {
+                    var nicknameNotice = string.IsNullOrWhiteSpace(assignedKey.ProfileNickname) ? "" : " Its profile nickname moved with the key.";
+                    AddProtectedKeyMessage(
+                        $"Reassigned the verified {assignedKey.DisplayName} TarkovTracker.org API key.{nicknameNotice}",
+                        ("Previous Account ID", key.AccountId),
+                        ("Previous Profile ID", key.ProfileId),
+                        ("New Account ID", assignedKey.AccountId),
+                        ("New Profile ID", assignedKey.ProfileId));
+                }
+                else
+                {
+                    var nicknameNotice = string.IsNullOrWhiteSpace(assignedKey.ProfileNickname)
+                        && string.IsNullOrWhiteSpace(reassignment.SwappedKey.ProfileNickname)
+                            ? ""
+                            : " Profile nicknames moved with their keys.";
+                    AddProtectedKeyMessage(
+                        $"Swapped the verified {assignedKey.DisplayName} TarkovTracker.org API keys between the two saved profiles.{nicknameNotice}",
+                        ("First Account ID", key.AccountId),
+                        ("First Profile ID", key.ProfileId),
+                        ("Second Account ID", assignedKey.AccountId),
+                        ("Second Profile ID", assignedKey.ProfileId));
+                }
+            }
+            else
+            {
+                assignedKey = await TarkovTracker.AssignOrgKey(key.Id, profile.AccountId, profile.ProfileId, profile.SessionMode);
+                AddProtectedKeyMessage(
+                    $"Assigned the verified {assignedKey.DisplayName} TarkovTracker.org API key manually.",
+                    ("Account ID", assignedKey.AccountId),
+                    ("Profile ID", assignedKey.ProfileId));
+            }
+
+            pendingDrawerExpanded = PendingOrgKeys.Count > 0;
+            boundDrawerExpanded = true;
+            expandedAccountIds.Add(assignedKey.AccountId);
+            await ReactivateCurrentTrackerProfile();
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Could not {action.ToLowerInvariant()} the TarkovTracker.org API key: {ex.Message}", "exception");
+        }
+        StateHasChanged();
+    }
+
+    private async Task SetOrgAccountNickname(OrgAccountGroup accountGroup)
+    {
+        var parameters = new DialogParameters
+        {
+            [nameof(SetTarkovTrackerAccountNicknameDialog.ExistingNickname)] = accountGroup.Nickname,
+            [nameof(SetTarkovTrackerAccountNicknameDialog.AccountId)] = accountGroup.AccountId,
+        };
+        var title = string.IsNullOrWhiteSpace(accountGroup.Nickname) ? "Set account nickname" : "Change account nickname";
+        var dialog = await DialogService.ShowAsync<SetTarkovTrackerAccountNicknameDialog>(
+            title,
+            parameters,
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+        var result = await dialog.Result;
+        if (result is not { Canceled: false, Data: string nickname })
+        {
+            return;
+        }
+
+        try
+        {
+            var savedNickname = TarkovTracker.SetOrgAccountNickname(accountGroup.AccountId, nickname);
+            AddProtectedKeyMessage($"Saved the TarkovTracker.org account nickname “{savedNickname}”.", ("Account ID", accountGroup.AccountId));
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Could not save the account nickname: {ex.Message}", "exception");
+        }
+        StateHasChanged();
+    }
+
+    private async Task SetOrgProfileNickname(TarkovTracker.OrgKeySummary key)
+    {
+        var parameters = new DialogParameters
+        {
+            [nameof(SetTarkovTrackerProfileNicknameDialog.ExistingNickname)] = key.ProfileNickname,
+            [nameof(SetTarkovTrackerProfileNicknameDialog.Mode)] = key.DisplayName,
+        };
+        var title = string.IsNullOrWhiteSpace(key.ProfileNickname)
+            ? $"Set {key.DisplayName} profile nickname"
+            : $"Change {key.DisplayName} profile nickname";
+        var dialog = await DialogService.ShowAsync<SetTarkovTrackerProfileNicknameDialog>(
+            title,
+            parameters,
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+        var result = await dialog.Result;
+        if (result is not { Canceled: false, Data: string nickname })
+        {
+            return;
+        }
+
+        try
+        {
+            var savedNickname = TarkovTracker.SetOrgProfileNickname(key.Id, nickname);
+            AddProtectedKeyMessage(
+                $"Saved the {key.DisplayName} profile nickname “{savedNickname}”.",
+                ("Account ID", key.AccountId),
+                ("Profile ID", key.ProfileId));
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Could not save the profile nickname: {ex.Message}", "exception");
+        }
+        StateHasChanged();
+    }
+
+    private async Task UnbindOrgKey(TarkovTracker.OrgKeySummary key)
+    {
+        if (!await ConfirmOrgKeyAction(
+            key,
+            $"Unbind {key.DisplayName} API key",
+            "Keep the key, but stop using it.",
+            string.IsNullOrWhiteSpace(key.ProfileNickname)
+                ? "The key will remain saved and move to Unassigned. You can assign it again later."
+                : "The key will remain saved and move to Unassigned. Its profile nickname will be cleared.",
+            "Unbind",
+            Icons.Material.Filled.LinkOff,
+            false))
+        {
+            return;
+        }
+
+        try
+        {
+            TarkovTracker.UnbindOrgKey(key.Id);
+            var nicknameNotice = string.IsNullOrWhiteSpace(key.ProfileNickname) ? "" : " Its profile nickname was cleared.";
+            AddProtectedKeyMessage(
+                $"Moved the verified {key.DisplayName} TarkovTracker.org API key to Unassigned.{nicknameNotice}",
+                ("Previous Account ID", key.AccountId),
+                ("Previous Profile ID", key.ProfileId));
+            pendingDrawerExpanded = true;
+            await ReactivateCurrentTrackerProfile();
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Could not unbind the TarkovTracker.org API key: {ex.Message}", "exception");
+        }
+        StateHasChanged();
+    }
+
+    private async Task RemoveOrgKey(TarkovTracker.OrgKeySummary key)
+    {
+        if (!await ConfirmOrgKeyAction(
+            key,
+            $"Remove {key.DisplayName} API key",
+            "Delete this API key?",
+            "This removes the key from Tarkov Monitor on this PC. To restore it, you will need to import it again.",
+            "Remove",
+            Icons.Material.Filled.DeleteOutline,
+            true))
+        {
+            return;
+        }
+
+        try
+        {
+            if (!TarkovTracker.RemoveOrgKey(key.Id))
+            {
+                messageLog.AddMessage("This TarkovTracker.org API key has already been removed.", "warning");
+                return;
+            }
+            if (key.IsBound)
+            {
+                AddProtectedKeyMessage(
+                    $"Removed the verified {key.DisplayName} TarkovTracker.org API key from Tarkov Monitor.",
+                    ("Previous Account ID", key.AccountId),
+                    ("Previous Profile ID", key.ProfileId));
+            }
+            else
+            {
+                var verificationState = key.IsVerified ? "verified" : "unverified recovered";
+                messageLog.AddMessage($"Removed the {verificationState} unassigned {key.DisplayName} TarkovTracker.org API key.", "update");
+            }
+            await ReactivateCurrentTrackerProfile();
+        }
+        catch (Exception ex)
+        {
+            messageLog.AddMessage($"Could not remove the TarkovTracker.org API key: {ex.Message}", "exception");
+        }
+        StateHasChanged();
+    }
+
+    private async Task<bool> ConfirmOrgKeyAction(
+        TarkovTracker.OrgKeySummary key,
+        string title,
+        string heading,
+        string message,
+        string confirmLabel,
+        string icon,
+        bool isDestructive)
+    {
+        var parameters = new DialogParameters
+        {
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.Heading)] = heading,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.Message)] = message,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.Mode)] = key.DisplayName,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.MaskedToken)] = key.MaskedToken,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.AccountId)] = key.AccountId,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.ConfirmLabel)] = confirmLabel,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.Icon)] = icon,
+            [nameof(ConfirmTarkovTrackerKeyActionDialog.IsDestructive)] = isDestructive,
+        };
+        var dialog = await DialogService.ShowAsync<ConfirmTarkovTrackerKeyActionDialog>(
+            title,
+            parameters,
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+        var result = await dialog.Result;
+        return result is { Canceled: false, Data: true };
+    }
+
+    private async Task EditOrgKey(TarkovTracker.OrgKeySummary key)
+    {
+        var savedProfile = TarkovTracker.GetKnownOrgProfiles().FirstOrDefault(profile =>
+            string.Equals(profile.AccountId, key.AccountId, StringComparison.Ordinal)
+            && string.Equals(profile.ProfileId, key.ProfileId, StringComparison.Ordinal)
+            && profile.SessionMode == key.SessionMode);
+        var lastPlayed = savedProfile?.LastSeenUtc is { } lastSeen
+            ? lastSeen.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+            : "Unknown";
+        var parameters = new DialogParameters
+        {
+            [nameof(EditTarkovTrackerKeyDialog.Mode)] = key.DisplayName,
+            [nameof(EditTarkovTrackerKeyDialog.MaskedToken)] = key.MaskedToken,
+            [nameof(EditTarkovTrackerKeyDialog.AccountId)] = key.AccountId,
+            [nameof(EditTarkovTrackerKeyDialog.ProfileId)] = key.ProfileId,
+            [nameof(EditTarkovTrackerKeyDialog.ProfileNickname)] = key.ProfileNickname,
+            [nameof(EditTarkovTrackerKeyDialog.LastPlayed)] = lastPlayed,
+            [nameof(EditTarkovTrackerKeyDialog.IsQuarantined)] = key.IsQuarantined,
+            [nameof(EditTarkovTrackerKeyDialog.KeyChangesDisabled)] = !OrgKeyChangesEnabled,
+            [nameof(EditTarkovTrackerKeyDialog.KeyChangesDisabledReason)] = OrgKeyChangesBlockedReason,
+        };
+        var dialog = await DialogService.ShowAsync<EditTarkovTrackerKeyDialog>(
+            $"Edit {key.DisplayName} API key",
+            parameters,
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+        var result = await dialog.Result;
+        if (result is not { Canceled: false, Data: EditTarkovTrackerKeyDialog.KeyAction action })
+        {
+            return;
+        }
+
+        switch (action)
+        {
+            case EditTarkovTrackerKeyDialog.KeyAction.Reassign:
+                await OpenAssignOrgKey(key, true);
+                break;
+            case EditTarkovTrackerKeyDialog.KeyAction.SetProfileNickname:
+                await SetOrgProfileNickname(key);
+                break;
+            case EditTarkovTrackerKeyDialog.KeyAction.Unbind:
+                await UnbindOrgKey(key);
+                break;
+            case EditTarkovTrackerKeyDialog.KeyAction.Remove:
+                await RemoveOrgKey(key);
+                break;
+        }
+    }
+
+    private async Task ShowOrgAccountDetails(OrgAccountGroup accountGroup)
+    {
+        var nickname = string.IsNullOrWhiteSpace(accountGroup.Nickname) ? "Not set" : accountGroup.Nickname;
+        var modes = string.Join(", ", accountGroup.Keys
+            .Select(key => key.DisplayName)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(mode => mode, StringComparer.Ordinal));
+        var parameters = new DialogParameters
+        {
+            [nameof(TarkovTrackerDetailsDialog.Details)] = new List<KeyValuePair<string, string>>
+            {
+                new("Account nickname", nickname),
+                new("Account ID", accountGroup.AccountId),
+                new("Assigned profiles", accountGroup.Keys.Count.ToString()),
+                new("Modes", modes),
+            },
+        };
+        var dialog = await DialogService.ShowAsync<TarkovTrackerDetailsDialog>(
+            "EFT account details",
+            parameters,
+            new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true });
+        await dialog.Result;
+    }
+
+    private void AddProtectedKeyMessage(string message, params (string Label, string Value)[] protectedValues)
+    {
+        messageLog.AddProtectedMessage(
+            message,
+            "update",
+            protectedValues.Select(value => new MonitorMessageProtectedValue(value.Label, value.Value)));
+    }
+
+    private static string CurrentAccountMarker(string accountId)
+    {
+        return string.Equals(accountId, GameWatcher.CurrentProfile.AccountId, StringComparison.Ordinal)
+            ? "• Current account"
+            : "";
+    }
+
+    private static string ActiveKeyMarker(TarkovTracker.OrgKeySummary key)
+    {
+        if (!TarkovTracker.IsLegacyService
+            && TarkovTracker.ValidToken
+            && string.Equals(key.AccountId, TarkovTracker.CurrentAccountId, StringComparison.Ordinal)
+            && string.Equals(key.ProfileId, TarkovTracker.CurrentProfileId, StringComparison.Ordinal)
+            && key.SessionMode == TarkovTracker.CurrentSessionMode)
+        {
+            return "• Active profile";
+        }
+
+        return string.Equals(key.AccountId, GameWatcher.CurrentProfile.AccountId, StringComparison.Ordinal)
+            && string.Equals(key.ProfileId, GameWatcher.CurrentProfile.Id, StringComparison.Ordinal)
+            && key.SessionMode == GameWatcher.CurrentProfile.SessionMode
+            && string.IsNullOrWhiteSpace(TarkovTracker.GetToken(key.ProfileId))
+            ? "• Last active profile"
+            : "";
+    }
+
+    private static string ProfileRowLabel(TarkovTracker.OrgKeySummary key)
+    {
+        var marker = ActiveKeyMarker(key);
+        if (string.IsNullOrWhiteSpace(key.ProfileNickname))
+        {
+            return marker;
+        }
+        return string.IsNullOrWhiteSpace(marker) ? key.ProfileNickname : $"{key.ProfileNickname} {marker}";
     }
 
     private void OpenTrackerSettings() {

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -885,6 +885,10 @@
         {
             await TarkovTracker.SetProfile(GameWatcher.CurrentProfile);
         }
+        catch (ProfileActivationSupersededException)
+        {
+            // A newer profile/key/mode activation owns the result.
+        }
         catch (Exception ex)
         {
             messageLog.AddException("Tarkov Tracker profile could not be loaded.", "TM-API-TRACKER-005", "SetProfile", ex, "TarkovTracker", "Profile", $"https://{TarkovTrackerDomain}", DiagnosticsService.ElapsedMilliseconds(startedUtc));

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -6,83 +6,17 @@
 @inject MessageLog messageLog
 @inject IDialogService DialogService
 @inject LocalizationService LocalizationService
-@inject MainBlazorUI WindowHost
 @inject TimersManager timersManager
+@inject MainBlazorUI WindowHost
 @layout AppLayout
 @implements IDisposable
 
 <MudGrid Class="settings-grid pa-0" Spacing="0">
-    <MudItem xs="12">
+    <MudItem xs="12" lg="6" xl="4">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Notifications" Class="mr-2" />@LocalizationService.GetString("Notifications")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Language" Class="mr-2"/><span class="tm-card-heading-text">@LocalizationService.GetString("Language")</span></MudText>
             <div>
-                <MudSelect @bind-Value="@AudioOutputDeviceSelect" T="int" Label="@LocalizationService.GetString("NotificationsPlaybackDevice")" AnchorOrigin="Origin.BottomCenter" xs="3">
-                    @foreach (var device in PlaybackDevices)
-                    {
-                        <MudSelectItem T="int" Value="@device.Key">@device.Value</MudSelectItem>
-                    }
-                </MudSelect>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@RaidStartSwitch" Label="@LocalizationService.GetString("RaidStartingAudioNotification")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRaidStart" Class="d-inline-flex mt-1" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@MatchFoundSwitch" Label="@LocalizationService.GetString("MatchFoundAudioNotification")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayMatchFound" Class="d-inline-flex" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@RestartTaskSwitch" Label="@LocalizationService.GetString("RestartTasksAudioReminder")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRestartTask" Class="d-inline-flex" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@RunthroughSwitch" Label="@LocalizationService.GetString("RunthroughPeriodAudioReminder")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRunthrough" Class="d-inline-flex" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@AirFilterSwitch" Label="@LocalizationService.GetString("AirFilterAudioReminders")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayAirFilters" Class="d-inline-flex" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@QuestItemsSwitch" Label="@LocalizationService.GetString("QuestItemReminderAudioNotification")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayQuestItems" Class="d-inline-flex mt-1" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-            </div>
-            <div>
-                <MudSwitch @bind-Value="@ScavCooldownSwitch" Label="@LocalizationService.GetString("ScavCooldownReminders")" Color="Color.Info" Class="d-inline-flex" xs="3" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayScavAvailable" Class="d-inline-flex" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
-                <MudSelect @bind-Value="@ScavKarmaSelect" T="int" Label="@LocalizationService.GetString("ScavKarma")" AnchorOrigin="Origin.BottomCenter" Class="d-inline-flex" xs="3">
-                    @if (TraderFence != null)
-                    {
-                        @foreach (TarkovDev.TraderReputationLevel lvl in TraderFence.reputationLevels)
-                        {
-                            <MudSelectItem Value="@lvl.minimumReputation" />
-                        }
-                    }
-                </MudSelect>
-            </div>
-            <div>
-                <MudTextField @bind-Value="@RunthroughTime" Label="@LocalizationService.GetString("RunthroughTime")" Class="d-inline-flex" sx="3" />
-            </div>
-        </MudPaper>
-    </MudItem>
-
-    <MudItem xs="12">
-        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" />Timers</MudText>
-            <MudSwitch @bind-Value="@FloatingTimerPanelSwitch" Label="Show floating time-in-raid panel" Color="Color.Info" />
-            <MudText Typo="Typo.caption">Shows a movable timer inside Tarkov Monitor after deployment finishes. It is hidden while viewing the Timers tab.</MudText>
-            <MudText Typo="Typo.subtitle2" Class="mt-3">Displayed timers</MudText>
-            <MudSwitch @bind-Value="@FloatingTimerShowTimeInRaidSwitch" Label="Elapsed raid time" Color="Color.Info" Class="ml-4" />
-            <MudSwitch @bind-Value="@FloatingTimerShowRunThroughSwitch" Label="Run-through remaining" Color="Color.Info" Class="ml-4" />
-            <MudText Typo="Typo.caption">At least one timer must remain selected. Scav cooldown is not currently available in the floating panel.</MudText>
-        </MudPaper>
-    </MudItem>
-
-    <MudItem xs="12">
-        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Language" Class="mr-2"/>@LocalizationService.GetString("Language")</MudText>
-            <div>
-                <MudSelect @bind-Value="@SelectedLanguage" T="string" Label="@LocalizationService.GetString("SelectLanguage")" AnchorOrigin="Origin.BottomCenter" xs="6">
+                <MudSelect @bind-Value="@SelectedLanguage" T="string" Label="@LocalizationService.GetString("SelectLanguage")" RelativeWidth="DropdownWidth.Adaptive" AnchorOrigin="Origin.BottomLeft" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--field" PopoverClass="tm-select-popover" ListClass="tm-select-list" xs="6">
                     @foreach (var language in AvailableLanguages)
                     {
                         <MudSelectItem T="string" Value="@language.Code">@language.Name</MudSelectItem>
@@ -92,9 +26,9 @@
         </MudPaper>
     </MudItem>
 
-    <MudItem xs="12">
+    <MudItem xs="12" lg="6" xl="4">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Window" Class="mr-2"/>@LocalizationService.GetString("WindowBehavior")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Window" Class="mr-2"/><span class="tm-card-heading-text">@LocalizationService.GetString("WindowBehavior")</span></MudText>
             <div>
                 <MudSwitch @bind-Value="@MinimizeAtStartupSwitch" Label="@LocalizationService.GetString("StartTarkovMonitorMinimized")" Color="Color.Info" />
             </div>
@@ -110,6 +44,72 @@
         </MudPaper>
     </MudItem>
 
+    <MudItem xs="12" lg="6" xl="4">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Notifications" Class="mr-2" /><span class="tm-card-heading-text">@LocalizationService.GetString("Notifications")</span></MudText>
+            <div>
+                <MudSelect @bind-Value="@AudioOutputDeviceSelect" T="int" Label="@LocalizationService.GetString("NotificationsPlaybackDevice")" RelativeWidth="DropdownWidth.Adaptive" AnchorOrigin="Origin.BottomLeft" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--field" PopoverClass="tm-select-popover" ListClass="tm-select-list" xs="3">
+                    @foreach (var device in PlaybackDevices)
+                    {
+                        <MudSelectItem T="int" Value="@device.Key">@device.Value</MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRaidStart" Class="d-inline-flex mr-2 mt-1" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@RaidStartSwitch" Label="@LocalizationService.GetString("RaidStartingAudioNotification")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayMatchFound" Class="d-inline-flex mr-2" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@MatchFoundSwitch" Label="@LocalizationService.GetString("MatchFoundAudioNotification")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRestartTask" Class="d-inline-flex mr-2" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@RestartTaskSwitch" Label="@LocalizationService.GetString("RestartTasksAudioReminder")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRunthrough" Class="d-inline-flex mr-2" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@RunthroughSwitch" Label="@LocalizationService.GetString("RunthroughPeriodAudioReminder")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayAirFilters" Class="d-inline-flex mr-2" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@AirFilterSwitch" Label="@LocalizationService.GetString("AirFilterAudioReminders")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayQuestItems" Class="d-inline-flex mr-2 mt-1" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@QuestItemsSwitch" Label="@LocalizationService.GetString("QuestItemReminderAudioNotification")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+            </div>
+            <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayScavAvailable" Class="d-inline-flex mr-2" xs="3"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
+                <MudSwitch @bind-Value="@ScavCooldownSwitch" Label="@LocalizationService.GetString("ScavCooldownReminders")" Color="Color.Info" Class="d-inline-flex" xs="3" />
+                <MudSelect @bind-Value="@ScavKarmaSelect" T="int" Label="@LocalizationService.GetString("ScavKarma")" RelativeWidth="DropdownWidth.Adaptive" AnchorOrigin="Origin.BottomLeft" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="d-inline-flex tm-select tm-select--field" PopoverClass="tm-select-popover" ListClass="tm-select-list" xs="3">
+                    @if (TraderFence != null)
+                    {
+                        @foreach (TarkovDev.TraderReputationLevel lvl in TraderFence.reputationLevels)
+                        {
+                            <MudSelectItem Value="@lvl.minimumReputation" />
+                        }
+                    }
+                </MudSelect>
+            </div>
+            <div>
+                <MudTextField @bind-Value="@RunthroughTime" Label="@LocalizationService.GetString("RunthroughTime")" Class="d-inline-flex tm-input tm-input--field" sx="3" />
+            </div>
+        </MudPaper>
+    </MudItem>
+
+    <MudItem xs="12" lg="6" xl="4">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" /><span class="tm-card-heading-text">Timers</span></MudText>
+            <MudSwitch @bind-Value="@FloatingTimerPanelSwitch" Label="Show the floating raid timer" Color="Color.Info" />
+            <MudText Typo="Typo.caption">Shows a movable timer in Tarkov Monitor after deployment finishes. It stays hidden on the Timers page.</MudText>
+            <MudText Typo="Typo.subtitle2" Class="mt-3">Displayed timers</MudText>
+            <MudSwitch @bind-Value="@FloatingTimerShowTimeInRaidSwitch" Label="Elapsed raid time" Color="Color.Info" Class="ml-4" />
+            <MudSwitch @bind-Value="@FloatingTimerShowRunThroughSwitch" Label="Run-through remaining" Color="Color.Info" Class="ml-4" />
+            <MudText Typo="Typo.caption">Keep at least one timer selected. Scav cooldown is not available in the floating panel.</MudText>
+        </MudPaper>
+    </MudItem>
+
     <!--MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Handshake" Class="mr-2"/>@LocalizationService.GetString("DataCollection")</MudText>
@@ -117,10 +117,10 @@
         </MudPaper>
     </MudItem-->
 
-    <MudItem xs="12">
-        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/>@LocalizationService.GetString("TarkovTracker")</MudText>
-            <MudSelect @bind-Value="@TarkovTrackerDomain" T="string" Label="@LocalizationService.GetString("TarkovTrackerService")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("TarkovTrackerServiceHelperText")" AnchorOrigin="Origin.BottomCenter" xs="3">
+    <MudItem xs="12" lg="6" xl="4">
+        <MudPaper id="tarkov-tracker" Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@trackerIcon" Class="mr-2"/><span class="tm-card-heading-text">@LocalizationService.GetString("TarkovTracker")</span></MudText>
+            <MudSelect @bind-Value="@TarkovTrackerDomain" T="string" Label="@LocalizationService.GetString("TarkovTrackerService")" RelativeWidth="DropdownWidth.Adaptive" ShrinkLabel="true" HelperText="@LocalizationService.GetString("TarkovTrackerServiceHelperText")" AnchorOrigin="Origin.BottomLeft" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--field" PopoverClass="tm-select-popover" ListClass="tm-select-list" xs="3">
                 @foreach (var pair in TarkovTracker.Domains)
                 {
                     <MudSelectItem T="string" Value="@pair.Key">@pair.Value</MudSelectItem>
@@ -136,7 +136,14 @@
             {
                 <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
                 <span>@LocalizationService.GetString("CurrentProfile"):</span>
-                <MudLink Href="@CurrentProfileUrl">@CurrentProfileName (@GameWatcher.CurrentProfile.Type)</MudLink>
+                @if (HasCurrentProfileRoute)
+                {
+                    <MudLink Href="@CurrentProfileUrl" Class="tm-profile-link">@CurrentProfileName (@GetProfileTypeDisplayName(GameWatcher.CurrentProfile.Type))</MudLink>
+                }
+                else
+                {
+                    <span>No EFT profile detected.</span>
+                }
                 <MudText Typo="Typo.body2" Class="tracker-key-intro">Add a TarkovTracker.org API key. Tarkov Monitor verifies the key and its game mode before it can be assigned to an EFT profile.</MudText>
                 @foreach (var warning in TrackerStorageWarnings)
                 {
@@ -330,9 +337,9 @@
         </MudPaper>
     </MudItem>
 
-    <MudItem xs="12">
+    <MudItem xs="12" lg="6" xl="4">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsRemote" Class="mr-2" /><MudButton @onclick="VisitWebsite" Variant="Variant.Text">@LocalizationService.GetString("TarkovDevWebsiteRemote")</MudButton></MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsRemote" Class="mr-2" /><span class="tm-card-heading-text">@TarkovDevWebsiteRemoteTitle</span></MudText>
             <MudTextField @bind-Value="@RemoteID" MaxLength="4" Label="@LocalizationService.GetString("RemoteID")" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.ContentPaste" OnAdornmentClick="PasteRemoteClick"></MudTextField>
             <div>
                 <MudSwitch @bind-Value="@NavigateMapSwitch" Label="@LocalizationService.GetString("SwitchToTarkovDevMapOnRaidLoad")" Color="Color.Info" />
@@ -343,7 +350,7 @@
             <div>
                 <MudSwitch @bind-Value="@AutomaticallyDeleteScreenshotsAfterRaid" Label="@LocalizationService.GetString("AutomaticallyDeleteScreenshotsAfterRaid")" Color="Color.Info" />
             </div>
-            <MudSelect @bind-Value="@MapOverrideSelect" T="string" Label="@LocalizationService.GetString("OfflineMap")" ShrinkLabel="true" HelperText="@LocalizationService.GetString("MapToUseForOfflineRaids")" AnchorOrigin="Origin.BottomCenter" xs="3">
+            <MudSelect @bind-Value="@MapOverrideSelect" T="string" Label="@LocalizationService.GetString("OfflineMap")" RelativeWidth="DropdownWidth.Adaptive" ShrinkLabel="true" HelperText="@LocalizationService.GetString("MapToUseForOfflineRaids")" AnchorOrigin="Origin.BottomLeft" PopoverFixed="false" Modal="false" MaxHeight="280" Margin="Margin.Dense" Dense="true" Class="tm-select tm-select--field" PopoverClass="tm-select-popover" ListClass="tm-select-list" xs="3">
                 <MudSelectItem T="string" Value="@string.Empty">@LocalizationService.GetString("None")</MudSelectItem>
                 @foreach (var map in TarkovDev.Maps)
                 {
@@ -353,10 +360,10 @@
         </MudPaper>
     </MudItem>
 
-    <MudItem xs="12">
+    <MudItem xs="12" lg="6" xl="4">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Folder" Class="mr-2" />@LocalizationService.GetString("LogsFolder")</MudText><MudText>@LocalizationService.GetString("DontChangeThisUnlessYouReallyKnowWhatYoureDoing")</MudText>
-            <MudTextField @bind-Value="@CustomLogsFolder" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="CustomLogsFolderClick"></MudTextField>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Folder" Class="mr-2" /><span class="tm-card-heading-text">@LocalizationService.GetString("LogsFolder")</span></MudText><MudText>@LocalizationService.GetString("DontChangeThisUnlessYouReallyKnowWhatYoureDoing")</MudText>
+            <MudTextField @bind-Value="@CustomLogsFolder" ReadOnly="true" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.FolderOpen" OnAdornmentClick="CustomLogsFolderClick" Class="tm-input tm-input--field tm-input--full"></MudTextField>
             @if (Properties.Settings.Default.customLogsPath != null && Properties.Settings.Default.customLogsPath != "")
             {
                 <div>
@@ -366,11 +373,11 @@
         </MudPaper>
     </MudItem>
 
-    <MudItem xs="12">
+    <MudItem xs="12" lg="6" xl="4">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsSuggest" Class="mr-2" />@LocalizationService.GetString("InitialSetup")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsSuggest" Class="mr-2" /><span class="tm-card-heading-text">@LocalizationService.GetString("InitialSetup")</span></MudText>
             <div>
-                <MudButton @onclick="ReadPastLogs" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("ReadPastLogs")</MudButton>
+                <MudButton @onclick="ReadPastLogs" Variant="Variant.Text" Class="tm-action-link">@LocalizationService.GetString("ReadPastLogs")</MudButton>
             </div>
         </MudPaper>
     </MudItem>
@@ -403,7 +410,35 @@
         }
     }
 
-    private string currentProfileName = GameWatcher.CurrentProfile.AccountId;
+    private string currentProfileName = GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
+        ? GameWatcher.CurrentProfile.AccountId
+        : "";
+
+    private RenderFragment TarkovDevWebsiteRemoteTitle => builder =>
+    {
+        var sequence = 0;
+        var title = LocalizationService.GetString("TarkovDevWebsiteRemote");
+        const string linkText = "Tarkov.dev";
+        var linkStart = title.IndexOf(linkText, StringComparison.OrdinalIgnoreCase);
+        if (linkStart < 0)
+        {
+            builder.AddContent(sequence++, title);
+            return;
+        }
+
+        builder.AddContent(sequence++, title[..linkStart]);
+        builder.OpenElement(sequence++, "a");
+        builder.AddAttribute(sequence++, "href", "https://tarkov.dev");
+        builder.AddAttribute(sequence++, "target", "_blank");
+        builder.AddAttribute(sequence++, "rel", "noopener noreferrer");
+        builder.AddAttribute(sequence++, "class", "tm-section-link");
+        builder.AddContent(sequence++, title.Substring(linkStart, linkText.Length));
+        builder.CloseElement();
+        builder.OpenElement(sequence++, "span");
+        builder.AddAttribute(sequence++, "class", "tm-section-suffix");
+        builder.AddContent(sequence++, title[(linkStart + linkText.Length)..].TrimStart());
+        builder.CloseElement();
+    };
     private string CurrentProfileName {
         get
         {
@@ -411,16 +446,32 @@
         }
     }
 
-    private Task UpdateProfileName()
+    private static string GetProfileTypeDisplayName(ProfileType profileType) => profileType switch
     {
-        return TarkovDev.GetPlayerName(GameWatcher.CurrentProfile).ContinueWith(t =>
+        ProfileType.PVE => "PVE",
+        ProfileType.Regular => "PVP",
+        ProfileType.PvpSeason => "Seasonal PVP",
+        _ => profileType.ToString(),
+    };
+
+    private async Task UpdateProfileName()
+    {
+        var profile = GameWatcher.CurrentProfile.Snapshot();
+        if (!profile.HasTarkovDevPlayerRoute)
         {
-            if (!t.IsCompletedSuccessfully)
-            {
-                return;
-            }
-            currentProfileName = t.Result;
-        });
+            currentProfileName = "";
+            return;
+        }
+
+        currentProfileName = profile.AccountId;
+        var profileName = await TarkovDev.GetPlayerName(profile);
+        if (GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
+            && string.Equals(GameWatcher.CurrentProfile.AccountId, profile.AccountId, StringComparison.Ordinal)
+            && string.Equals(GameWatcher.CurrentProfile.Id, profile.Id, StringComparison.Ordinal)
+            && GameWatcher.CurrentProfile.SessionMode == profile.SessionMode)
+        {
+            currentProfileName = profileName;
+        }
     }
 
     protected override void OnInitialized()
@@ -429,7 +480,9 @@
         PlaybackDevices = Sound.GetPlaybackDevices();
         AvailableLanguages = LocalizationService.GetAvailableLanguages();
         LocalizationService.LanguageChanged += OnLanguageChanged;
-        UpdateProfileName();
+        eft.GameStarted += OnGameClientStateChanged;
+        eft.ProfileChanged += OnGameClientStateChanged;
+        _ = UpdateProfileName();
     }
 
     protected override void OnParametersSet()
@@ -449,6 +502,17 @@
     public void Dispose()
     {
         LocalizationService.LanguageChanged -= OnLanguageChanged;
+        eft.GameStarted -= OnGameClientStateChanged;
+        eft.ProfileChanged -= OnGameClientStateChanged;
+    }
+
+    private void OnGameClientStateChanged(object? sender, EventArgs e)
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await UpdateProfileName();
+            StateHasChanged();
+        });
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)
@@ -468,7 +532,7 @@
             if (Properties.Settings.Default.language != value)
             {
                 LocalizationService.SetCulture(value);
-                messageLog.AddMessage("Please restart this application to complete the language change.", "warning");
+                    messageLog.AddMessage("Restart Tarkov Monitor to finish applying the language change.", "warning");
                 //Properties.Settings.Default.language = value; // handled by LocalizationService.SetCulture
                 //Properties.Settings.Default.Save();
                 //InvokeAsync(StateHasChanged); // should be unnecessary since we're handling the OnLanguageChanged event
@@ -739,8 +803,8 @@
 
     void ReadPastLogs()
     {
-        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
-        DialogService.ShowAsync<RawLogs.ForceReadDialog>("Read Past Log Files", options);
+        var options = new DialogOptions { CloseOnEscapeKey = false, BackdropClick = false, MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
+        DialogService.ShowAsync<RawLogs.ForceReadDialog>("Read past log files", options);
     }
 
     private string trackerIcon = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><svg enable-background=\"new 0 0 512.8 512.8\" version=\"1.1\" viewBox=\"0 0 512.8 512.8\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"m101.7 199.7c6.6-11.1 13.6-22 19.8-33.4 2-3.6 3.1-8.3 2.8-12.3-0.6-9.1-2.4-18-3.8-28 9.6 2.5 18.1 5.1 26.9 6.9 2.7 0.6 6.4-0.1 8.5-1.6 16.4-12.1 34.4-20.9 53.9-26.9 2.5-0.8 5.4-3.4 6.4-5.8 12.5-29.3 24.6-58.7 36.9-88 1.1-2.6 2.2-5.1 4-9.3 18.4 44.2 36.3 87.1 53.9 129.3-13.5-2.9-26.6-7.2-40-8.5-53.7-5.2-97.3 14.2-130.1 56.9-5.4 7.1-11.1 12.3-19.5 15.1-6.1 2-11.9 4.8-17.9 7.3-0.6-0.7-1.2-1.2-1.8-1.7z\" fill=\"#818181\"/><path d=\"m1.2 256.9c41.7-17.3 81.9-34 123.3-51.3-0.9 2.7-1.3 4.3-1.9 5.9-26.2 67.8 1.8 143.4 65.7 178 3 1.6 5.7 4.9 7.3 8.1 3.5 7.1 6.2 14.6 10.1 24-8.8-3.6-15.9-6.5-22.9-9.6-4.2-1.9-8.9-3.7-12.2-6.8-10.5-9.9-22.2-10.1-34.9-5.9-3.4 1.1-7.1 1.4-11.5 2.3 1.8-9 3.7-17.2 5-25.5 0.4-2.6-0.3-6-1.9-8-16.3-20.4-27.4-43.2-33.4-68.7-0.6-2.3-3.3-5-5.6-6-26.1-11-52.3-21.8-78.5-32.7-2.3-1-4.7-2.1-8.6-3.8z\" fill=\"#818181\"/><path d=\"m512.8 257.1c-41.1 17.2-80.8 33.7-120.7 50.3 1.8-10.5 4.2-20.3 5-30.3 4.3-54.7-16.3-98.2-60.3-130.5-6-4.4-10.2-9-12.6-15.8-2.3-6.6-5.3-13.1-6.5-21.3 10.3 5.9 20.5 11.8 31 17.5 2.6 1.4 5.9 2.4 8.6 2.1 12.2-1.4 24.3-3.3 37.6-5.3-3 11.3-6 21.6-8.3 32.1-0.6 2.9 0.4 6.6 1.7 9.4 7.7 15.4 15.7 30.7 23.9 45.9 1.3 2.5 3.6 5.3 6.1 6.3 28.3 12.1 56.8 23.8 85.3 35.7 2.6 1 5.1 2.1 9.2 3.9z\" fill=\"#818181\"/><path d=\"m398.3 396.8c-11.1-2.3-21.2-4.6-31.3-6.2-2.6-0.4-6.1 0.3-8.1 1.9-18.2 14.2-38.4 24.5-60.6 30.8-2.4 0.7-5.1 3.2-6.1 5.5-10.7 25.1-21.1 50.4-31.6 75.6-0.9 2.3-2 4.5-3.7 8.4-16-38.5-31.5-75.6-47.2-113.1 10.7 2 20.3 4.4 30.1 5.4 60 6 113.4-22.8 142.3-75.8 1.8-3.4 5.6-6.3 9.1-8.1 6.6-3.4 13.7-5.9 22.3-9.4-2.3 6.2-3.9 10.9-5.8 15.6-1.5 3.7-2.6 7.9-5.1 10.8-13 15.2-11.8 31.9-6.2 49.3 1 2.5 1.2 5.3 1.9 9.3z\" fill=\"#818181\"/><path d=\"m254.2 130.3c73.9 0.3 132.3 59.7 132 134.1-0.3 72-60 130.8-132.4 130.6-73.4-0.2-132.2-59.7-131.9-133.3 0.3-72.4 60.1-131.8 132.3-131.4zm-101.2 212.8c2.3 2.8 4.5 5.8 7.1 8.4 31 31.5 68.6 45.1 112.4 39.2 34.3-4.6 62.3-21.1 83.6-48.7 20.3-25.3 29-54.4 27.2-86.6-5.2-96.2-110.4-153-193.8-104.8-68.5 39.6-86.5 134.4-36.5 192.5z\" fill=\"#818181\"/><path d=\"m153 343.1c9.4 1.7 12.1-2.4 11.3-11.5-0.5-6-3.1-13.5 5.5-17.1 0.9-0.4 1.1-3.3 1.1-5 0.1-11.2-0.1-22.3 0.2-33.5 0-2 2-5.7 2.3-5.6 4.9 1.3 7.4-11.1 13.4-2.4 0.2 0.2 0.6 0.5 0.8 0.5 11.8-0.2 9.3 8.4 9.4 15.3 0.1 10 0 19.9 0 29.9 1 0 2 0.1 3 0.1 1-13.6 1.9-27.2 3.1-40.8 0.2-1.9 1.4-4.8 2.8-5.2 5.2-1.7 5.5-5.3 5.4-9.8-0.1-22-0.2-44 0-66 0.1-6.6 0.9-13.2 2-19.7 0.2-1.3 2.8-2.8 4.5-3.1 4.2-0.7 8.4-0.7 13-1 2.8 9.4 5.9 19.5 8.8 29.7 0.6 2 0.6 4.3 0.6 6.4 0 21 0 42 0.1 63 0 1.7 1.1 3.5 1.7 5.2 0.8-1.8 2.1-3.5 2.2-5.3 0.9-13.4 1.5-26.8 2.2-40.2 0.3-4.6 1.2-8.4 7.5-8.2 6.2 0.3 5.3 4.7 6.1 8.4 2.3 10.1 4.7 20.3 7.2 31.1 0.3-2.2 0.7-4 0.7-5.8 0.1-11.3-0.1-22.7 0.2-34 0.1-2.1 2.3-4 3.4-6.1 1-1.9 2.1-3.9 2.4-6 0.7-5 3.5-5.9 7.3-3.7 4.8 2.7 9.6 5.7 13.9 9.1 1.4 1.1 1.7 4.2 1.7 6.3 0.1 38.3 0 76.6 0.1 115 0 2.1 1.1 4.1 1.7 6.2 0.7-2.1 2.1-4.2 2.1-6.3 0.2-22.3 0.1-44.6 0.1-68.2 6.8 0 13-0.3 19.2 0.2 1.7 0.1 4.4 3 4.4 4.7 0.4 21.3 0.2 42.6 0.5 63.9 0 2 2 4 3.1 6.1 0.9-2 2.6-4 2.7-6 0.2-13.3-0.1-26.7 0.4-40 0.1-2 3-5.4 5.1-5.7 19.8-3.1 19.8-3 19.8 16.9v37c-21.2 27.6-49.3 44.1-83.6 48.7-43.8 5.9-81.4-7.7-112.4-39.2-2.5-2.5-4.7-5.5-7-8.3z\" fill=\"#B4B4B4\"/></svg>";
@@ -828,7 +892,11 @@
         "tarkovtracker.io",
         StringComparison.OrdinalIgnoreCase);
 
-    private string CurrentProfileUrl => $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}";
+    private bool HasCurrentProfileRoute => GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute;
+
+    private string CurrentProfileUrl => HasCurrentProfileRoute
+        ? $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.TarkovDevPlayerMode}/{GameWatcher.CurrentProfile.AccountId}"
+        : "";
 
     private IReadOnlyList<TarkovTracker.OrgKeySummary> OrgKeys => TarkovTracker.GetOrgKeys();
     private IReadOnlyList<string> TrackerStorageWarnings => TarkovTracker.GetStorageWarnings();
@@ -1453,7 +1521,7 @@
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error getting default logs folder: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not find the default logs folder: {ex.Message}", "exception");
             }
             return "";
         }
@@ -1471,7 +1539,7 @@
             var currentFolder = CustomLogsFolder;
             using var dialog = new System.Windows.Forms.FolderBrowserDialog
             {
-                Description = "Select the Escape from Tarkov logs folder.",
+                Description = "Select your Escape from Tarkov logs folder.",
                 UseDescriptionForTitle = true,
                 ShowNewFolderButton = false,
                 SelectedPath = Directory.Exists(currentFolder) ? currentFolder : "",
@@ -1484,7 +1552,7 @@
         }
         catch (Exception ex)
         {
-            messageLog.AddMessage($"Error opening logs folder picker: {ex.Message}", "exception");
+            messageLog.AddMessage($"Could not open the logs-folder picker: {ex.Message}", "exception");
         }
     }
 

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -181,7 +181,7 @@
                             <div class="tracker-drawer-content">
                                 <div class="tracker-state-note" role="note">
                                     <MudIcon Icon="@Icons.Material.Filled.Info" Size="Size.Small" Class="tracker-state-note-icon" />
-                                    <span><b>Verified, but unassigned.</b> Tarkov Monitor assigns a key automatically when it is the only unassigned key for the active game mode. Otherwise, click Assign to choose the correct EFT profile.</span>
+                                    <span><b>Verified, but unassigned.</b> Tarkov Monitor automatically assigns one eligible key to the first complete EFT account, profile, and game mode it observes. If more than one key is eligible, or you intentionally unbound a key, click Assign for the manual fallback.</span>
                                 </div>
                                 @if (PendingOrgKeys.Count == 0)
                                 {
@@ -198,6 +198,12 @@
                                                     <span class="tracker-verification-badge @(key.IsVerified ? "tracker-verification-badge--verified" : "tracker-verification-badge--pending")">
                                                         @(key.IsVerified ? "Verified" : "Verify on assign")
                                                     </span>
+                                                    @if (key.IsAutoBindBlocked)
+                                                    {
+                                                        <span class="tracker-assignment-badge tracker-assignment-badge--manual" title="Automatic assignment is blocked for the account that previously owned this key.">
+                                                            MANUAL ASSIGNMENT ONLY
+                                                        </span>
+                                                    }
                                                 </div>
                                                 <MudText Typo="Typo.caption" Class="tracker-token">@key.MaskedToken</MudText>
                                                 @if (key.IsLegacyRecovery)
@@ -228,7 +234,7 @@
                                                 }
                                             </div>
                                         </div>
-                                        @if (key.HasPendingConflict || key.IsQuarantined)
+                                        @if (key.IsAutoBindBlocked || key.HasPendingConflict || key.IsQuarantined)
                                         {
                                             <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">@PendingKeyIssue(key)</MudAlert>
                                         }
@@ -484,6 +490,7 @@
         LocalizationService.LanguageChanged += OnLanguageChanged;
         ResolveCustomLogsFolder();
         eft.GameStarted += OnGameClientStateChanged;
+        eft.GameStopped += OnGameClientStateChanged;
         eft.ProfileChanged += OnGameClientStateChanged;
         _ = UpdateProfileName();
     }
@@ -506,6 +513,7 @@
     {
         LocalizationService.LanguageChanged -= OnLanguageChanged;
         eft.GameStarted -= OnGameClientStateChanged;
+        eft.GameStopped -= OnGameClientStateChanged;
         eft.ProfileChanged -= OnGameClientStateChanged;
     }
 
@@ -954,6 +962,11 @@
 
     private static string PendingKeyIssue(TarkovTracker.OrgKeySummary key)
     {
+        if (key.IsAutoBindBlocked)
+        {
+            return "MANUAL ASSIGNMENT ONLY: automatic assignment is blocked for the EFT account that previously owned this key. Use Assign to choose its account, profile, and game mode.";
+        }
+
         return key.HasPendingConflict
             ? $"Manual assignment required: more than one {key.DisplayName} key is waiting. Automatic assignment is paused for this mode."
             : "This key is inactive because its saved record is ambiguous or invalid.";
@@ -1028,7 +1041,9 @@
         if (result is { Canceled: false, Data: TarkovTracker.ImportedToken importedToken })
         {
             messageLog.AddMessage(
-                $"Imported and verified the {importedToken.DisplayName} TarkovTracker.org API key. It is ready to assign.",
+                importedToken.IsBound
+                    ? $"Imported, verified, and automatically assigned the {importedToken.DisplayName} TarkovTracker.org API key to the active EFT profile."
+                    : $"Imported and verified the {importedToken.DisplayName} TarkovTracker.org API key. It will auto-assign on the first matching EFT profile, or you can assign it manually.",
                 "update");
             await ReactivateCurrentTrackerProfile();
             StateHasChanged();
@@ -1209,8 +1224,8 @@
             $"Unbind {key.DisplayName} API key",
             "Keep the key, but stop using it.",
             string.IsNullOrWhiteSpace(key.ProfileNickname)
-                ? "The key will remain saved and move to Unassigned. You can assign it again later."
-                : "The key will remain saved and move to Unassigned. Its profile nickname will be cleared.",
+                ? "The key will remain saved and move to Unassigned and will be marked MANUAL ASSIGNMENT ONLY for its previous EFT account. Assign it explicitly to use it again."
+                : "The key will remain saved and move to Unassigned. Its profile nickname will be cleared, and it will be marked MANUAL ASSIGNMENT ONLY for its previous EFT account.",
             "Unbind",
             Icons.Material.Filled.LinkOff,
             false))

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor.css
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor.css
@@ -1,0 +1,412 @@
+.tracker-key-manager {
+    --tracker-border: rgba(255, 255, 255, 0.11);
+    --tracker-border-hover: rgba(104, 164, 255, 0.42);
+    --tracker-surface: rgba(255, 255, 255, 0.025);
+    --tracker-surface-raised: rgba(255, 255, 255, 0.045);
+    margin-top: 0.42rem;
+}
+
+.tracker-key-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.3rem;
+    margin: 0;
+    padding: 0 0 0.45rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.085);
+}
+
+.tracker-drawer,
+.tracker-account-drawer {
+    overflow: hidden;
+    border: 1px solid var(--tracker-border);
+    background: linear-gradient(135deg, rgba(32, 33, 37, 0.96), rgba(21, 22, 25, 0.96));
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.tracker-drawer {
+    border-radius: 13px;
+}
+
+.tracker-account-drawer {
+    border-radius: 9px;
+}
+
+.tracker-drawer:hover,
+.tracker-account-drawer:hover {
+    border-color: var(--tracker-border-hover);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.tracker-drawer-toggle,
+.tracker-account-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-width: 0;
+    flex: 1 1 auto;
+    padding: 0.68rem 0.8rem;
+    border: 0;
+    color: inherit;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+}
+
+.tracker-drawer-toggle--primary {
+    width: 100%;
+    padding: 0.5rem 0.72rem;
+    background: transparent;
+}
+
+.tracker-drawer-toggle:hover,
+.tracker-account-toggle:hover,
+.tracker-drawer-toggle:focus-visible,
+.tracker-account-toggle:focus-visible {
+    background-color: rgba(94, 151, 235, 0.09);
+    outline: none;
+}
+
+.tracker-drawer-toggle:focus-visible,
+.tracker-account-toggle:focus-visible {
+    box-shadow: inset 0 0 0 2px rgba(104, 164, 255, 0.72);
+}
+
+.tracker-chevron {
+    flex: 0 0 auto;
+    color: #78aefb;
+}
+
+.tracker-drawer-title,
+.tracker-account-title {
+    overflow: hidden;
+    font-size: 0.92rem;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tracker-count-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.55rem;
+    height: 1.35rem;
+    padding: 0 0.38rem;
+    border: 1px solid rgba(120, 174, 251, 0.35);
+    border-radius: 999px;
+    color: #b9d4ff;
+    background: rgba(72, 126, 206, 0.16);
+    font-size: 0.68rem;
+    font-weight: 700;
+}
+
+.tracker-drawer-content {
+    padding: 0 0.65rem 0.65rem;
+}
+
+.tracker-state-note {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin: 0 0 0.55rem;
+    padding: 0.48rem 0.58rem;
+    border: 1px solid rgba(143, 130, 95, 0.35);
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.76);
+    background: rgba(143, 130, 95, 0.08);
+    font-size: 0.72rem;
+    line-height: 1.35;
+}
+
+.tracker-state-note-icon {
+    flex: 0 0 auto;
+    margin-top: 0.03rem;
+    color: #c2b27e;
+}
+
+.tracker-state-note-icon--bound {
+    color: #8ce0b8;
+}
+
+.tracker-manager-warning {
+    margin-bottom: 0.45rem;
+    padding: 0.36rem 0.55rem;
+    border-color: rgba(229, 176, 70, 0.42);
+    background: rgba(159, 112, 28, 0.1);
+}
+
+.tracker-empty-state {
+    padding: 0.7rem 0.25rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.tracker-pending-card,
+.tracker-profile-row {
+    padding: 0.48rem 0.62rem;
+    border: 1px solid var(--tracker-border);
+    border-radius: 7px;
+    background: var(--tracker-surface);
+}
+
+.tracker-profile-row {
+    padding: 0.34rem 0.55rem;
+}
+
+.tracker-pending-card + .tracker-pending-card,
+.tracker-profile-row + .tracker-profile-row {
+    margin-top: 0.35rem;
+}
+
+.tracker-profile-row + .tracker-profile-row {
+    margin-top: 0.26rem;
+}
+
+.tracker-key-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.65rem;
+}
+
+.tracker-key-copy {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.tracker-key-actions,
+.tracker-account-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    gap: 0.05rem;
+}
+
+.tracker-filter {
+    margin: 0.05rem 0 0.5rem;
+}
+
+.tracker-account-list {
+    max-height: 360px;
+    overflow-y: auto;
+    padding: 0.1rem 0.28rem 0.1rem 0;
+    scrollbar-color: rgba(120, 174, 251, 0.7) rgba(255, 255, 255, 0.04);
+    scrollbar-width: thin;
+}
+
+.tracker-account-heading {
+    display: grid;
+    grid-template-columns: minmax(11rem, 1fr) 10rem 10.4rem;
+    align-items: center;
+    column-gap: 0.35rem;
+    min-height: 2.65rem;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.035), transparent);
+    transition: background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.tracker-account-heading:hover,
+.tracker-account-heading:focus-within {
+    background-color: rgba(94, 151, 235, 0.09);
+}
+
+.tracker-account-heading:focus-within {
+    box-shadow: inset 0 0 0 2px rgba(104, 164, 255, 0.72);
+}
+
+.tracker-account-drawer {
+    position: relative;
+}
+
+.tracker-account-drawer::before {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 2px;
+    background: linear-gradient(180deg, #78aefb, rgba(139, 92, 246, 0.55));
+    content: "";
+    opacity: 0.58;
+    pointer-events: none;
+}
+
+.tracker-account-toggle {
+    width: 100%;
+    padding: 0.34rem 0.62rem;
+}
+
+.tracker-account-toggle:hover,
+.tracker-account-toggle:focus-visible {
+    background-color: transparent;
+    box-shadow: none;
+}
+
+.tracker-account-actions {
+    display: grid;
+    width: 10.4rem;
+    grid-template-columns: 4.35rem 5.8rem;
+    gap: 0.25rem;
+    padding-right: 0.35rem;
+}
+
+.tracker-account-action-slot {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: center;
+}
+
+.tracker-account-copy {
+    display: flex;
+    min-width: 0;
+    flex: 1 1 auto;
+    align-items: baseline;
+    gap: 0.48rem;
+}
+
+.tracker-account-subtitle,
+.tracker-token {
+    overflow: hidden;
+    color: rgba(255, 255, 255, 0.58);
+    font-size: 0.7rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tracker-account-title {
+    flex: 0 1 auto;
+}
+
+.tracker-account-subtitle {
+    flex: 1 1 auto;
+}
+
+.tracker-profile-identity {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.tracker-profile-identity .mud-typography {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tracker-profile-identity .tracker-token {
+    flex: 0 1 auto;
+}
+
+.tracker-mode-summary {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    gap: 0.2rem;
+}
+
+.tracker-mode-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.22rem;
+    padding: 0.03rem 0.36rem;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: 0.64rem;
+    font-weight: 700;
+    letter-spacing: 0.025em;
+}
+
+.tracker-verification-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.15rem;
+    padding: 0.02rem 0.38rem;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+
+.tracker-verification-badge--verified {
+    border-color: rgba(108, 203, 154, 0.32);
+    color: rgba(150, 226, 187, 0.92);
+    background: rgba(55, 137, 94, 0.12);
+}
+
+.tracker-verification-badge--pending {
+    border-color: rgba(242, 188, 87, 0.38);
+    color: #f2ca7f;
+    background: rgba(181, 123, 37, 0.14);
+}
+
+.tracker-mode-badge--pve {
+    border-color: rgba(87, 194, 142, 0.45);
+    color: #8ce0b8;
+    background: rgba(48, 146, 99, 0.15);
+}
+
+.tracker-mode-badge--pvp {
+    border-color: rgba(111, 166, 255, 0.45);
+    color: #9fc5ff;
+    background: rgba(61, 112, 194, 0.16);
+}
+
+.tracker-mode-badge--seasonal {
+    border-color: rgba(212, 148, 255, 0.46);
+    color: #deb0ff;
+    background: rgba(139, 74, 180, 0.16);
+}
+
+.tracker-mode-badge--unknown {
+    border-color: rgba(255, 255, 255, 0.24);
+    color: rgba(255, 255, 255, 0.72);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.tracker-profile-list {
+    padding: 0.28rem 0.5rem 0.42rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+@media (max-width: 640px) {
+    .tracker-account-heading {
+        grid-template-columns: minmax(0, 1fr) 10.4rem;
+    }
+
+    .tracker-mode-summary {
+        display: none;
+    }
+}
+
+@media (max-width: 520px) {
+    .tracker-account-heading,
+    .tracker-key-main {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .tracker-account-actions,
+    .tracker-key-actions {
+        justify-content: flex-start;
+        padding: 0 0.45rem 0.35rem;
+    }
+
+    .tracker-account-actions {
+        width: auto;
+        grid-column: 1;
+    }
+
+    .tracker-account-heading {
+        min-height: auto;
+    }
+
+    .tracker-account-copy,
+    .tracker-profile-identity {
+        flex-wrap: wrap;
+        row-gap: 0.12rem;
+    }
+}

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor.css
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor.css
@@ -344,6 +344,26 @@
     background: rgba(181, 123, 37, 0.14);
 }
 
+.tracker-assignment-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.15rem;
+    padding: 0.02rem 0.42rem;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    font-size: 0.66rem;
+    font-weight: 800;
+    letter-spacing: 0.035em;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.tracker-assignment-badge--manual {
+    border-color: rgba(255, 112, 112, 0.62);
+    color: #ffd0d0;
+    background: rgba(177, 47, 47, 0.24);
+}
+
 .tracker-mode-badge--pve {
     border-color: rgba(87, 194, 142, 0.45);
     color: #8ce0b8;

--- a/TarkovMonitor/Blazor/Pages/Settings/TarkovTrackerDetailsDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/TarkovTrackerDetailsDialog.razor
@@ -1,0 +1,37 @@
+<MudDialog Class="tracker-settings-dialog">
+    <DialogContent>
+        <div class="tracker-dialog-note" role="note">
+            <MudIcon Icon="@Icons.Material.Filled.AccountBox" Size="Size.Small" Class="tracker-dialog-note__icon" />
+            <span class="tracker-dialog-note__copy">
+                <strong>Account overview.</strong>
+                <span>These details summarize the API keys assigned to this EFT account.</span>
+            </span>
+        </div>
+
+        <div class="tracker-dialog-section-heading">
+            <MudIcon Icon="@Icons.Material.Filled.Badge" Size="Size.Small" />
+            <span>Account details</span>
+        </div>
+        <dl class="tracker-dialog-detail-card">
+            @foreach (var detail in Details)
+            {
+                <div class="tracker-dialog-detail-row">
+                    <dt>@detail.Key</dt>
+                    <dd>@detail.Value</dd>
+                </div>
+            }
+        </dl>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Info" Variant="Variant.Filled" OnClick="Close" StartIcon="@Icons.Material.Filled.Close" Class="tracker-dialog-footer-button">Close</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public IReadOnlyList<KeyValuePair<string, string>> Details { get; set; }
+        = Array.Empty<KeyValuePair<string, string>>();
+
+    private void Close() => MudDialog.Close();
+}

--- a/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
+++ b/TarkovMonitor/Blazor/Pages/Sounds/Sounds.razor
@@ -11,42 +11,42 @@
 <MudGrid Class="pa-0" Spacing="0">
 	<MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Speaker" Class="mr-2"/>@LocalizationService.GetString("Sounds")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Speaker" Class="mr-2"/><span class="tm-card-heading-text">@LocalizationService.GetString("Sounds")</span></MudText>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRaidStart" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@RaidStartSwitch" Label="@LocalizationService.GetString("CustomRaidStartingSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRaidStart" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayMatchFound" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@MatchFoundSwitch" Label="@LocalizationService.GetString("CustomMatchFoundSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayMatchFound" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRestartTask" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@RestartTaskSwitch" Label="@LocalizationService.GetString("CustomRestartTasksSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRestartTask" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRunthrough" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@RunthroughSwitch" Label="@LocalizationService.GetString("CustomRunthroughPeriodSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayRunthrough" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayAirFilterOn" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@AirFilterOnSwitch" Label="@LocalizationService.GetString("CustomAirFilterOnSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayAirFilterOn" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayAirFilterOff" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@AirFilterOffSwitch" Label="@LocalizationService.GetString("CustomAirFilterOffSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayAirFilterOff" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
             <div>
+                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayScavAvailable" Class="d-inline-flex mr-2"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
                 <MudSwitch @bind-Value="@ScavCooldownSwitch" Label="@LocalizationService.GetString("CustomScavCooldownSound")" Color="Color.Info" Class="d-inline-flex" />
-                <MudButton Variant="Variant.Outlined" Size="Size.Small" Color="Color.Info" @onclick="PlayScavAvailable" Class="d-inline-flex"><MudIcon Icon="@Icons.Material.Filled.Audiotrack" Size="Size.Small" /></MudButton>
             </div>
         </MudPaper>
         
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.MusicNote" Class="mr-2"/>Media Control</MudText>
+                <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.MusicNote" Class="mr-2"/><span class="tm-card-heading-text">Media controls</span></MudText>
             <div>
                 <MudSwitch @bind-Value="@PauseMediaOnRaidSwitch" Label="Pause media on raid start" Color="Color.Primary" />
-                <MudText Typo="Typo.caption" Class="ml-7">Automatically fade and pause playing music apps when entering a raid, then resume them when leaving</MudText>
+                <MudText Typo="Typo.caption" Class="ml-7">Automatically fade and pause music when you enter a raid, then resume it when you leave.</MudText>
             </div>
         </MudPaper>
 	</MudItem>
@@ -144,7 +144,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select raid starting sound";
+                fileDialog.Title = "Select a sound for raid start";
             }
             ToggleCustomSound("raid_starting", value);
         }
@@ -159,7 +159,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select match found sound";
+                fileDialog.Title = "Select a sound for match found";
             }
             ToggleCustomSound("match_found", value);
         }
@@ -175,7 +175,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select restart failed tasks sound";
+                fileDialog.Title = "Select a sound for task restart";
             }
             ToggleCustomSound("restart_failed_tasks", value);
         }
@@ -191,7 +191,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select runthrough period over sound";
+                fileDialog.Title = "Select a sound for run-through";
             }
             ToggleCustomSound("runthrough_over", value);
         }
@@ -207,7 +207,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select air filter on sound";
+                fileDialog.Title = "Select a sound for air filter on";
             }
             ToggleCustomSound("air_filter_on", value);
         }
@@ -223,7 +223,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select air filter off sound";
+                fileDialog.Title = "Select a sound for air filter off";
             }
             ToggleCustomSound("air_filter_off", value);
         }
@@ -239,7 +239,7 @@
         {
             if (value)
             {
-                fileDialog.Title = "Select scav available sound";
+                fileDialog.Title = "Select a sound for Scav availability";
             }
             ToggleCustomSound("scav_available", value);
         }

--- a/TarkovMonitor/Blazor/Pages/Stats/Stats.razor
+++ b/TarkovMonitor/Blazor/Pages/Stats/Stats.razor
@@ -11,7 +11,7 @@
 <MudGrid Class="pa-0" Spacing="0">
 	<MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.CurrencyRuble" Class="mr-2"/>@LocalizationService.GetString("FleaMarketSales")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.CurrencyRuble" Class="mr-2"/><span class="tm-card-heading-text">@LocalizationService.GetString("FleaMarketSales")</span></MudText>
             @foreach (KeyValuePair<string, string> currency in Currencies)
             {
                 <MudText Typo="Typo.body2">@GetSales(currency.Key, currency.Value)</MudText>
@@ -20,7 +20,7 @@
 	</MudItem>
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Map" Class="mr-2" />@LocalizationService.GetString("Raids")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Map" Class="mr-2" /><span class="tm-card-heading-text">@LocalizationService.GetString("Raids")</span></MudText>
             @foreach (var map in TarkovDev.Maps)
             {
                 <MudText Typo="Typo.body2">@map.name: @GetRaidCount(map.nameId)</MudText>
@@ -95,6 +95,6 @@
     void ClearData()
     {
         var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.ExtraLarge, FullWidth = true };
-        DialogService.ShowAsync<ConfirmClearDataDialog>("Clear Data?", options);
+        DialogService.ShowAsync<ConfirmClearDataDialog>("Clear data?", options);
     }
 }

--- a/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
+++ b/TarkovMonitor/Blazor/Pages/Timers/Timers.razor
@@ -8,14 +8,14 @@
 <MudGrid Class="pa-0" Spacing="0">
     <MudItem xs="12">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
-            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" />@LocalizationService.GetString("Timers")</MudText>
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Timer" Class="mr-2" /><span class="tm-card-heading-text">@LocalizationService.GetString("Timers")</span></MudText>
             <div class="d-flex align-center mt-2">
-                <MudText Class="mr-2">Floating timer panel:</MudText>
+                <MudText Class="mr-2">Floating timer panel</MudText>
                 <MudChip T="string" Color="@(timersManager.FloatingPanelEnabled ? Color.Success : Color.Default)" Size="Size.Small">
                     @(timersManager.FloatingPanelEnabled ? "Enabled" : "Disabled")
                 </MudChip>
             </div>
-            <MudText Typo="Typo.caption">Displayed: @FloatingPanelTimerSummary</MudText>
+            <MudText Typo="Typo.caption">Timers shown: @FloatingPanelTimerSummary</MudText>
             <MudList T="string">
                 <MudListItem>@LocalizationService.GetString("TimeInRaid"): @FormatTimer(TimeInRaidTime)</MudListItem>
                 <MudListItem>@LocalizationService.GetString("RunthroughPeriod"): @FormatTimer(RunThroughRemainingTime)</MudListItem>

--- a/TarkovMonitor/Diagnostics/DiagnosticModels.cs
+++ b/TarkovMonitor/Diagnostics/DiagnosticModels.cs
@@ -50,6 +50,10 @@ public static class DiagnosticRedactor
         @"(?ix)(?<key>\b(?:authorization|bearer|token|api[_-]?key|sessionid|accountid|profileid|remoteid|cookie)\b\s*(?:[:=]|=>)\s*)(?<value>Bearer\s+[^\s,;}&]+|[^\s,;}&]+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    private static readonly Regex DictionaryKey = new(
+        @"(?ix)(?<key>\bkey\b\s*:\s*)(?<value>\d+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private static readonly Regex JsonSensitiveKeyValue = new(
         @"(?ix)(?<key>(?<![a-z0-9_])""?(?:authorization|bearer|token|api[_-]?key|sessionid|accountid|profileid|remoteid|cookie)""?\s*:\s*)""?(?<value>[^""\s,}]+)""?",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -92,6 +96,7 @@ public static class DiagnosticRedactor
         sanitized = sanitized.Replace("%TMP%", "<temp>", StringComparison.OrdinalIgnoreCase);
         sanitized = ApiKey.Replace(sanitized, "[REDACTED_API_KEY]");
         sanitized = SensitiveKeyValue.Replace(sanitized, match => $"{match.Groups["key"].Value}[REDACTED]");
+        sanitized = DictionaryKey.Replace(sanitized, match => $"{match.Groups["key"].Value}[REDACTED_ID]");
         sanitized = JsonSensitiveKeyValue.Replace(sanitized, match => $"{match.Groups["key"].Value}\"[REDACTED]\"");
         sanitized = BearerToken.Replace(sanitized, "Bearer [REDACTED]");
         sanitized = QueryString.Replace(sanitized, "$url?[REDACTED_QUERY]");

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -1617,10 +1617,14 @@ namespace TarkovMonitor
 	{
 		public Exception Exception { get; set; }
         public string Context { get; set; }
-		public ExceptionEventArgs(Exception ex, string context)
+		public string? Endpoint { get; set; }
+        public long? DurationMilliseconds { get; set; }
+		public ExceptionEventArgs(Exception ex, string context, string? endpoint = null, long? durationMilliseconds = null)
 		{
 			this.Exception = ex;
             Context = context;
+			Endpoint = endpoint;
+            DurationMilliseconds = durationMilliseconds;
 		}
 	}
 	public class DebugEventArgs : EventArgs

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -16,6 +16,9 @@ namespace TarkovMonitor
         private readonly System.Timers.Timer processTimer;
         private readonly FileSystemWatcher logFileCreateWatcher;
         private readonly FileSystemWatcher screenshotWatcher;
+        private readonly bool historicalReplay;
+        private Profile parsingProfile = new();
+        private Profile ActiveProfile => historicalReplay ? parsingProfile : CurrentProfile;
         private string _logsPath = "";
         public static Profile CurrentProfile { get; set; } = new();
         public static bool ReadingPastLogs = false;
@@ -179,8 +182,9 @@ namespace TarkovMonitor
 		    throw new Exception("No Tarkov install path found");
 		}
 
-        public GameWatcher()
+        public GameWatcher(bool historicalReplay = false)
 		{
+			this.historicalReplay = historicalReplay;
 			Monitors = new();
 			raidInfo = new RaidInfo();
             logFileCreateWatcher = new FileSystemWatcher
@@ -653,18 +657,18 @@ namespace TarkovMonitor
                         if (systemMessageEvent.message.type >= MessageType.TaskStarted && systemMessageEvent.message.type <= MessageType.TaskFinished)
                         {
                             var args = jsonNode?.AsObject().Deserialize<TaskStatusMessageLogContent>() ?? throw new Exception("Error parsing TaskStatusMessageLogContent");
-                            TaskModified?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = CurrentProfile });
+                            TaskModified?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = ActiveProfile });
                             if (args.Status == TaskStatus.Started)
                             {
-                                TaskStarted?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = CurrentProfile });
+                                TaskStarted?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = ActiveProfile });
                             }
                             if (args.Status == TaskStatus.Failed)
                             {
-                                TaskFailed?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = CurrentProfile });
+                                TaskFailed?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = ActiveProfile });
                             }
                             if (args.Status == TaskStatus.Finished)
                             {
-                                TaskFinished?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = CurrentProfile });
+                                TaskFinished?.Invoke(this, new LogContentEventArgs<TaskStatusMessageLogContent>() { LogContent = args, Profile = ActiveProfile });
                             }
                         }
                     }
@@ -705,10 +709,12 @@ namespace TarkovMonitor
         // Process the log files in the specified folder
         public void ProcessLogs(LogDetails target, List<LogDetails> profiles)
         {
+            profiles = profiles.OrderBy(profile => profile.Date).ToList();
             for (var i = 0; i < profiles.Count; i++)
             {
                 var logProfile = profiles[i];
-                if (logProfile.Profile.Id != target.Profile.Id)
+                if (logProfile.Profile.Id != target.Profile.Id
+                    || logProfile.Profile.SessionMode != target.Profile.SessionMode)
                 {
                     continue;
                 }
@@ -717,30 +723,19 @@ namespace TarkovMonitor
                 {
                     endDate = profiles[i + 1].Date;
                 }
+                var startDate = logProfile.Date > target.Date ? logProfile.Date : target.Date;
+                if (endDate <= startDate)
+                {
+                    continue;
+                }
+                parsingProfile = logProfile.Profile.Snapshot();
                 var logFiles = Directory.GetFiles(logProfile.Folder);
-                // TODO: This could be improved by processing lines in the order they were created
-                // rather than a full file at a time, this could be valuable for future features
+                var replayEntries = new List<(DateTime Date, string Data)>();
                 foreach (string logFile in logFiles)
                 {
-                    GameLogType logType;
-                    // Check which type of log file this is by the filename
-                    if (logFile.Contains("application.log") || logFile.Contains("application_000.log"))
+                    if (!logFile.Contains("notifications.log")
+                        && !logFile.Contains("notifications_000.log"))
                     {
-                        logType = GameLogType.Application;
-                    }
-                    else if (logFile.Contains("notifications.log") || logFile.Contains("notifications_000.log"))
-                    {
-                        logType = GameLogType.Notifications;
-                    }
-                    else if (logFile.Contains("traces.log") || logFile.Contains("traces_000.log"))
-                    {
-                        // logType = GameLogType.Traces;
-                        // Traces are not currently used, so skip them
-                        continue;
-                    }
-                    else
-                    {
-                        // We're not a known log type, so skip this file
                         continue;
                     }
 
@@ -756,13 +751,21 @@ namespace TarkovMonitor
                         var dateTimeString = match.Groups["date"].Value + " " + match.Groups["time"].Value;
                         DateTime logMessageDate = DateTime.ParseExact(dateTimeString, "yyyy-MM-dd HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
 
-                        if (logMessageDate < logProfile.Date || logMessageDate >= endDate)
+                        if (logMessageDate < startDate || logMessageDate >= endDate)
                         {
                             continue;
                         }
 
-                        GameWatcher_NewLogData(this, new NewLogDataEventArgs { Type = logType, Data = match.Value });
+                        replayEntries.Add((logMessageDate, match.Value));
                     }
+                }
+                foreach (var replayEntry in replayEntries.OrderBy(entry => entry.Date))
+                {
+                    GameWatcher_NewLogData(this, new NewLogDataEventArgs
+                    {
+                        Type = GameLogType.Notifications,
+                        Data = replayEntry.Data,
+                    });
                 }
             }
         }
@@ -891,18 +894,24 @@ namespace TarkovMonitor
                     {
                         continue;
                     }
-                    var matchingBreakpoint = breakpoints.Where((bp) => bp.Version == breakpoint.Version && bp.Profile.Id == breakpoint.Profile.Id).FirstOrDefault();
+                    var matchingBreakpoint = breakpoints.Where((bp) => bp.Version == breakpoint.Version
+                        && bp.Profile.Id == breakpoint.Profile.Id
+                        && bp.Profile.SessionMode == breakpoint.Profile.SessionMode).FirstOrDefault();
                     if (matchingBreakpoint == null)
                     {
                         breakpoints.Add(breakpoint);
                     }
                 }
             }
-            return breakpoints;
+            return breakpoints.OrderBy(breakpoint => breakpoint.Date).ToList();
         }
 
         public void ProcessLogsFromBreakpoint(LogDetails breakpoint)
         {
+            if (!historicalReplay)
+            {
+                throw new InvalidOperationException("Past logs must be processed by an isolated historical watcher.");
+            }
             List<List<LogDetails>> logDetails = new();
             var logFolders = Directory.GetDirectories(LogsPath);
             // For each log folder, get the details
@@ -913,7 +922,8 @@ namespace TarkovMonitor
                 {
                     continue;
                 }
-                if (!details.Any(d => d.Profile.Id == breakpoint.Profile.Id))
+                if (!details.Any(d => d.Profile.Id == breakpoint.Profile.Id
+                    && d.Profile.SessionMode == breakpoint.Profile.SessionMode))
                 {
                     continue;
                 }

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -20,6 +20,38 @@ namespace TarkovMonitor
         public static Profile CurrentProfile { get; set; } = new();
         public static bool ReadingPastLogs = false;
         public bool InitialLogsRead { get; private set; } = false;
+        public bool IsGameRunning
+        {
+            get
+            {
+                try
+                {
+                    if (process != null && !process.HasExited)
+                    {
+                        return true;
+                    }
+
+                    var processes = Process.GetProcessesByName("EscapeFromTarkov");
+                    try
+                    {
+                        return processes.Length > 0;
+                    }
+                    finally
+                    {
+                        foreach (var candidate in processes)
+                        {
+                            candidate.Dispose();
+                        }
+                    }
+                }
+                catch
+                {
+                    // If process state cannot be read, block manual historical
+                    // assignment from replacing a potentially live identity.
+                    return true;
+                }
+            }
+        }
         public string LogsPath { 
             get
             {
@@ -316,6 +348,35 @@ namespace TarkovMonitor
             }
         }
 
+        internal static EftSessionMode ResolveSessionMode(string? rawSessionMode)
+        {
+            if (string.Equals(rawSessionMode, "Pve", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(rawSessionMode, "PVE", StringComparison.OrdinalIgnoreCase))
+            {
+                return EftSessionMode.PVE;
+            }
+            if (string.Equals(rawSessionMode, "Regular", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(rawSessionMode, "PVP", StringComparison.OrdinalIgnoreCase))
+            {
+                return EftSessionMode.Regular;
+            }
+            if (string.Equals(rawSessionMode, "PvpSeason", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(rawSessionMode, "Seasonal", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(rawSessionMode, "SZN", StringComparison.OrdinalIgnoreCase))
+            {
+                return EftSessionMode.Seasonal;
+            }
+
+            return EftSessionMode.Unknown;
+        }
+
+        internal static ProfileType ResolveProfileType(EftSessionMode sessionMode) => sessionMode switch
+        {
+            EftSessionMode.PVE => ProfileType.PVE,
+            EftSessionMode.Seasonal => ProfileType.PvpSeason,
+            _ => ProfileType.Regular,
+        };
+
         internal void GameWatcher_NewLogData(object? sender, NewLogDataEventArgs e)
         {
             try
@@ -356,13 +417,22 @@ namespace TarkovMonitor
                     //System.Diagnostics.Debug.WriteLine(eventLine);
                     if (eventLine.Contains("Session mode: "))
                     {
-                        var modeMatch = Regex.Match(eventLine, @"Session mode: (?<mode>\w+)");
+                        var modeMatch = Regex.Match(eventLine, @"Session mode: (?<mode>[^\s|]+)");
                         if (!modeMatch.Success)
                         {
                             continue;
                         }
-                        CurrentProfile.Type = Enum.Parse<ProfileType>(modeMatch.Groups["mode"].Value, true);
-                        raidInfo.Profile = CurrentProfile;
+                        var sessionMode = ResolveSessionMode(modeMatch.Groups["mode"].Value);
+                        if (CurrentProfile.SessionMode != sessionMode)
+                        {
+                            // EFT reports the mode before the matching profile identity.
+                            // Never let the previous mode's identity cross that boundary.
+                            CurrentProfile.Id = "";
+                            CurrentProfile.AccountId = "";
+                        }
+                        CurrentProfile.SessionMode = sessionMode;
+                        CurrentProfile.Type = ResolveProfileType(sessionMode);
+                        raidInfo.Profile = CurrentProfile.Snapshot();
                         continue;
                     }
                     // Profile selection messages have changed names across EFT versions.
@@ -720,25 +790,40 @@ namespace TarkovMonitor
             using var fileStream = new FileStream(appLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var textReader = new StreamReader(fileStream, Encoding.UTF8);
             var applicationLog = textReader.ReadToEnd();
-            var matches = Regex.Matches(applicationLog, @$"{logPatternPrefix}(?<version>\d+\.\d+\.\d+\.\d+)\.\d+\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|(?:SelectProfile|CompleteSelectedProfile) ProfileId:(?<profileId>[a-f0-9]+) AccountId:(?<accountId>\d+)", RegexOptions.Multiline);
+            var matches = Regex.Matches(applicationLog, @$"{logPatternPrefix}(?<version>\d+\.\d+\.\d+\.\d+)\.\d+\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|(?:Select(?:ed)?Profile|PrepareSelectedProfileLocally|CompleteSelectedProfile) ProfileId:(?<profileId>[a-f0-9]+) AccountId:(?<accountId>\d+)", RegexOptions.Multiline);
             if (matches.Count == 0)
             {
                 return logDetails;
             }
-            var profileTypeMatches = Regex.Matches(applicationLog, @$"{logPatternPrefix}(?<version>\d+\.\d+\.\d+\.\d+)\.\d+\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|Session mode: (?<profileType>\w+)", RegexOptions.Multiline);
+            var profileTypeMatches = Regex.Matches(applicationLog, @$"{logPatternPrefix}(?<version>\d+\.\d+\.\d+\.\d+)\.\d+\|(?<logLevel>[^|]+)\|(?<logType>[^|]+)\|Session mode: (?<profileType>[^\s|]+)", RegexOptions.Multiline);
             for (var i = 0; i < matches.Count; i++)
             {
                 Match match = matches[i];
                 var dateTimeString = match.Groups["date"].Value + " " + match.Groups["time"].Value;
                 DateTime profileDate = DateTime.ParseExact(dateTimeString, "yyyy-MM-dd HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
-                ProfileType profileType = ProfileType.Regular;
-                if (matches.Count == profileTypeMatches.Count)
+                var sessionMode = EftSessionMode.Unknown;
+                Match? sessionModeMatch = null;
+                foreach (Match candidate in profileTypeMatches)
                 {
-                    profileType = Enum.Parse<ProfileType>(profileTypeMatches[i].Groups["profileType"].Value, true);
+                    if (candidate.Index > match.Index)
+                    {
+                        break;
+                    }
+                    sessionModeMatch = candidate;
+                }
+                if (sessionModeMatch != null)
+                {
+                    sessionMode = ResolveSessionMode(sessionModeMatch.Groups["profileType"].Value);
                 }
                 logDetails.Add(new LogDetails()
                 {
-                    Profile = new() { Id = match.Groups["profileId"].Value, Type = profileType },
+                    Profile = new()
+                    {
+                        Id = match.Groups["profileId"].Value,
+                        Type = ResolveProfileType(sessionMode),
+                        SessionMode = sessionMode,
+                        AccountId = match.Groups["accountId"].Value,
+                    },
                     AccountId = Int32.Parse(match.Groups["accountId"].Value),
                     Date = profileDate,
                     Version = new Version(match.Groups["version"].Value),
@@ -746,6 +831,48 @@ namespace TarkovMonitor
                 });
             }
             return logDetails;
+        }
+
+        public List<DiscoveredEftProfile> DiscoverProfiles()
+        {
+            var observations = GetLogFolders()
+                .Values
+                .SelectMany(GetLogDetails)
+                .Select(details =>
+                {
+                    var sessionMode = details.Profile.SessionMode;
+                    return new DiscoveredEftProfile
+                    {
+                        Profile = new Profile
+                        {
+                            AccountId = details.AccountId.ToString(CultureInfo.InvariantCulture),
+                            Id = details.Profile.Id,
+                            SessionMode = sessionMode,
+                            Type = ResolveProfileType(sessionMode),
+                        },
+                        FirstSeenUtc = new DateTimeOffset(details.Date).ToUniversalTime(),
+                        LastSeenUtc = new DateTimeOffset(details.Date).ToUniversalTime(),
+                    };
+                })
+                .Where(observation => observation.Profile.HasIdentity
+                    && observation.Profile.SupportsTarkovTrackerWrites)
+                .ToList();
+
+            return observations
+                .GroupBy(observation => new
+                {
+                    observation.Profile.AccountId,
+                    observation.Profile.Id,
+                    observation.Profile.SessionMode,
+                })
+                .Select(group => new DiscoveredEftProfile
+                {
+                    Profile = group.First().Profile.Snapshot(),
+                    FirstSeenUtc = group.Min(observation => observation.FirstSeenUtc),
+                    LastSeenUtc = group.Max(observation => observation.LastSeenUtc),
+                })
+                .OrderByDescending(observation => observation.LastSeenUtc)
+                .ToList();
         }
 
         public List<LogDetails> GetLogBreakpoints(string profileId)
@@ -1047,7 +1174,7 @@ namespace TarkovMonitor
         public RaidInfoEventArgs(RaidInfo raidInfo, Profile profile)
         {
             RaidInfo = raidInfo;
-            Profile = profile;
+            Profile = profile.Snapshot();
         }
     }
 	public class ExceptionEventArgs : EventArgs
@@ -1090,6 +1217,13 @@ namespace TarkovMonitor
         public string Folder { get; set; }
     }
 
+    public sealed class DiscoveredEftProfile
+    {
+        public Profile Profile { get; set; } = new();
+        public DateTimeOffset FirstSeenUtc { get; set; }
+        public DateTimeOffset LastSeenUtc { get; set; }
+    }
+
     public enum ProfileType
     {
         PVE,
@@ -1112,11 +1246,52 @@ namespace TarkovMonitor
         };
     }
 
+    public enum EftSessionMode
+    {
+        Unknown,
+        PVE,
+        Regular,
+        Seasonal,
+    }
+
     public class Profile
     {
         public string Id { get; set; } = "";
         public ProfileType Type { get; set; } = ProfileType.Regular;
+        public EftSessionMode SessionMode { get; set; } = EftSessionMode.Unknown;
         public string AccountId { get; set; } = "";
+        public string DisplayName => SessionMode switch
+        {
+            EftSessionMode.PVE => "PVE",
+            EftSessionMode.Regular => "Regular (PVP)",
+            EftSessionMode.Seasonal => "Seasonal",
+            _ => "Unknown",
+        };
+        public string TarkovDevPlayerMode => SessionMode switch
+        {
+            EftSessionMode.PVE => "pve",
+            EftSessionMode.Regular => "pvp",
+            EftSessionMode.Seasonal => "pvp-season",
+            _ => "",
+        };
+        public bool HasTarkovDevPlayerRoute => HasIdentity
+            && !string.IsNullOrWhiteSpace(TarkovDevPlayerMode);
+        public bool SupportsTarkovTrackerWrites => SessionMode is EftSessionMode.PVE
+            or EftSessionMode.Regular
+            or EftSessionMode.Seasonal;
+        public bool HasIdentity => !string.IsNullOrWhiteSpace(AccountId)
+            && !string.IsNullOrWhiteSpace(Id);
+
+        public Profile Snapshot()
+        {
+            return new Profile
+            {
+                Id = Id,
+                Type = Type,
+                SessionMode = SessionMode,
+                AccountId = AccountId,
+            };
+        }
     }
 
     public class ProfileEventArgs : EventArgs
@@ -1124,14 +1299,19 @@ namespace TarkovMonitor
         public Profile Profile { get; set; }
         public ProfileEventArgs(Profile profile)
         {
-            Profile = profile;
+            Profile = profile.Snapshot();
         }
     }
 
     public class LogContentEventArgs<T> : EventArgs where T : JsonLogContent
     {
         public T LogContent { get; set; }
-        public Profile Profile { get; set; }
+        private Profile profile = new();
+        public Profile Profile
+        {
+            get => profile;
+            set => profile = value.Snapshot();
+        }
 
     }
 

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -188,6 +188,7 @@ namespace TarkovMonitor
         public event EventHandler<ExceptionEventArgs>? ExceptionThrown;
         public event EventHandler<DebugEventArgs>? DebugMessage;
         public event EventHandler? GameStarted;
+        public event EventHandler? GameStopped;
         public event EventHandler<LogContentEventArgs<GroupLogContent>>? GroupInviteAccept;
         public event EventHandler<LogContentEventArgs<GroupRaidSettingsLogContent>>? GroupRaidSettings;
         public event EventHandler<LogContentEventArgs<GroupMatchRaidReadyLogContent>>? GroupMemberReady;
@@ -213,6 +214,7 @@ namespace TarkovMonitor
         public event EventHandler<PlayerPositionEventArgs>? PlayerPosition;
         public event EventHandler<ProfileEventArgs> ProfileChanged;
         public event EventHandler<ProfileEventArgs> InitialReadComplete;
+        public event EventHandler<ProfileEventArgs>? ProfileReady;
         public event EventHandler<ControlSettingsEventArgs> ControlSettings;
 
         private static string logPatternPrefix = @"(?<date>^\d{4}-\d{2}-\d{2}) (?<time>\d{2}:\d{2}:\d{2}\.\d{3})(?<tzoffset> [+-]\d{2}:\d{2})?\|";
@@ -1274,6 +1276,9 @@ namespace TarkovMonitor
                     }
                     //DebugMessage?.Invoke(this, new DebugEventArgs("EFT exited."));
                     process = null;
+                    CurrentProfile = new();
+                    raidInfo = new();
+                    GameStopped?.Invoke(this, EventArgs.Empty);
                 }
                 raidInfo = new();
                 var processes = Process.GetProcessesByName("EscapeFromTarkov");
@@ -1406,8 +1411,10 @@ namespace TarkovMonitor
                             applicationInitialReadComplete = false;
                         }
                     }
-                    newMon.InitialReadComplete += LogMonitor_InitialReadComplete;
                 }
+                // Every replacement application log must produce a profile-ready
+                // transition, even after the original startup read completed.
+                newMon.InitialReadComplete += LogMonitor_InitialReadComplete;
                 Monitors[newType.Value] = newMon;
                 newMon.Start();
             }
@@ -1449,9 +1456,12 @@ namespace TarkovMonitor
             }
 
             var shouldPublish = false;
+            var shouldPublishProfileReady = false;
             lock (initialReadGate)
             {
-                if (!pendingInitialReads.Remove(monitor))
+                var wasPendingInitialRead = pendingInitialReads.Remove(monitor);
+                if (!wasPendingInitialRead
+                    && (!InitialLogsRead || monitor.Type != GameLogType.Application))
                 {
                     return;
                 }
@@ -1461,14 +1471,22 @@ namespace TarkovMonitor
                     applicationInitialReadComplete = true;
                 }
 
-                if (!InitialLogsRead && applicationInitialReadComplete && pendingInitialReads.Count == 0)
+                if (InitialLogsRead && monitor.Type == GameLogType.Application)
+                {
+                    shouldPublishProfileReady = true;
+                }
+                else if (!InitialLogsRead && applicationInitialReadComplete && pendingInitialReads.Count == 0)
                 {
                     InitialLogsRead = true;
                     shouldPublish = true;
                 }
             }
 
-            if (shouldPublish)
+            if (shouldPublishProfileReady)
+            {
+                ProfileReady?.Invoke(this, new(CurrentProfile));
+            }
+            else if (shouldPublish)
             {
                 PublishMatchingStarted(false);
                 InitialReadComplete?.Invoke(this, new(CurrentProfile));

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -238,7 +238,9 @@ namespace TarkovMonitor
                 }
             }
 
-            throw new DirectoryNotFoundException("No Escape from Tarkov logs folder was found in the installed game locations.");
+            // A missing installation is a valid first-run state. Callers keep
+            // monitoring dormant until the user configures a logs folder.
+            return "";
         }
 
         private static string? GetLogsFolder(string installPath)

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -668,7 +668,15 @@ namespace TarkovMonitor
             var displayMessage = e.Context == "player profile lookup"
                 ? "Player profile lookup failed; copy diagnostics for details."
                 : "Automatic Tarkov.dev refresh failed; copy diagnostics for details.";
-            RecordException(displayMessage, "TM-API-TARKOVDEV-002", e.Context, e.Exception, "TarkovDev", "Background", "https://json.tarkov.dev");
+            RecordException(
+                displayMessage,
+                e.Context == "player profile lookup" ? "TM-API-TARKOVDEV-002" : "TM-API-TARKOVDEV-001",
+                e.Context,
+                e.Exception,
+                "TarkovDev",
+                "Background",
+                e.Endpoint ?? "https://json.tarkov.dev",
+                e.DurationMilliseconds);
         }
 
         private void UpdateCheck_NewVersion(object? sender, NewVersionEventArgs e)
@@ -871,6 +879,12 @@ namespace TarkovMonitor
             try
             {
                 await TarkovTracker.SetProfile(profileSnapshot);
+            }
+            catch (ProfileActivationSupersededException)
+            {
+                // A newer profile/key/mode activation owns the result. This is
+                // expected latest-wins behavior, not a user-visible failure.
+                return;
             }
             catch (Exception ex)
             {

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -61,6 +61,15 @@ namespace TarkovMonitor
         private readonly System.Timers.Timer scavCooldownTimer;
         private LocalizationService localizationService;
         private bool inRaid;
+        private int trackerStatusTransitionDepth;
+        private readonly object trackerSessionNoticeLock = new();
+        private long trackerSessionNoticeGeneration;
+        private TrackerSessionNoticeIdentity? lastAnnouncedTrackerSession;
+
+        private readonly record struct TrackerSessionNoticeIdentity(
+            string AccountId,
+            string ProfileId,
+            EftSessionMode SessionMode);
 
         public MainBlazorUI()
         {
@@ -135,6 +144,7 @@ namespace TarkovMonitor
             eft.GroupDisbanded += Eft_GroupDisbanded;
             eft.MatchingAborted += Eft_GroupStaleEvent;
             eft.GameStarted += Eft_GroupStaleEvent;
+            eft.GameStarted += Eft_GameStarted;
             eft.MapLoading += Eft_MapLoading;
             eft.MapLoading += Eft_MapLoading_NavigateToMap;
             eft.MatchFound += Eft_MatchFound;
@@ -150,19 +160,9 @@ namespace TarkovMonitor
                 TarkovDev.StartAutoUpdates();
                 //TarkovDev.UpdatePlayerNames();
 
-                // Update Tarkov Tracker
-                if (Properties.Settings.Default.tarkovTrackerToken != "" && e.Profile.Id != "")
-                {
-                    try {
-                        TarkovTracker.SetToken(e.Profile.Id, Properties.Settings.Default.tarkovTrackerToken);
-                    } catch (Exception ex) {
-                        messageLog.AddMessage($"Error setting token from previously saved settings {ex.Message}", "exception");
-                    }
-
-                    Properties.Settings.Default.tarkovTrackerToken = "";
-                    Properties.Settings.Default.Save();
-                }
-                InitializeProgress();
+                // The versioned .org store performs guarded legacy recovery. Keep the
+                // original settings intact until a recovered key is explicitly assigned.
+                _ = InitializeProgress(e.Profile);
             };
 
             try
@@ -186,6 +186,7 @@ namespace TarkovMonitor
             };
 
             TarkovTracker.ProgressRetrieved += TarkovTracker_ProgressRetrieved;
+            TarkovTracker.OrgKeyAutoAssigned += TarkovTracker_OrgKeyAutoAssigned;
 
             UpdateCheck.NewVersion += UpdateCheck_NewVersion;
             UpdateCheck.Error += UpdateCheck_Error;
@@ -337,12 +338,16 @@ namespace TarkovMonitor
 
         private void Eft_ProfileChanged(object? sender, ProfileEventArgs e)
         {
-            if (e.Profile.Id == TarkovTracker.CurrentProfileId)
+            _ = InitializeProgress(e.Profile);
+        }
+
+        private void Eft_GameStarted(object? sender, EventArgs e)
+        {
+            lock (trackerSessionNoticeLock)
             {
-                return;
+                trackerSessionNoticeGeneration++;
+                lastAnnouncedTrackerSession = null;
             }
-            messageLog.AddMessage(string.Format(localizationService.GetString("UsingProfile"), e.Profile.Type));
-            TarkovTracker.SetProfile(e.Profile.Id);
         }
 
         private void Eft_ExitedPostRaidMenus(object? sender, RaidInfoEventArgs e)
@@ -582,9 +587,33 @@ namespace TarkovMonitor
             groupManager.ClearGroup();
         }
 
-        private void TarkovTracker_ProgressRetrieved(object? sender, EventArgs e)
+        private void TarkovTracker_ProgressRetrieved(object? sender, TarkovTracker.ProgressRetrievedEventArgs e)
         {
-            messageLog.AddMessage(string.Format(localizationService.GetString("RetrievedDataFromTarkovTracker"), TarkovTracker.Progress.data.displayName, TarkovTracker.Progress.data.playerLevel, TarkovTracker.Progress.data.pmcFaction), "update", $"https://{Properties.Settings.Default.tarkovTrackerDomain}");
+            messageLog.AddProtectedMessage(
+                string.Format(
+                    localizationService.GetString("RetrievedDataFromTarkovTracker"),
+                    e.Progress.data.displayName,
+                    e.Progress.data.playerLevel,
+                    e.Progress.data.pmcFaction),
+                "update",
+                new[]
+                {
+                    new MonitorMessageProtectedValue("Account ID", e.AccountId),
+                    new MonitorMessageProtectedValue("Profile ID", e.ProfileId),
+                },
+                $"https://{Properties.Settings.Default.tarkovTrackerDomain}");
+        }
+
+        private void TarkovTracker_OrgKeyAutoAssigned(object? sender, TarkovTracker.OrgKeyAutoAssignedEventArgs e)
+        {
+            messageLog.AddProtectedMessage(
+                $"TarkovTracker.org API key assigned - Mode: {TarkovTracker.GetSessionDisplayName(e.SessionMode)}.",
+                "info",
+                new[]
+                {
+                    new MonitorMessageProtectedValue("Account ID", e.AccountId),
+                    new MonitorMessageProtectedValue("Profile ID", e.ProfileId),
+                });
         }
 
         private void Eft_GroupStaleEvent(object? sender, EventArgs e)
@@ -611,19 +640,55 @@ namespace TarkovMonitor
             }
         }
 
-        private async Task InitializeProgress()
+        private async Task InitializeProgress(Profile? profile = null)
         {
+            var profileSnapshot = (profile ?? GameWatcher.CurrentProfile).Snapshot();
+            long noticeGeneration;
+            lock (trackerSessionNoticeLock)
+            {
+                noticeGeneration = trackerSessionNoticeGeneration;
+            }
+
+            if (TarkovTracker.IsLegacyService
+                || !profileSnapshot.HasIdentity
+                || !profileSnapshot.SupportsTarkovTrackerWrites)
+            {
+                TarkovTracker.DeactivateProfile();
+                return;
+            }
             try
             {
-                await TarkovTracker.SetProfile(GameWatcher.CurrentProfile.Id);
+                await TarkovTracker.SetProfile(profileSnapshot);
             }
             catch (Exception ex)
             {
                 messageLog.AddMessage($"Error retrieving Tarkov Tracker profile: {ex.Message}");
                 return;
             }
-            messageLog.AddMessage(string.Format(localizationService.GetString("UsingProfile"), GameWatcher.CurrentProfile.Type));
-            if (TarkovTracker.GetToken(GameWatcher.CurrentProfile.Id) == "")
+            var identity = new TrackerSessionNoticeIdentity(
+                profileSnapshot.AccountId,
+                profileSnapshot.Id,
+                profileSnapshot.SessionMode);
+            lock (trackerSessionNoticeLock)
+            {
+                if (noticeGeneration != trackerSessionNoticeGeneration
+                    || lastAnnouncedTrackerSession == identity)
+                {
+                    return;
+                }
+
+                lastAnnouncedTrackerSession = identity;
+            }
+
+            messageLog.AddProtectedMessage(
+                $"EFT session confirmed - Mode: {profileSnapshot.DisplayName}.",
+                "info",
+                new[]
+                {
+                    new MonitorMessageProtectedValue("Account ID", profileSnapshot.AccountId),
+                    new MonitorMessageProtectedValue("Profile ID", profileSnapshot.Id),
+                });
+            if (TarkovTracker.GetTokenForProfile(profileSnapshot) == "")
             {
                 messageLog.AddMessage(localizationService.GetString("ToAutomaticallyTrackTaskProgress"));
                 return;
@@ -642,6 +707,23 @@ namespace TarkovMonitor
                 return;
             }*/
         }
+
+        internal void BeginTrackerStatusTransition()
+        {
+            Interlocked.Increment(ref trackerStatusTransitionDepth);
+            TarkovTracker.DeactivateProfile();
+        }
+
+        internal void CompleteTrackerStatusTransition()
+        {
+            if (Interlocked.Decrement(ref trackerStatusTransitionDepth) < 0)
+            {
+                Interlocked.Exchange(ref trackerStatusTransitionDepth, 0);
+                throw new InvalidOperationException(
+                    "TarkovTracker status transition completed without a matching start.");
+            }
+        }
+
 
         private void Eft_MatchFound(object? sender, RaidInfoEventArgs e)
         {
@@ -694,7 +776,11 @@ namespace TarkovMonitor
             }
             try
             {
-                await TarkovTracker.SetTaskComplete(task.id);
+                await TarkovTracker.SetTaskComplete(
+                    task.id,
+                    e.Profile.Id,
+                    e.Profile.SessionMode,
+                    e.Profile.AccountId);
                 //messageLog.AddMessage(response, "quest");
             }
             catch (Exception ex)
@@ -719,7 +805,11 @@ namespace TarkovMonitor
             }
             try
             {
-                await TarkovTracker.SetTaskFailed(task.id);
+                await TarkovTracker.SetTaskFailed(
+                    task.id,
+                    e.Profile.Id,
+                    e.Profile.SessionMode,
+                    e.Profile.AccountId);
                 //messageLog.AddMessage(response, "quest");
             }
             catch (Exception ex)
@@ -743,7 +833,11 @@ namespace TarkovMonitor
             }
             try
             {
-                await TarkovTracker.SetTaskStarted(e.LogContent.TaskId);
+                await TarkovTracker.SetTaskStarted(
+                    e.LogContent.TaskId,
+                    e.Profile.Id,
+                    e.Profile.SessionMode,
+                    e.Profile.AccountId);
             }
             catch (Exception ex)
             {

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -82,6 +82,10 @@ namespace TarkovMonitor
         private readonly object trackerSessionNoticeLock = new();
         private long trackerSessionNoticeGeneration;
         private TrackerSessionNoticeIdentity? lastAnnouncedTrackerSession;
+        private readonly object tarkovDevDataRefreshLock = new();
+        private CancellationTokenSource? tarkovDevDataRefreshCancellation;
+        private long tarkovDevDataRefreshGeneration;
+        private ProfileType tarkovDevDataRefreshProfileType = ProfileType.Unknown;
 
         private readonly record struct TrackerSessionNoticeIdentity(
             string AccountId,
@@ -185,9 +189,10 @@ namespace TarkovMonitor
                     return;
                 }
 
-                // Update tarkov.dev API data
-
-                UpdateTarkovDevApiData();
+                // Load the data set for the exact EFT session mode detected by
+                // the watcher. A later mode switch starts a new generation and
+                // invalidates this load before it can publish stale assets.
+                _ = RefreshTarkovDevApiData(e.Profile);
                 TarkovDev.StartAutoUpdates();
                 //TarkovDev.UpdatePlayerNames();
 
@@ -460,7 +465,9 @@ namespace TarkovMonitor
 
         private void Eft_ProfileChanged(object? sender, ProfileEventArgs e)
         {
-            _ = InitializeProgress(e.Profile, announceSession: true);
+            var profileSnapshot = e.Profile.Snapshot();
+            _ = RefreshTarkovDevApiData(profileSnapshot);
+            _ = InitializeProgress(profileSnapshot, announceSession: true);
         }
 
         private void Eft_GameStarted(object? sender, EventArgs e)
@@ -779,12 +786,12 @@ namespace TarkovMonitor
                     localizationService.GetString("RetrievedDataFromTarkovTracker"),
                     e.Progress.data.displayName,
                     e.Progress.data.playerLevel,
-                    e.Progress.data.pmcFaction),
+                    e.Progress.data.pmcFaction,
+                    TarkovTracker.GetSessionDisplayName(e.SessionMode)),
                 "update",
                 new[]
                 {
-                    new MonitorMessageProtectedValue("Account ID", e.AccountId),
-                    new MonitorMessageProtectedValue("Profile ID", e.ProfileId),
+                    new MonitorMessageProtectedValue("API key", e.ApiKey),
                 },
                 $"https://{Properties.Settings.Default.tarkovTrackerDomain}");
         }
@@ -792,7 +799,7 @@ namespace TarkovMonitor
         private void TarkovTracker_OrgKeyAutoAssigned(object? sender, TarkovTracker.OrgKeyAutoAssignedEventArgs e)
         {
             messageLog.AddProtectedMessage(
-                $"TarkovTracker.org API key assigned - Mode: {TarkovTracker.GetSessionDisplayName(e.SessionMode)}.",
+                $"TarkovTracker.org API key assigned - Session: {TarkovTracker.GetSessionDisplayName(e.SessionMode)}.",
                 "info",
                 new[]
                 {
@@ -842,17 +849,101 @@ namespace TarkovMonitor
             }
         }
 
-        private async Task UpdateTarkovDevApiData()
+        private async Task RefreshTarkovDevApiData(Profile profile)
         {
-            var startedUtc = DateTime.UtcNow;
+            var profileSnapshot = profile.Snapshot();
+            if (profileSnapshot.Type == ProfileType.Unknown)
+            {
+                lock (tarkovDevDataRefreshLock)
+                {
+                    tarkovDevDataRefreshGeneration++;
+                    tarkovDevDataRefreshCancellation?.Cancel();
+                    tarkovDevDataRefreshCancellation = null;
+                    tarkovDevDataRefreshProfileType = ProfileType.Unknown;
+                    TarkovDev.ClearApiData();
+                }
+                return;
+            }
+
+            CancellationTokenSource refreshCancellation;
+            long refreshGeneration;
+            lock (tarkovDevDataRefreshLock)
+            {
+                if (tarkovDevDataRefreshProfileType == profileSnapshot.Type
+                    || (tarkovDevDataRefreshProfileType == ProfileType.Unknown
+                        && TarkovDev.LoadedProfileType == profileSnapshot.Type))
+                {
+                    return;
+                }
+
+                tarkovDevDataRefreshGeneration++;
+                refreshGeneration = tarkovDevDataRefreshGeneration;
+                tarkovDevDataRefreshCancellation?.Cancel();
+                refreshCancellation = new CancellationTokenSource();
+                tarkovDevDataRefreshCancellation = refreshCancellation;
+                tarkovDevDataRefreshProfileType = profileSnapshot.Type;
+
+                if (TarkovDev.LoadedProfileType != profileSnapshot.Type)
+                {
+                    TarkovDev.ClearApiData();
+                }
+            }
+
             try
             {
-                await TarkovDev.UpdateApiData();
-                messageLog.AddMessage(string.Format(localizationService.GetString("RetrievedDataFromTarkovDev"), String.Format("{0:n0}", TarkovDev.Items.Count), TarkovDev.Maps.Count, TarkovDev.Traders.Count, TarkovDev.Tasks.Count, TarkovDev.Stations.Count), "update");
+                var data = await TarkovDev.LoadApiData(profileSnapshot.Type, refreshCancellation.Token);
+                lock (tarkovDevDataRefreshLock)
+                {
+                    if (refreshGeneration != tarkovDevDataRefreshGeneration
+                        || !ReferenceEquals(refreshCancellation, tarkovDevDataRefreshCancellation)
+                        || GameWatcher.CurrentProfile.Type != profileSnapshot.Type)
+                    {
+                        return;
+                    }
+
+                    TarkovDev.PublishApiData(data);
+                }
+
+                messageLog.AddMessage(
+                    string.Format(
+                        localizationService.GetString("RetrievedDataFromTarkovDev"),
+                        String.Format("{0:n0}", data.Items.Count),
+                        data.Maps.Count,
+                        data.Traders.Count,
+                        data.Tasks.Count,
+                        data.Stations.Count,
+                        TarkovTracker.GetSessionDisplayName(profileSnapshot.SessionMode)),
+                    "update");
+            }
+            catch (OperationCanceledException) when (refreshCancellation.IsCancellationRequested)
+            {
+                // A newer EFT session owns the next asset load.
             }
             catch (Exception ex)
             {
-                RecordException("Tarkov.dev data update failed; copy diagnostics for details.", "TM-API-TARKOVDEV-001", "UpdateApiData", ex, "TarkovDev", "DataUpdate", "https://json.tarkov.dev", DiagnosticsService.ElapsedMilliseconds(startedUtc));
+                lock (tarkovDevDataRefreshLock)
+                {
+                    if (refreshGeneration != tarkovDevDataRefreshGeneration
+                        || !ReferenceEquals(refreshCancellation, tarkovDevDataRefreshCancellation)
+                        || GameWatcher.CurrentProfile.Type != profileSnapshot.Type)
+                    {
+                        return;
+                    }
+                }
+
+                RecordException($"Tarkov.dev data update failed for {TarkovTracker.GetSessionDisplayName(profileSnapshot.SessionMode)}; copy diagnostics for details.", "TM-API-TARKOVDEV-001", "UpdateApiData", ex, "TarkovDev", "DataUpdate", "https://json.tarkov.dev");
+            }
+            finally
+            {
+                lock (tarkovDevDataRefreshLock)
+                {
+                    if (refreshGeneration == tarkovDevDataRefreshGeneration
+                        && ReferenceEquals(refreshCancellation, tarkovDevDataRefreshCancellation))
+                    {
+                        tarkovDevDataRefreshProfileType = ProfileType.Unknown;
+                        tarkovDevDataRefreshCancellation = null;
+                    }
+                }
             }
         }
 
@@ -913,7 +1004,7 @@ namespace TarkovMonitor
             }
 
             messageLog.AddProtectedMessage(
-                $"EFT session confirmed - Mode: {profileSnapshot.DisplayName}.",
+                $"EFT session confirmed - Session: {TarkovTracker.GetSessionDisplayName(profileSnapshot.SessionMode)}.",
                 "info",
                 new[]
                 {

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -24,6 +24,11 @@ namespace TarkovMonitor
         private const int WsThickFrame = 0x00040000;
         private const int WsMinimizeBox = 0x00020000;
         private const int WsMaximizeBox = 0x00010000;
+        private const uint SwpNoSize = 0x0001;
+        private const uint SwpNoMove = 0x0002;
+        private const uint SwpNoZOrder = 0x0004;
+        private const uint SwpNoActivate = 0x0010;
+        private const uint SwpFrameChanged = 0x0020;
         private const int DwmWindowCornerPreference = 33;
         private const int DwmBorderColor = 34;
         private const int DwmCaptionColor = 35;
@@ -38,6 +43,9 @@ namespace TarkovMonitor
 
         [DllImport("user32.dll")]
         private static extern IntPtr SendMessage(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        private static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int width, int height, uint flags);
 
         [DllImport("dwmapi.dll")]
         private static extern int DwmSetWindowAttribute(IntPtr windowHandle, int attribute, ref int value, int valueSize);
@@ -62,6 +70,13 @@ namespace TarkovMonitor
         private LocalizationService localizationService;
         private bool inRaid;
         private int trackerStatusTransitionDepth;
+        private FormWindowState lastPublishedWindowState = FormWindowState.Normal;
+        private bool windowStateNotificationPending;
+        private bool uiReady;
+        private bool uiHostRevealed;
+        private bool uiHostRevealQueued;
+        private bool startupHeldForSplash;
+        private bool startupServicesStarted;
         private readonly object trackerSessionNoticeLock = new();
         private long trackerSessionNoticeGeneration;
         private TrackerSessionNoticeIdentity? lastAnnouncedTrackerSession;
@@ -71,21 +86,24 @@ namespace TarkovMonitor
             string ProfileId,
             EftSessionMode SessionMode);
 
-        public MainBlazorUI()
+        public event EventHandler? UiReady;
+        public bool IsUiReady => uiReady;
+
+        public MainBlazorUI(bool holdUntilSplashCompletes = false)
         {
             InitializeComponent();
-            if (Properties.Settings.Default.upgradeRequired)
-            {
-                Properties.Settings.Default.Upgrade();
-                Properties.Settings.Default.upgradeRequired = false;
-                Properties.Settings.Default.Save();
-            }
+            startupHeldForSplash = holdUntilSplashCompletes;
+            // The splash is an independent startup window. Unless a caller
+            // explicitly asks for a gate, keep the main window visible while
+            // WebView2 paints so both windows launch together with no reveal
+            // delay or second native-host repaint.
+            Opacity = startupHeldForSplash ? 0 : 1;
             this.TopMost = Properties.Settings.Default.stayOnTop;
             inRaid = false;
 
             // Singleton message log used to record and display messages for TarkovMonitor
             messageLog = new MessageLog();
-            messageLog.AddMessage($"TarkovMonitor v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
+            messageLog.AddMessage($"Tarkov Monitor v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
 
             // Singleton log repository to record, display, and analyze logs for TarkovMonitor
             logRepository = new LogRepository();
@@ -106,6 +124,8 @@ namespace TarkovMonitor
             services.AddMudServices(configuration =>
             {
                 configuration.SnackbarConfiguration.PositionClass = Defaults.Classes.Position.TopCenter;
+                configuration.PopoverOptions.FlipMargin = 8;
+                configuration.PopoverOptions.OverflowPadding = 8;
             });
             services.AddLocalization();
             services.AddSingleton<LocalizationService>();
@@ -160,19 +180,19 @@ namespace TarkovMonitor
                 TarkovDev.StartAutoUpdates();
                 //TarkovDev.UpdatePlayerNames();
 
+                // Historical profile identity remains available through GameWatcher for
+                // Settings and Read Past Logs, but it must not activate or auto-bind a
+                // tracker key while EFT is not running.
+                if (!eft.IsGameRunning)
+                {
+                    TarkovTracker.DeactivateProfile();
+                    return;
+                }
+
                 // The versioned .org store performs guarded legacy recovery. Keep the
                 // original settings intact until a recovered key is explicitly assigned.
                 _ = InitializeProgress(e.Profile);
             };
-
-            try
-            {
-                eft.Start();
-            }
-            catch (Exception ex)
-            {
-                messageLog.AddMessage($"Error starting game watcher: {ex.Message} {ex.StackTrace}", "exception");
-            }
 
             Properties.Settings.Default.PropertyChanged += (object? sender, PropertyChangedEventArgs e) => {
                 if (e.PropertyName == "stayOnTop")
@@ -192,8 +212,6 @@ namespace TarkovMonitor
             UpdateCheck.Error += UpdateCheck_Error;
 
             SocketClient.ExceptionThrown += SocketClient_ExceptionThrown;
-
-            UpdateCheck.CheckForNewVersion();
 
             blazorWebView1.WebView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
 
@@ -217,20 +235,97 @@ namespace TarkovMonitor
 
         public void ToggleMaximizeWindow()
         {
-            WindowState = IsMaximized ? FormWindowState.Normal : FormWindowState.Maximized;
+            if (!IsMaximized)
+            {
+                WindowState = FormWindowState.Maximized;
+                return;
+            }
+
+            WindowState = FormWindowState.Normal;
         }
 
         public void CloseWindow() => Close();
 
-        public void BeginWindowDrag()
+        public void MarkUiReady()
         {
-            if (IsMaximized)
+            if (uiReady)
             {
                 return;
             }
 
+            uiReady = true;
+            UiReady?.Invoke(this, EventArgs.Empty);
+            RevealUiHostIfReady(revealImmediately: !startupHeldForSplash);
+        }
+
+        public void ReleaseSplashGate()
+        {
+            if (!startupHeldForSplash)
+            {
+                return;
+            }
+
+            startupHeldForSplash = false;
+            RevealUiHostIfReady(revealImmediately: true);
+        }
+
+        private void RevealUiHostIfReady(bool revealImmediately = false)
+        {
+            if (IsDisposed || !IsHandleCreated || !uiReady || startupHeldForSplash || uiHostRevealed || uiHostRevealQueued)
+            {
+                return;
+            }
+
+            if (revealImmediately && !InvokeRequired)
+            {
+                RevealUiHost();
+                return;
+            }
+
+            // WebView2 and Blazor are allowed to finish painting while the
+            // splash is on top, but the native host must be revealed exactly
+            // once. Multiple opacity changes can produce a full -> black ->
+            // full repaint when the WebView surface is restored.
+            uiHostRevealQueued = true;
+            BeginInvoke(new Action(() =>
+            {
+                uiHostRevealQueued = false;
+                RevealUiHost();
+            }));
+        }
+
+        private void RevealUiHost()
+        {
+            if (IsDisposed || startupHeldForSplash || !uiReady || uiHostRevealed)
+            {
+                return;
+            }
+
+            uiHostRevealed = true;
+            ShowInTaskbar = true;
+            Opacity = 1;
+            if (WindowState != FormWindowState.Minimized)
+            {
+                Activate();
+            }
+        }
+
+        public void BeginWindowDrag()
+        {
             ReleaseCapture();
             SendMessage(Handle, WmNcLButtonDown, (IntPtr)HtCaption, IntPtr.Zero);
+        }
+
+        private void RefreshNormalWindowFrame()
+        {
+            SetWindowPos(
+                Handle,
+                IntPtr.Zero,
+                0,
+                0,
+                0,
+                0,
+                SwpNoSize | SwpNoMove | SwpNoZOrder | SwpNoActivate | SwpFrameChanged);
         }
 
         public void BeginWindowResize(int hitTest)
@@ -315,7 +410,7 @@ namespace TarkovMonitor
                 JsonNode screenshotBind = keyBindings.FirstOrDefault((n) => n.AsObject()["keyName"].ToString() == "MakeScreenshot" && n.AsObject()["variants"].AsArray().Any(variant => variant.AsObject()["isAxis"]?.GetValue<bool>() == true || variant.AsObject()["keyCode"].AsArray().Count > 0));
                 if (screenshotBind == null)
                 {
-                    messageLog.AddMessage($"Screenshot key is not bound in EFT. Using this keybind is required to update tarkov.dev map position.", "info");
+            messageLog.AddMessage("EFT has no screenshot key bound. Bind one to update your position on the Tarkov.dev map.", "info");
                     return;
                 }
                 var variant = screenshotBind["variants"].AsArray().FirstOrDefault(variant => variant.AsObject()["keyCode"].AsArray().Count > 0);
@@ -327,18 +422,18 @@ namespace TarkovMonitor
                 var keys = variant["keyCode"].AsArray().Select(n => n.GetValue<string>());
                 if (keys.Any(key => key == "SysReq"))
                 {
-                    messageLog.AddMessage($"Screenshot key is not properly bound in EFT. Please re-bind your screenshot key in EFT for use with updating tarkov.dev map position.", "info");
+                    messageLog.AddMessage("The EFT screenshot key is not bound correctly. Rebind it to update your position on the Tarkov.dev map.", "info");
                 }
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error checking screenshot keybind: {ex.Message} {ex.StackTrace}", "exception");
+                messageLog.AddMessage($"Could not check the EFT screenshot keybind: {ex.Message} {ex.StackTrace}", "exception");
             }
         }
 
         private void Eft_ProfileChanged(object? sender, ProfileEventArgs e)
         {
-            _ = InitializeProgress(e.Profile);
+            _ = InitializeProgress(e.Profile, announceSession: true);
         }
 
         private void Eft_GameStarted(object? sender, EventArgs e)
@@ -368,7 +463,7 @@ namespace TarkovMonitor
             {
                 Sound.Play("scav_available");
             }
-            messageLog.AddMessage("Player scav available", "info");
+            messageLog.AddMessage("Your Scav is available.", "info");
         }
 
         private void RunthroughTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
@@ -376,23 +471,25 @@ namespace TarkovMonitor
             if (Properties.Settings.Default.runthroughAlert)
             {
                 Sound.Play("runthrough_over");
-                messageLog.AddMessage("Runthrough period over", "info");
+                messageLog.AddMessage("The run-through period is over.", "info");
             }
         }
 
         private void Delete_Screenshots(RaidInfoEventArgs e, MonitorMessage? monMessage = null, MonitorMessageButton? screenshotButton = null)
         {
+            var screenshotCount = e.RaidInfo.Screenshots.Count;
+            var screenshotLabel = screenshotCount == 1 ? "screenshot" : "screenshots";
             try
             {
                 foreach (var filename in e.RaidInfo.Screenshots)
                 {
                     File.Delete(Path.Combine(eft.ScreenshotsPath, filename));
                 }
-                messageLog.AddMessage($"Deleted {e.RaidInfo.Screenshots.Count} screenshots");
+                messageLog.AddMessage($"Deleted {screenshotCount} raid {screenshotLabel}.");
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error deleting screenshot: {ex.Message} {ex.StackTrace}", "exception");
+                messageLog.AddMessage($"Could not delete the raid {screenshotLabel}: {ex.Message} {ex.StackTrace}", "exception");
             }
 
             if (monMessage is null || screenshotButton is null)
@@ -412,7 +509,9 @@ namespace TarkovMonitor
                 return;
             }
 
-            MonitorMessageButton screenshotButton = new($"Delete {e.RaidInfo.Screenshots.Count} Screenshots", Icons.Material.Filled.Delete);
+            var screenshotCount = e.RaidInfo.Screenshots.Count;
+            var screenshotLabel = screenshotCount == 1 ? "raid screenshot" : "raid screenshots";
+            MonitorMessageButton screenshotButton = new($"Deleted {screenshotCount} {screenshotLabel}", Icons.Material.Filled.Delete);
             screenshotButton.OnClick = () =>
             {
                 Delete_Screenshots(e, monMessage, screenshotButton);
@@ -427,7 +526,7 @@ namespace TarkovMonitor
             await ResumeMediaAfterRaid();
             
             //groupManager.Stale = true;
-            MonitorMessage monMessage = new($"Ended {e.RaidInfo.Map?.name} raid");
+            MonitorMessage monMessage = new($"Raid ended on {e.RaidInfo.Map?.name}.");
 
             if (e.RaidInfo.Screenshots.Count > 0) {
                 Handle_Screenshots(e, monMessage);
@@ -451,7 +550,7 @@ namespace TarkovMonitor
 
         private void SocketClient_ExceptionThrown(object? sender, ExceptionEventArgs e)
         {
-            messageLog.AddMessage($"Error {e.Context}: {e.Exception.Message}\n{e.Exception.StackTrace}", "exception");
+            messageLog.AddMessage($"{e.Context} failed: {e.Exception.Message}\n{e.Exception.StackTrace}", "exception");
         }
 
         protected override void OnShown(EventArgs e)
@@ -465,10 +564,42 @@ namespace TarkovMonitor
 
                     WindowState = FormWindowState.Minimized;
                 }
+
+                // Let WebView2 render the startup shell before watcher and
+                // update-check work begins. This keeps startup responsive and
+                // lets the application initialize behind the splash.
+                BeginInvoke(new Action(StartStartupServices));
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error minimizing at startup: {ex.Message} {ex.StackTrace}", "exception");
+                messageLog.AddMessage($"Could not minimize at startup: {ex.Message} {ex.StackTrace}", "exception");
+            }
+        }
+
+        private void StartStartupServices()
+        {
+            if (startupServicesStarted || IsDisposed)
+            {
+                return;
+            }
+
+            startupServicesStarted = true;
+            try
+            {
+                eft.Start();
+            }
+            catch (Exception ex)
+            {
+                messageLog.AddMessage($"Could not start the game watcher: {ex.Message} {ex.StackTrace}", "exception");
+            }
+
+            try
+            {
+                UpdateCheck.CheckForNewVersion();
+            }
+            catch (Exception ex)
+            {
+                messageLog.AddMessage($"Could not check for updates: {ex.Message}", "exception");
             }
         }
 
@@ -478,7 +609,7 @@ namespace TarkovMonitor
             {
                 return;
             }
-            messageLog.AddMessage($"Player position on {e.RaidInfo.Map.name}: x: {e.Position.X}, y: {e.Position.Y}, z: {e.Position.Z}");
+            messageLog.AddMessage($"Current position on {e.RaidInfo.Map.name}: x={e.Position.X}, y={e.Position.Y}, z={e.Position.Z}.");
             List<JsonObject> socketMessages = new();
             socketMessages.Add(SocketClient.GetPlayerPositionMessage(e));
             //await SocketClient.UpdatePlayerPosition(e);
@@ -492,12 +623,12 @@ namespace TarkovMonitor
 
         private void UpdateCheck_Error(object? sender, ExceptionEventArgs e)
         {
-            messageLog.AddMessage($"Error {e.Context}: {e.Exception.Message}", "exception");
+            messageLog.AddMessage($"{e.Context} failed: {e.Exception.Message}", "exception");
         }
 
         private void UpdateCheck_NewVersion(object? sender, NewVersionEventArgs e)
         {
-            messageLog.AddMessage($"New TarkovMonitor version available ({e.Version})! Click here to open the download page. Please update to this new version before reporting any bugs.", null, e.Uri.ToString());
+            messageLog.AddMessage($"A new Tarkov Monitor version is available ({e.Version}). Click to open the download page, and update before reporting a bug.", null, e.Uri.ToString());
         }
 
         private async void Eft_MapLoading(object? sender, EventArgs e)
@@ -540,7 +671,7 @@ namespace TarkovMonitor
                 }
                 foreach (var task in failedTasks)
                 {
-                    messageLog.AddMessage($"Failed task {task.name} should be restarted", "quest", task.wikiLink);
+                    messageLog.AddMessage($"Task failed: {task.name}. Restart required.", "quest", task.wikiLink);
                 }
                 if (Properties.Settings.Default.restartTaskAlert)
                 {
@@ -549,7 +680,7 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error on matching started: {ex.Message}");
+                messageLog.AddMessage($"Could not process the start of the match: {ex.Message}", "exception");
             }
         }
 
@@ -578,7 +709,7 @@ namespace TarkovMonitor
 
         private void Eft_GroupInviteAccept(object? sender, LogContentEventArgs<GroupLogContent> e)
         {
-            messageLog.AddMessage($"{e.LogContent.Info.Nickname} ({e.LogContent.Info.Side.ToUpper()} {e.LogContent.Info.Level}) accepted group invite.", "group");
+            messageLog.AddMessage($"{e.LogContent.Info.Nickname} ({e.LogContent.Info.Side.ToUpper()} {e.LogContent.Info.Level}) accepted the group invite.", "group");
         }
 
         private void Eft_GroupDisbanded(object? sender, EventArgs e)
@@ -625,6 +756,14 @@ namespace TarkovMonitor
         private void WebView_CoreWebView2InitializationCompleted(object? sender, CoreWebView2InitializationCompletedEventArgs e)
         {
             if (Debugger.IsAttached) blazorWebView1.WebView.CoreWebView2.OpenDevToolsWindow();
+
+            if (!e.IsSuccess)
+            {
+                // Do not leave the native host invisible if WebView2 cannot
+                // initialize; the normal Blazor error surface must remain
+                // reachable for diagnosis.
+                MarkUiReady();
+            }
         }
 
         private async Task UpdateTarkovDevApiData()
@@ -636,17 +775,20 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error updating tarkov.dev API data: {ex.Message}");
+                messageLog.AddMessage($"Could not update Tarkov.dev data: {ex.Message}", "exception");
             }
         }
 
-        private async Task InitializeProgress(Profile? profile = null)
+        private async Task InitializeProgress(Profile? profile = null, bool announceSession = true)
         {
             var profileSnapshot = (profile ?? GameWatcher.CurrentProfile).Snapshot();
-            long noticeGeneration;
-            lock (trackerSessionNoticeLock)
+            long noticeGeneration = 0;
+            if (announceSession)
             {
-                noticeGeneration = trackerSessionNoticeGeneration;
+                lock (trackerSessionNoticeLock)
+                {
+                    noticeGeneration = trackerSessionNoticeGeneration;
+                }
             }
 
             if (TarkovTracker.IsLegacyService
@@ -662,9 +804,15 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error retrieving Tarkov Tracker profile: {ex.Message}");
+                messageLog.AddMessage($"Could not retrieve the Tarkov Tracker profile: {ex.Message}", "exception");
                 return;
             }
+
+            if (!announceSession)
+            {
+                return;
+            }
+
             var identity = new TrackerSessionNoticeIdentity(
                 profileSnapshot.AccountId,
                 profileSnapshot.Id,
@@ -698,12 +846,12 @@ namespace TarkovMonitor
                 var tokenResponse = await TarkovTracker.TestToken(TarkovTracker.GetToken(eft.CurrentProfile.Id));
                 if (!tokenResponse.permissions.Contains("WP"))
                 {
-                    messageLog.AddMessage("Your Tarkov Tracker token is missing the required write permissions");
+                    messageLog.AddMessage("Your Tarkov Tracker token does not have the required write permissions.", "warning");
                 }
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error updating progress: {ex.Message}");
+                messageLog.AddMessage($"Could not update Tarkov Tracker progress: {ex.Message}", "exception");
                 return;
             }*/
         }
@@ -724,7 +872,6 @@ namespace TarkovMonitor
             }
         }
 
-
         private void Eft_MatchFound(object? sender, RaidInfoEventArgs e)
         {
             if (Properties.Settings.Default.matchFoundAlert)
@@ -735,7 +882,7 @@ namespace TarkovMonitor
             {
                 return;
             }
-            messageLog.AddMessage($"Matching complete on {e.RaidInfo.Map.name} after {e.RaidInfo.QueueTime} seconds");
+            messageLog.AddMessage($"Matching complete on {e.RaidInfo.Map.name} after {e.RaidInfo.QueueTime:0.##} seconds.");
         }
 
         private void Eft_NewLogData(object? sender, NewLogDataEventArgs e)
@@ -747,7 +894,7 @@ namespace TarkovMonitor
                 logRepository.AddLog(e.Data, e.Type.ToString());
             } catch (Exception ex)
             {
-                messageLog.AddMessage($"{ex.GetType().Name} adding raw lag to repository: "+ex.StackTrace, "exception");
+                messageLog.AddMessage($"{ex.GetType().Name} while adding raw log data to the repository: {ex.StackTrace}", "exception");
             }
         }
 
@@ -755,7 +902,7 @@ namespace TarkovMonitor
         {
             return;
             groupManager.UpdateGroupMember(e.LogContent);
-            messageLog.AddMessage($"{e.LogContent.extendedProfile.Info.Nickname} ({e.LogContent.extendedProfile.PlayerVisualRepresentation.Info.Side.ToUpper()} {e.LogContent.extendedProfile.PlayerVisualRepresentation.Info.Level}) ready.", "group");
+            messageLog.AddMessage($"{e.LogContent.extendedProfile.Info.Nickname} ({e.LogContent.extendedProfile.PlayerVisualRepresentation.Info.Side.ToUpper()} {e.LogContent.extendedProfile.PlayerVisualRepresentation.Info.Level}) is ready.", "group");
         }
 
         private async void Eft_TaskFinished(object? sender, LogContentEventArgs<TaskStatusMessageLogContent> e)
@@ -768,7 +915,7 @@ namespace TarkovMonitor
                 return;
             }
 
-            messageLog.AddMessage($"Completed task {task.name}", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
+            messageLog.AddMessage($"Task completed: {task.name}.", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
 
             if (!TarkovTracker.ValidToken)
             {
@@ -785,7 +932,7 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error updating Tarkov Tracker task progression: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not update Tarkov Tracker task progress: {ex.Message}", "exception");
             }
         }
 
@@ -797,7 +944,7 @@ namespace TarkovMonitor
                 return;
             }
 
-            messageLog.AddMessage($"Failed task {task.name}", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
+            messageLog.AddMessage($"Task failed: {task.name}.", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
 
             if (!TarkovTracker.ValidToken)
             {
@@ -814,7 +961,7 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error updating Tarkov Tracker task progression: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not update Tarkov Tracker task progress: {ex.Message}", "exception");
             }
         }
 
@@ -825,7 +972,7 @@ namespace TarkovMonitor
             {
                 return;
             }
-            messageLog.AddMessage($"Started task {task.name}", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
+            messageLog.AddMessage($"Task started: {task.name}.", "quest", $"https://tarkov.dev/task/{task.normalizedName}");
 
             if (!TarkovTracker.ValidToken)
             {
@@ -841,7 +988,7 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error updating Tarkov Tracker task progression: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not update Tarkov Tracker task progress: {ex.Message}", "exception");
             }
         }
 
@@ -897,7 +1044,7 @@ namespace TarkovMonitor
             {
                 return;
             }
-            messageLog.AddMessage($"Your offer for {unsoldItem.name} (x{e.LogContent.ItemCount}) expired", "flea", unsoldItem.link);
+            messageLog.AddMessage($"Your offer for {unsoldItem.name} (x{e.LogContent.ItemCount}) has expired.", "flea", unsoldItem.link);
         }
 
         private void Eft_DebugMessage(object? sender, DebugEventArgs e)
@@ -907,7 +1054,7 @@ namespace TarkovMonitor
 
         private void Eft_ExceptionThrown(object? sender, ExceptionEventArgs e)
         {
-            messageLog.AddMessage($"Error {e.Context}: {e.Exception.Message}\n{e.Exception.StackTrace}", "exception");
+            messageLog.AddMessage($"{e.Context} failed: {e.Exception.Message}\n{e.Exception.StackTrace}", "exception");
         }
 
         private async void Eft_RaidStarting(object? sender, RaidInfoEventArgs e)
@@ -928,11 +1075,12 @@ namespace TarkovMonitor
             try
             {
                 int pausedSessions = await MediaController.PauseAsync();
-                messageLog.AddMessage($"Paused {pausedSessions} music session(s)", "info");
+                var sessionLabel = pausedSessions == 1 ? "session" : "sessions";
+                messageLog.AddMessage($"Paused {pausedSessions} music {sessionLabel}.", "info");
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error pausing media: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not pause media: {ex.Message}", "exception");
             }
         }
 
@@ -950,12 +1098,13 @@ namespace TarkovMonitor
                 int resumedSessions = await MediaController.ResumeAsync();
                 if (resumedSessions > 0)
                 {
-                    messageLog.AddMessage($"Resumed {resumedSessions} music session(s)", "info");
+                    var sessionLabel = resumedSessions == 1 ? "session" : "sessions";
+                    messageLog.AddMessage($"Resumed {resumedSessions} music {sessionLabel}.", "info");
                 }
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error resuming media: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not resume media: {ex.Message}", "exception");
             }
         }
 
@@ -972,29 +1121,29 @@ namespace TarkovMonitor
             
             if (!e.RaidInfo.Reconnected && e.RaidInfo.RaidType != RaidType.Unknown)
             {
-                MonitorMessage monMessage = new($"Starting {e.RaidInfo.RaidType} raid on {e.RaidInfo.Map?.name}");
+                MonitorMessage monMessage = new($"Starting a {e.RaidInfo.RaidType} raid on {e.RaidInfo.Map?.name}.");
                 if (e.RaidInfo.Map != null && e.RaidInfo.StartedTime != null && e.RaidInfo.Map.HasGoons())
                 {
                     AddGoonsButton(monMessage, e.RaidInfo);
                 }
                 else if (e.RaidInfo.Map == null)
                 {
-                    monMessage.Message = $"Starting {e.RaidInfo.RaidType} raid on:";
+                    monMessage.Message = $"Starting a {e.RaidInfo.RaidType} raid. Choose a map:";
                     MonitorMessageSelect select = new();
                     foreach (var gameMap in TarkovDev.Maps)
                     {
                         select.Options.Add(new(gameMap.name, gameMap.id));
                     }
-                    select.Placeholder = "Select map";
+                    select.Placeholder = "Choose a map";
                     monMessage.Selects.Add(select);
-                    MonitorMessageButton mapButton = new("Set map", Icons.Material.Filled.Map);
+                     MonitorMessageButton mapButton = new("Set map", Icons.Material.Filled.Map);
                     mapButton.OnClick += () => {
                         if (select.Selected == null)
                         {
                             return;
                         }
                         e.RaidInfo.Map = TarkovDev.Maps.Find(m => m.id == select.Selected.Value);
-                        monMessage.Message = $"Starting {e.RaidInfo.RaidType} raid on {select.Selected.Text}";
+                        monMessage.Message = $"Starting a {e.RaidInfo.RaidType} raid on {select.Selected.Text}.";
                         monMessage.Buttons.Clear();
                         monMessage.Selects.Clear();
                         //AddGoonsButton(monMessage, e.RaidInfo); // offline raids have goons on all goons maps
@@ -1018,7 +1167,7 @@ namespace TarkovMonitor
             }
             else
             {
-                messageLog.AddMessage($"Re-entering raid on {e.RaidInfo.Map?.name}");
+                messageLog.AddMessage($"Re-entering the raid on {e.RaidInfo.Map?.name}.");
             }
             if (Properties.Settings.Default.runthroughAlert && !e.RaidInfo.Reconnected && (e.RaidInfo.RaidType == RaidType.PMC || e.RaidInfo.RaidType == RaidType.PVE))
             {
@@ -1045,22 +1194,22 @@ namespace TarkovMonitor
         {
             if (raidInfo.Map != null && raidInfo.StartedTime != null && raidInfo.Map.HasGoons())
             {
-                MonitorMessageButton goonsButton = new($"Report Goons", Icons.Material.Filled.Groups);
+                MonitorMessageButton goonsButton = new("Report Goons", Icons.Material.Filled.Groups);
                 goonsButton.OnClick = async () => {
                     try
                     {
                         await TarkovDev.PostGoonsSighting(raidInfo.Map?.nameId, (DateTime)raidInfo.StartedTime, Int32.Parse(raidInfo.Profile.AccountId), GameWatcher.CurrentProfile.Type);
-                        messageLog.AddMessage($"Goons reported on {raidInfo.Map?.name}", "info");
+                        messageLog.AddMessage($"Reported Goons on {raidInfo.Map?.name}.", "info");
                     }
                     catch (Exception ex)
                     {
-                        messageLog.AddMessage($"Error reporting goons: {ex.Message} {ex.StackTrace}", "exception");
+                        messageLog.AddMessage($"Could not report the Goons sighting: {ex.Message} {ex.StackTrace}", "exception");
                     }
                     monMessage.Buttons.Remove(goonsButton);
                 };
                 goonsButton.Confirm = new(
                     $"Report Goons on {raidInfo.Map?.name}",
-                    "<p>Please only submit a report if you saw the goons in this raid.</p><p><strong>Notice:</strong> By submitting a goons report, you consent to collection of your IP address and EFT account id for report verification purposes.</p>",
+                    "<p>Submit a report only if you saw the Goons during this raid.</p><p><strong>Notice:</strong> By submitting a report, you consent to the collection of your IP address and EFT account ID for verification.</p>",
                     "Submit report", "Cancel"
                 );
                 goonsButton.Timeout = TimeSpan.FromMinutes(120).TotalMilliseconds;
@@ -1080,17 +1229,16 @@ namespace TarkovMonitor
                 var mapName = e.Map;
                 var map = TarkovDev.Maps.Find(m => m.nameId == mapName);
                 if (map != null) mapName = map.name;
-                messageLog.AddMessage($"Exited {mapName} raid", "raidleave");
+                messageLog.AddMessage($"Left the {mapName} raid.", "raidleave");
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error updating log message from event: {ex.Message}", "exception");
+                messageLog.AddMessage($"Could not update the message for this event: {ex.Message}", "exception");
             }
         }
 
         private void MainBlazorUI_Resize(object sender, EventArgs e)
         {
-            WindowStateChanged?.Invoke(this, EventArgs.Empty);
             try
             {
                 if (this.WindowState == FormWindowState.Minimized && Properties.Settings.Default.minimizeToTray)
@@ -1098,10 +1246,37 @@ namespace TarkovMonitor
                     Hide();
                     notifyIconTarkovMonitor.Visible = true;
                 }
+
+                if (WindowState == lastPublishedWindowState || windowStateNotificationPending)
+                {
+                    return;
+                }
+
+                windowStateNotificationPending = true;
+                BeginInvoke(new Action(() =>
+                {
+                    windowStateNotificationPending = false;
+
+                    if (IsDisposed || !IsHandleCreated || WindowState == lastPublishedWindowState)
+                    {
+                        return;
+                    }
+
+                    var previousWindowState = lastPublishedWindowState;
+                    var nextWindowState = WindowState;
+                    lastPublishedWindowState = nextWindowState;
+
+                    if (previousWindowState == FormWindowState.Maximized && nextWindowState == FormWindowState.Normal)
+                    {
+                        RefreshNormalWindowFrame();
+                    }
+
+                    WindowStateChanged?.Invoke(this, EventArgs.Empty);
+                }));
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error minimizing to tray: {ex.Message} {ex.StackTrace}", "exception");
+                messageLog.AddMessage($"Could not minimize to the system tray: {ex.Message} {ex.StackTrace}", "exception");
             }
         }
 
@@ -1115,7 +1290,7 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                messageLog.AddMessage($"Error restoring from tray: {ex.Message} {ex.StackTrace}", "exception");
+                messageLog.AddMessage($"Could not restore the window from the system tray: {ex.Message} {ex.StackTrace}", "exception");
             }
         }
 

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -85,7 +85,7 @@ namespace TarkovMonitor
         private readonly object tarkovDevDataRefreshLock = new();
         private CancellationTokenSource? tarkovDevDataRefreshCancellation;
         private long tarkovDevDataRefreshGeneration;
-        private ProfileType tarkovDevDataRefreshProfileType = ProfileType.Unknown;
+        private Profile? tarkovDevDataProfile;
 
         private readonly record struct TrackerSessionNoticeIdentity(
             string AccountId,
@@ -173,19 +173,35 @@ namespace TarkovMonitor
             eft.MatchingAborted += Eft_GroupStaleEvent;
             eft.GameStarted += Eft_GroupStaleEvent;
             eft.GameStarted += Eft_GameStarted;
+            eft.GameStopped += Eft_GameStopped;
             eft.MapLoading += Eft_MapLoading;
             eft.MapLoading += Eft_MapLoading_NavigateToMap;
             eft.MatchingStarted += Eft_MatchingStarted;
             eft.MatchFound += Eft_MatchFound;
             eft.PlayerPosition += Eft_PlayerPosition;
             eft.ProfileChanged += Eft_ProfileChanged;
+            eft.ProfileReady += Eft_ProfileReady;
             eft.ControlSettings += Eft_ControlSettings;
 
             eft.InitialReadComplete += (object? sender, ProfileEventArgs e) =>
             {
-                if (e.Profile.Type == ProfileType.Unknown)
+                if (!e.Profile.HasTarkovDevPlayerRoute)
                 {
                     TarkovTracker.ResetActiveState();
+                    TarkovDev.StopAutoUpdates();
+                    InvalidateTarkovDevData();
+                    return;
+                }
+
+                if (!eft.IsGameRunning)
+                {
+                    // The startup scan is historical, not a live EFT session.
+                    // It may still establish the read-only Tarkov.dev context so
+                    // the user does not need to launch EFT just to verify the
+                    // data connection. Tracker writes remain inactive.
+                    _ = RefreshTarkovDevApiData(e.Profile, allowPersistedProfile: true);
+                    TarkovTracker.ResetActiveState();
+                    TarkovDev.StopAutoUpdates();
                     return;
                 }
 
@@ -224,7 +240,6 @@ namespace TarkovMonitor
 
             TarkovTracker.ProgressRetrieved += TarkovTracker_ProgressRetrieved;
             TarkovDev.ExceptionThrown += TarkovDev_ExceptionThrown;
-            TarkovTracker.OrgKeyAutoAssigned += TarkovTracker_OrgKeyAutoAssigned;
 
             UpdateCheck.NewVersion += UpdateCheck_NewVersion;
             UpdateCheck.Error += UpdateCheck_Error;
@@ -467,7 +482,37 @@ namespace TarkovMonitor
         {
             var profileSnapshot = e.Profile.Snapshot();
             _ = RefreshTarkovDevApiData(profileSnapshot);
+            if (profileSnapshot.HasTarkovDevPlayerRoute && eft.IsGameRunning)
+            {
+                TarkovDev.StartAutoUpdates();
+            }
+            else
+            {
+                TarkovDev.StopAutoUpdates();
+            }
             _ = InitializeProgress(profileSnapshot, announceSession: true);
+        }
+
+        private void Eft_ProfileReady(object? sender, ProfileEventArgs e)
+        {
+            var profileSnapshot = e.Profile.Snapshot();
+            _ = RefreshTarkovDevApiData(profileSnapshot);
+            if (profileSnapshot.HasTarkovDevPlayerRoute && eft.IsGameRunning)
+            {
+                TarkovDev.StartAutoUpdates();
+            }
+            else
+            {
+                TarkovDev.StopAutoUpdates();
+            }
+            _ = InitializeProgress(profileSnapshot, announceSession: true);
+        }
+
+        private void Eft_GameStopped(object? sender, EventArgs e)
+        {
+            TarkovTracker.DeactivateProfile();
+            TarkovDev.StopAutoUpdates();
+            InvalidateTarkovDevData();
         }
 
         private void Eft_GameStarted(object? sender, EventArgs e)
@@ -622,6 +667,15 @@ namespace TarkovMonitor
             startupServicesStarted = true;
             try
             {
+                var lastKnownProfile = TarkovTracker.GetLastKnownOrgProfile();
+                if (lastKnownProfile != null)
+                {
+                    // Tarkov.dev data is read-only and can be preloaded from the
+                    // last complete profile without requiring EFT to be running.
+                    // Live EFT identity is still required before tracker writes
+                    // are activated.
+                    _ = RefreshTarkovDevApiData(lastKnownProfile, allowPersistedProfile: true);
+                }
                 gameWatcherStarted = eft.Start();
             }
             catch (Exception ex)
@@ -796,18 +850,6 @@ namespace TarkovMonitor
                 $"https://{Properties.Settings.Default.tarkovTrackerDomain}");
         }
 
-        private void TarkovTracker_OrgKeyAutoAssigned(object? sender, TarkovTracker.OrgKeyAutoAssignedEventArgs e)
-        {
-            messageLog.AddProtectedMessage(
-                $"TarkovTracker.org API key assigned - Session: {TarkovTracker.GetSessionDisplayName(e.SessionMode)}.",
-                "info",
-                new[]
-                {
-                    new MonitorMessageProtectedValue("Account ID", e.AccountId),
-                    new MonitorMessageProtectedValue("Profile ID", e.ProfileId),
-                });
-        }
-
         private void Eft_GroupStaleEvent(object? sender, EventArgs e)
         {
             return;
@@ -849,29 +891,24 @@ namespace TarkovMonitor
             }
         }
 
-        private async Task RefreshTarkovDevApiData(Profile profile)
+        private async Task RefreshTarkovDevApiData(Profile profile, bool allowPersistedProfile = false)
         {
             var profileSnapshot = profile.Snapshot();
-            if (profileSnapshot.Type == ProfileType.Unknown)
+            if (!profileSnapshot.HasTarkovDevPlayerRoute
+                || profileSnapshot.Type == ProfileType.Unknown)
             {
-                lock (tarkovDevDataRefreshLock)
-                {
-                    tarkovDevDataRefreshGeneration++;
-                    tarkovDevDataRefreshCancellation?.Cancel();
-                    tarkovDevDataRefreshCancellation = null;
-                    tarkovDevDataRefreshProfileType = ProfileType.Unknown;
-                    TarkovDev.ClearApiData();
-                }
+                InvalidateTarkovDevData();
                 return;
             }
 
             CancellationTokenSource refreshCancellation;
             long refreshGeneration;
+            Profile? previousProfile;
             lock (tarkovDevDataRefreshLock)
             {
-                if (tarkovDevDataRefreshProfileType == profileSnapshot.Type
-                    || (tarkovDevDataRefreshProfileType == ProfileType.Unknown
-                        && TarkovDev.LoadedProfileType == profileSnapshot.Type))
+                if (tarkovDevDataProfile != null
+                    && ProfilesMatch(tarkovDevDataProfile, profileSnapshot)
+                    && TarkovDev.LoadedProfileType == profileSnapshot.Type)
                 {
                     return;
                 }
@@ -881,14 +918,18 @@ namespace TarkovMonitor
                 tarkovDevDataRefreshCancellation?.Cancel();
                 refreshCancellation = new CancellationTokenSource();
                 tarkovDevDataRefreshCancellation = refreshCancellation;
-                tarkovDevDataRefreshProfileType = profileSnapshot.Type;
+                previousProfile = tarkovDevDataProfile;
+                tarkovDevDataProfile = profileSnapshot;
 
-                if (TarkovDev.LoadedProfileType != profileSnapshot.Type)
+                if (previousProfile == null
+                    || !ProfilesMatch(previousProfile, profileSnapshot)
+                    || TarkovDev.LoadedProfileType != profileSnapshot.Type)
                 {
                     TarkovDev.ClearApiData();
                 }
             }
 
+            var published = false;
             try
             {
                 var data = await TarkovDev.LoadApiData(profileSnapshot.Type, refreshCancellation.Token);
@@ -896,12 +937,13 @@ namespace TarkovMonitor
                 {
                     if (refreshGeneration != tarkovDevDataRefreshGeneration
                         || !ReferenceEquals(refreshCancellation, tarkovDevDataRefreshCancellation)
-                        || GameWatcher.CurrentProfile.Type != profileSnapshot.Type)
+                        || !IsTarkovDevRefreshOwnerCurrent(profileSnapshot, allowPersistedProfile))
                     {
                         return;
                     }
 
                     TarkovDev.PublishApiData(data);
+                    published = true;
                 }
 
                 messageLog.AddMessage(
@@ -925,7 +967,7 @@ namespace TarkovMonitor
                 {
                     if (refreshGeneration != tarkovDevDataRefreshGeneration
                         || !ReferenceEquals(refreshCancellation, tarkovDevDataRefreshCancellation)
-                        || GameWatcher.CurrentProfile.Type != profileSnapshot.Type)
+                        || !IsTarkovDevRefreshOwnerCurrent(profileSnapshot, allowPersistedProfile))
                     {
                         return;
                     }
@@ -940,10 +982,64 @@ namespace TarkovMonitor
                     if (refreshGeneration == tarkovDevDataRefreshGeneration
                         && ReferenceEquals(refreshCancellation, tarkovDevDataRefreshCancellation))
                     {
-                        tarkovDevDataRefreshProfileType = ProfileType.Unknown;
+                        if (!published)
+                        {
+                            tarkovDevDataProfile = null;
+                        }
                         tarkovDevDataRefreshCancellation = null;
                     }
                 }
+            }
+        }
+
+        private static bool ProfilesMatch(Profile left, Profile right)
+        {
+            return left.Type == right.Type
+                && left.SessionMode == right.SessionMode
+                && string.Equals(left.AccountId, right.AccountId, StringComparison.Ordinal)
+                && string.Equals(left.Id, right.Id, StringComparison.Ordinal);
+        }
+
+        private static bool IsCurrentProfile(Profile expectedProfile)
+        {
+            var currentProfile = GameWatcher.CurrentProfile.Snapshot();
+            return currentProfile.HasTarkovDevPlayerRoute
+                && ProfilesMatch(currentProfile, expectedProfile);
+        }
+
+        private bool IsTarkovDevRefreshOwnerCurrent(Profile expectedProfile, bool allowPersistedProfile)
+        {
+            if (eft.IsGameRunning)
+            {
+                return IsCurrentProfile(expectedProfile);
+            }
+
+            if (!allowPersistedProfile)
+            {
+                return false;
+            }
+
+            var historicalProfile = GameWatcher.CurrentProfile.Snapshot();
+            if (historicalProfile.HasTarkovDevPlayerRoute
+                && ProfilesMatch(historicalProfile, expectedProfile))
+            {
+                return true;
+            }
+
+            var lastKnownProfile = TarkovTracker.GetLastKnownOrgProfile();
+            return lastKnownProfile != null
+                && ProfilesMatch(lastKnownProfile, expectedProfile);
+        }
+
+        private void InvalidateTarkovDevData()
+        {
+            lock (tarkovDevDataRefreshLock)
+            {
+                tarkovDevDataRefreshGeneration++;
+                tarkovDevDataRefreshCancellation?.Cancel();
+                tarkovDevDataRefreshCancellation = null;
+                tarkovDevDataProfile = null;
+                TarkovDev.ClearApiData();
             }
         }
 

--- a/TarkovMonitor/MessageLog.cs
+++ b/TarkovMonitor/MessageLog.cs
@@ -54,6 +54,36 @@ namespace TarkovMonitor
             AddMessageCore(monMessage);
         }
 
+        public void AddMessages(IEnumerable<MonitorMessage> messageBatch, bool preserveDisplayOrder = false)
+        {
+            var batch = messageBatch.ToList();
+            if (batch.Count == 0)
+            {
+                return;
+            }
+
+            var batchId = preserveDisplayOrder ? Guid.NewGuid() : (Guid?)null;
+            foreach (var message in batch)
+            {
+                message.Message = LimitMessageLength(message.Message);
+                message.DisplayBatchId = batchId;
+                message.PreserveDisplayBatchOrder = preserveDisplayOrder;
+            }
+
+            lock (messagesLock)
+            {
+                messages.AddRange(batch);
+                if (messages.Count > MaxMessages)
+                {
+                    messages.RemoveRange(0, messages.Count - MaxMessages);
+                }
+            }
+
+            // A historical replay can produce many task messages at once. Notify once
+            // after the complete batch is visible so the UI performs one stable render.
+            newMessage(this, new NewLogMessageArgs(batch[^1]));
+        }
+
         public void AddProtectedMessage(
             string message,
             string? type,

--- a/TarkovMonitor/MessageLog.cs
+++ b/TarkovMonitor/MessageLog.cs
@@ -27,29 +27,73 @@ namespace TarkovMonitor
 
     internal class MessageLog
     {
+        internal const int MaxMessageLength = 2048;
+        internal const int MaxMessages = 200;
+        private const string ShortenedMessageSuffix = "\n[Message shortened by Tarkov Monitor.]";
+        private readonly object messagesLock = new();
+        private readonly List<MonitorMessage> messages = new();
         public event NewLogMessage newMessage = delegate { };
 
-        public MessageLog()
+        public IReadOnlyList<MonitorMessage> GetSnapshot()
         {
-            Messages = new List<MonitorMessage>();
+            lock (messagesLock)
+            {
+                return messages.ToList();
+            }
         }
-        public List<MonitorMessage> Messages { get; set; }
-        
+
         public void AddMessage(MonitorMessage message)
         {
-            Messages.Add(message);
+            message.Message = LimitMessageLength(message.Message);
+            AddMessageCore(message);
+        }
 
-            // Throw event to let watchers know something has changed
+        public void AddMessage(string message, string? type = "", string? url = null, string? linkText = null)
+        {
+            var monMessage = new MonitorMessage(LimitMessageLength(message), type, url, linkText);
+            AddMessageCore(monMessage);
+        }
+
+        public void AddProtectedMessage(
+            string message,
+            string? type,
+            IEnumerable<MonitorMessageProtectedValue> protectedValues,
+            string? url = null,
+            string? linkText = null)
+        {
+            var monMessage = new MonitorMessage(LimitMessageLength(message), type, url, linkText);
+            foreach (var protectedValue in protectedValues
+                .Where(value => !string.IsNullOrWhiteSpace(value.Label)
+                    && !string.IsNullOrWhiteSpace(value.Value)))
+            {
+                monMessage.ProtectedValues.Add(protectedValue);
+            }
+            AddMessageCore(monMessage);
+        }
+
+        private void AddMessageCore(MonitorMessage message)
+        {
+            lock (messagesLock)
+            {
+                messages.Add(message);
+                if (messages.Count > MaxMessages)
+                {
+                    messages.RemoveRange(0, messages.Count - MaxMessages);
+                }
+            }
+
+            // Notify after releasing the lock so render callbacks can safely take a snapshot.
             newMessage(this, new NewLogMessageArgs(message));
         }
 
-        public void AddMessage(string message, string? type = "", string? url = null)
+        private static string LimitMessageLength(string message)
         {
-            var monMessage = new MonitorMessage(message, type, url);
-            Messages.Add(monMessage);
+            if (message.Length <= MaxMessageLength)
+            {
+                return message;
+            }
 
-            // Throw event to let watchers know something has changed
-            newMessage(this, new NewLogMessageArgs(monMessage));
+            return message[..(MaxMessageLength - ShortenedMessageSuffix.Length)] + ShortenedMessageSuffix;
         }
     }
 }

--- a/TarkovMonitor/MonitorMessage.cs
+++ b/TarkovMonitor/MonitorMessage.cs
@@ -194,6 +194,9 @@ namespace TarkovMonitor
         public MonitorMessageButtonConfirm? Confirm { get; set; }
         private System.Timers.Timer? buttonTimer;
         private double? timeout = null;
+        private DateTimeOffset? expiresAtUtc;
+        private int expirationRaised;
+        public bool IsExpired => expiresAtUtc.HasValue && DateTimeOffset.UtcNow >= expiresAtUtc.Value;
         public double? Timeout {
             get
             {
@@ -202,6 +205,10 @@ namespace TarkovMonitor
             set
             {
                 timeout = value;
+                expiresAtUtc = value is > 0
+                    ? DateTimeOffset.UtcNow.AddMilliseconds(value.Value)
+                    : null;
+                Interlocked.Exchange(ref expirationRaised, 0);
                 if (buttonTimer != null)
                 {
                     buttonTimer.Stop();
@@ -219,7 +226,7 @@ namespace TarkovMonitor
                     };
                     buttonTimer.Elapsed += (object? sender, ElapsedEventArgs e) =>
                     {
-                        Expired?.Invoke(this, e);
+                        RaiseExpired(e);
                     };
 
                 }
@@ -243,7 +250,16 @@ namespace TarkovMonitor
         public void Expire()
         {
             buttonTimer?.Stop();
-            Expired?.Invoke(this, new());
+            expiresAtUtc = DateTimeOffset.UtcNow;
+            RaiseExpired(EventArgs.Empty);
+        }
+
+        private void RaiseExpired(EventArgs args)
+        {
+            if (Interlocked.Exchange(ref expirationRaised, 1) == 0)
+            {
+                Expired?.Invoke(this, args);
+            }
         }
     }
 

--- a/TarkovMonitor/MonitorMessage.cs
+++ b/TarkovMonitor/MonitorMessage.cs
@@ -1,20 +1,95 @@
 ﻿using MudBlazor;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Timers;
 
 namespace TarkovMonitor
 {
+    public sealed class MonitorMessageCollection<T>
+    {
+        private readonly object syncRoot = new();
+        private readonly List<T> items = new();
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public int Count
+        {
+            get
+            {
+                lock (syncRoot)
+                {
+                    return items.Count;
+                }
+            }
+        }
+
+        public IReadOnlyList<T> GetSnapshot()
+        {
+            lock (syncRoot)
+            {
+                return items.ToList();
+            }
+        }
+
+        public void Add(T item)
+        {
+            lock (syncRoot)
+            {
+                var index = items.Count;
+                items.Add(item);
+                CollectionChanged?.Invoke(
+                    this,
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            lock (syncRoot)
+            {
+                var index = items.IndexOf(item);
+                if (index < 0)
+                {
+                    return false;
+                }
+
+                var removedItem = items[index];
+                items.RemoveAt(index);
+                CollectionChanged?.Invoke(
+                    this,
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItem, index));
+                return true;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (syncRoot)
+            {
+                if (items.Count == 0)
+                {
+                    return;
+                }
+
+                var removedItems = items.ToList();
+                items.Clear();
+                CollectionChanged?.Invoke(
+                    this,
+                    new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItems, 0));
+            }
+        }
+    }
+
     public class MonitorMessage
     {
         public string Message { get; set; }
         public DateTime Time { get; set; } = DateTime.Now;
         public string Type { get; set; } = "";
         public string Url { get; set; } = "";
+        public string LinkText { get; set; } = "";
         public Action? OnClick { get; set; } = null;
-        public ObservableCollection<MonitorMessageButton> Buttons { get; set; } = new();
-        public ObservableCollection<MonitorMessageSelect> Selects { get; set; } = new();
+        public MonitorMessageCollection<MonitorMessageButton> Buttons { get; } = new();
+        public MonitorMessageCollection<MonitorMessageSelect> Selects { get; } = new();
+        public List<MonitorMessageProtectedValue> ProtectedValues { get; } = new();
         public MonitorMessage(string message)
         {
             Message = message;
@@ -43,10 +118,11 @@ namespace TarkovMonitor
                 }
             };
         }
-        public MonitorMessage(string message, string? type = "", string? url = "") : this(message)
+        public MonitorMessage(string message, string? type = "", string? url = "", string? linkText = "") : this(message)
         {
             Type = type ?? "";
             Url = url ?? "";
+            LinkText = linkText ?? "";
             if (Type == "exception")
             {
                 Buttons.Add(new("Copy", () => {
@@ -70,6 +146,18 @@ namespace TarkovMonitor
                 return;
             }
             Buttons.Remove((MonitorMessageButton)sender);
+        }
+    }
+
+    public sealed class MonitorMessageProtectedValue
+    {
+        public string Label { get; }
+        public string Value { get; }
+
+        public MonitorMessageProtectedValue(string label, string value)
+        {
+            Label = label;
+            Value = value;
         }
     }
 
@@ -103,7 +191,7 @@ namespace TarkovMonitor
                 else
                 {
                     buttonTimer = new(timeout ?? 0) {
-                        AutoReset = true,
+                        AutoReset = false,
                         Enabled = true,
                     };
                     buttonTimer.Elapsed += (object? sender, ElapsedEventArgs e) =>

--- a/TarkovMonitor/MonitorMessage.cs
+++ b/TarkovMonitor/MonitorMessage.cs
@@ -81,6 +81,8 @@ namespace TarkovMonitor
 
     public class MonitorMessage
     {
+        internal Guid? DisplayBatchId { get; set; }
+        internal bool PreserveDisplayBatchOrder { get; set; }
         public string Message { get; set; }
         public DateTime Time { get; set; } = DateTime.Now;
         public string Type { get; set; } = "";

--- a/TarkovMonitor/Program.cs
+++ b/TarkovMonitor/Program.cs
@@ -43,6 +43,12 @@ namespace TarkovMonitor
 				Properties.Settings.Default.upgradeRequired = false;
 				Properties.Settings.Default.Save();
 			}
+
+			// WebView2 and the executable working directory are prerequisites for
+			// every startup path, including skip-splash and minimized startup.
+			Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+			Splash.EnsureWebView2Runtime(diagnostics);
+
 			// Initialize the application behind the branding splash. The native
 			// window stays hidden, but WebView2 and Blazor are allowed to render
 			// immediately so the first revealed frame is complete.

--- a/TarkovMonitor/Program.cs
+++ b/TarkovMonitor/Program.cs
@@ -12,13 +12,65 @@ namespace TarkovMonitor
             // see https://aka.ms/applicationconfiguration.
             ApplicationConfiguration.Initialize();
 
-            var splashTime = 2000;
-			if (Properties.Settings.Default.skipSplash || Properties.Settings.Default.minimizeAtStartup)
+			// Upgrade the previous version's user settings before any startup
+			// preference is read. Otherwise a first launch after an update uses
+			// the new defaults for the splash and startup window state, then only
+			// restores the user's saved choices after the main window is created.
+			if (Properties.Settings.Default.upgradeRequired)
 			{
-				splashTime = 1;
+				Properties.Settings.Default.Upgrade();
+				Properties.Settings.Default.upgradeRequired = false;
+				Properties.Settings.Default.Save();
 			}
-			Application.Run(new Splash(TarkovMonitor.Properties.Resources.tarkov_dev_logo, splashTime));
-			Application.Run(new MainBlazorUI());
+
+			// Initialize the application behind the branding splash. The native
+			// window stays hidden, but WebView2 and Blazor are allowed to render
+			// immediately so the first revealed frame is complete.
+			var splashTime = 1000;
+			var splashEnabled = !Properties.Settings.Default.skipSplash && !Properties.Settings.Default.minimizeAtStartup;
+			// Keep the native host hidden until the first complete Blazor render in
+			// both modes. Skip mode has no branding window, but it should still
+			// reveal the finished UI instead of exposing the temporary WebView
+			// startup shell.
+			var mainWindow = new MainBlazorUI(holdUntilSplashCompletes: true)
+			{
+				ShowInTaskbar = false
+			};
+			if (!splashEnabled)
+			{
+				mainWindow.UiReady += (_, _) => mainWindow.ReleaseSplashGate();
+			}
+			else
+			{
+				mainWindow.Shown += (_, _) =>
+				{
+					var startupSplash = new Splash(TarkovMonitor.Properties.Resources.tarkov_dev_logo, splashTime, waitForReadiness: true);
+					var startupFallback = new System.Windows.Forms.Timer { Interval = 10000 };
+					mainWindow.UiReady += (_, _) => startupSplash.CloseWhenReady();
+					startupFallback.Tick += (_, _) =>
+					{
+						startupFallback.Stop();
+						startupSplash.CloseWhenReady();
+					};
+					startupSplash.FormClosing += (_, _) =>
+					{
+						mainWindow.ReleaseSplashGate();
+					};
+					startupSplash.FormClosed += (_, _) => startupFallback.Dispose();
+					var startupWorkArea = Screen.PrimaryScreen!.WorkingArea;
+					var startupLeft = startupWorkArea.Left + Math.Max(0, (startupWorkArea.Width - startupSplash.Width) / 2);
+					var startupTop = startupWorkArea.Top + Math.Max(0, (startupWorkArea.Height - startupSplash.Height) / 2);
+					startupSplash.SetStartupLocation(new Point(startupLeft, startupTop));
+					startupSplash.Show();
+					if (mainWindow.IsUiReady)
+					{
+						startupSplash.CloseWhenReady();
+					}
+					startupFallback.Start();
+				};
+			}
+
+			Application.Run(mainWindow);
         }
     }
 }

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -313,7 +313,7 @@ namespace TarkovMonitor.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("{\"version\":4,\"keys\":[],\"accounts\":[],\"profiles\":[]}")]
+        [global::System.Configuration.DefaultSettingValueAttribute("{\"version\":6,\"keys\":[],\"accounts\":[],\"profiles\":[]}")]
         public string tarkovTrackerOrgTokenStore {
             get {
                 return ((string)(this["tarkovTrackerOrgTokenStore"]));

--- a/TarkovMonitor/Properties/Settings.Designer.cs
+++ b/TarkovMonitor/Properties/Settings.Designer.cs
@@ -286,6 +286,54 @@ namespace TarkovMonitor.Properties {
                 this["tarkovTrackerTokens"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{}")]
+        public string tarkovTrackerModeTokens {
+            get {
+                return ((string)(this["tarkovTrackerModeTokens"]));
+            }
+            set {
+                this["tarkovTrackerModeTokens"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{}")]
+        public string tarkovTrackerVerifiedModeTokenHashes {
+            get {
+                return ((string)(this["tarkovTrackerVerifiedModeTokenHashes"]));
+            }
+            set {
+                this["tarkovTrackerVerifiedModeTokenHashes"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{\"version\":4,\"keys\":[],\"accounts\":[],\"profiles\":[]}")]
+        public string tarkovTrackerOrgTokenStore {
+            get {
+                return ((string)(this["tarkovTrackerOrgTokenStore"]));
+            }
+            set {
+                this["tarkovTrackerOrgTokenStore"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string lastTarkovSessionMode {
+            get {
+                return ((string)(this["lastTarkovSessionMode"]));
+            }
+            set {
+                this["lastTarkovSessionMode"] = value;
+            }
+        }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -68,6 +68,18 @@
     <Setting Name="tarkovTrackerTokens" Type="System.String" Scope="User">
       <Value Profile="(Default)">{}</Value>
     </Setting>
+    <Setting Name="tarkovTrackerModeTokens" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{}</Value>
+    </Setting>
+    <Setting Name="tarkovTrackerVerifiedModeTokenHashes" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{}</Value>
+    </Setting>
+    <Setting Name="tarkovTrackerOrgTokenStore" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{"version":4,"keys":[],"accounts":[],"profiles":[]}</Value>
+    </Setting>
+    <Setting Name="lastTarkovSessionMode" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
     <Setting Name="runthroughTime" Type="System.TimeSpan" Scope="User">
       <Value Profile="(Default)">00:07:10</Value>
     </Setting>

--- a/TarkovMonitor/Properties/Settings.settings
+++ b/TarkovMonitor/Properties/Settings.settings
@@ -75,7 +75,7 @@
       <Value Profile="(Default)">{}</Value>
     </Setting>
     <Setting Name="tarkovTrackerOrgTokenStore" Type="System.String" Scope="User">
-      <Value Profile="(Default)">{"version":4,"keys":[],"accounts":[],"profiles":[]}</Value>
+      <Value Profile="(Default)">{"version":6,"keys":[],"accounts":[],"profiles":[]}</Value>
     </Setting>
     <Setting Name="lastTarkovSessionMode" Type="System.String" Scope="User">
       <Value Profile="(Default)" />

--- a/TarkovMonitor/Properties/Strings.Designer.cs
+++ b/TarkovMonitor/Properties/Strings.Designer.cs
@@ -583,7 +583,7 @@ namespace TarkovMonitor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from tarkov.dev.
+        ///   Looks up a localized string similar to Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from Tarkov.dev for {5}.
         /// </summary>
         internal static string RetrievedDataFromTarkovDev {
             get {
@@ -592,7 +592,7 @@ namespace TarkovMonitor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Retrieved {0} level {1} {2} progress from Tarkov Tracker.
+        ///   Looks up a localized string similar to Retrieved Tarkov Tracker progress for {0} (level {1}, {2}) ({3}).
         /// </summary>
         internal static string RetrievedDataFromTarkovTracker {
             get {
@@ -862,7 +862,7 @@ namespace TarkovMonitor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To automatically track task progress, set your Tarkov Tracker token in Settings.
+        ///   Looks up a localized string similar to To track task progress automatically, assign your Tarkov Tracker token in Settings.
         /// </summary>
         internal static string ToAutomaticallyTrackTaskProgress {
             get {

--- a/TarkovMonitor/Properties/Strings.de.resx
+++ b/TarkovMonitor/Properties/Strings.de.resx
@@ -333,15 +333,15 @@
     <value>Quest</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Es wurden {0} Gegenstände, {1} Karten, {2} Händler, {3} Aufgaben und {4} Versteckstationen von tarkov.dev abgerufen.</value>
+    <value>Es wurden {0} Gegenstände, {1} Karten, {2} Händler, {3} Aufgaben und {4} Versteckstationen von tarkov.dev für {5} abgerufen.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>Um den Aufgabenfortschritt automatisch zu verfolgen, lege deinen Tarkov-Tracker-Token in den Einstellungen fest.</value>
+    <value>Um den Aufgabenfortschritt automatisch zu verfolgen, weise deinen Tarkov-Tracker-Token in den Einstellungen zu.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Profil {0} wird verwendet</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Fortschritt von {0} Level {1} {2} aus Tarkov Tracker abgerufen</value>
+    <value>Fortschritt von {0} Level {1} {2} aus Tarkov Tracker für {3} abgerufen</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.es.resx
+++ b/TarkovMonitor/Properties/Strings.es.resx
@@ -333,15 +333,15 @@
     <value>Misión</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Se obtuvieron {0} objetos, {1} mapas, {2} comerciantes, {3} misiones y {4} estaciones del escondite desde tarkov.dev.</value>
+    <value>Se obtuvieron {0} objetos, {1} mapas, {2} comerciantes, {3} misiones y {4} estaciones del escondite desde tarkov.dev para {5}.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>Para seguir automáticamente el progreso de las misiones, establece tu token de Tarkov Tracker en Configuración.</value>
+    <value>Para seguir automáticamente el progreso de las misiones, asigna tu token de Tarkov Tracker en Configuración.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Usando el perfil {0}</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Se recuperó el progreso de {0} nivel {1} {2} desde Tarkov Tracker</value>
+    <value>Se recuperó el progreso de {0} nivel {1} {2} desde Tarkov Tracker para {3}</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.fr.resx
+++ b/TarkovMonitor/Properties/Strings.fr.resx
@@ -333,15 +333,15 @@
     <value>Quête</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Récupéré {0} objets, {1} cartes, {2} marchands, {3} quêtes et {4} stations d'abri depuis tarkov.dev.</value>
+    <value>Récupéré {0} objets, {1} cartes, {2} marchands, {3} quêtes et {4} stations d'abri depuis tarkov.dev pour {5}.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>Pour suivre automatiquement la progression des quêtes, définissez votre jeton Tarkov Tracker dans Paramètres.</value>
+    <value>Pour suivre automatiquement la progression des quêtes, attribuez votre jeton Tarkov Tracker dans Paramètres.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Profil {0} utilisé</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Récupéré la progression {0} niveau {1} {2} depuis Tarkov Tracker</value>
+    <value>Récupéré la progression {0} niveau {1} {2} depuis Tarkov Tracker pour {3}</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.pl.resx
+++ b/TarkovMonitor/Properties/Strings.pl.resx
@@ -333,15 +333,15 @@
     <value>Zadanie</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Pobrano z tarkov.dev {0} przedmiotów, {1} map, {2} handlarzy, {3} zadań i {4} stacji kryjówki.</value>
+    <value>Pobrano z tarkov.dev {0} przedmiotów, {1} map, {2} handlarzy, {3} zadań i {4} stacji kryjówki dla {5}.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>Aby automatycznie śledzić postęp zadań, ustaw token Tarkov Tracker w Ustawieniach.</value>
+    <value>Aby automatycznie śledzić postęp zadań, przypisz token Tarkov Tracker w Ustawieniach.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Używany profil {0}</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Pobrano z Tarkov Tracker postęp {0} poziomu {1} {2}</value>
+    <value>Pobrano z Tarkov Tracker postęp {0} poziomu {1} {2} dla {3}</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.pt.resx
+++ b/TarkovMonitor/Properties/Strings.pt.resx
@@ -333,15 +333,15 @@
     <value>Missão</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Foram obtidos {0} itens, {1} mapas, {2} comerciantes, {3} tarefas e {4} estações do abrigo de tarkov.dev.</value>
+    <value>Foram obtidos {0} itens, {1} mapas, {2} comerciantes, {3} tarefas e {4} estações do abrigo de tarkov.dev para {5}.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>Para rastrear automaticamente o progresso das tarefas, defina seu token do Tarkov Tracker em Configurações.</value>
+    <value>Para rastrear automaticamente o progresso das tarefas, atribua seu token do Tarkov Tracker em Configurações.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Usando o perfil {0}</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Progresso {0} nível {1} {2} recuperado do Tarkov Tracker</value>
+    <value>Progresso {0} nível {1} {2} recuperado do Tarkov Tracker para {3}</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.resx
+++ b/TarkovMonitor/Properties/Strings.resx
@@ -391,15 +391,15 @@
     <value>Quest</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from Tarkov.dev.</value>
+    <value>Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from Tarkov.dev for {5}.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>To track task progress automatically, set your Tarkov Tracker token in Settings.</value>
+    <value>To track task progress automatically, assign your Tarkov Tracker token in Settings.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Using the {0} profile.</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Retrieved Tarkov Tracker progress for {0} (level {1}, {2}).</value>
+    <value>Retrieved Tarkov Tracker progress for {0} (level {1}, {2}) ({3}).</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.resx
+++ b/TarkovMonitor/Properties/Strings.resx
@@ -124,118 +124,118 @@
     <value>Notifications</value>
   </data>
   <data name="NotificationsPlaybackDevice" xml:space="preserve">
-    <value>Notifications playback device</value>
+    <value>Notification playback device</value>
   </data>
   <data name="RaidStartingAudioNotification" xml:space="preserve">
-    <value>Raid Starting Audio Notification</value>
+    <value>Raid start notification</value>
   </data>
   <data name="MatchFoundAudioNotification" xml:space="preserve">
-    <value>Match Found Audio Notification</value>
+    <value>Match found notification</value>
   </data>
   <data name="RestartTasksAudioReminder" xml:space="preserve">
-    <value>Restart Tasks Audio Reminder</value>
+    <value>Task restart reminder</value>
   </data>
   <data name="RunthroughPeriodAudioReminder" xml:space="preserve">
-    <value>Runthrough Period Audio Reminder</value>
+    <value>Run-through reminder</value>
   </data>
   <data name="AirFilterAudioReminders" xml:space="preserve">
-    <value>Air Filter Audio Reminders</value>
+    <value>Air filter reminders</value>
   </data>
   <data name="QuestItemReminderAudioNotification" xml:space="preserve">
-    <value>Quest Item Reminder Audio Notification</value>
+    <value>Quest item reminder</value>
   </data>
   <data name="ScavCooldownReminders" xml:space="preserve">
-    <value>Scav Cooldown Reminders</value>
+    <value>Scav cooldown reminders</value>
   </data>
   <data name="ScavKarma" xml:space="preserve">
-    <value>Scav Karma</value>
+    <value>Scav karma</value>
   </data>
   <data name="RunthroughTime" xml:space="preserve">
-    <value>Runthrough Time (HH:MM:SS)</value>
+    <value>Run-through time (HH:MM:SS)</value>
   </data>
   <data name="WindowBehavior" xml:space="preserve">
-    <value>Window Behavior</value>
+    <value>Window behavior</value>
   </data>
   <data name="StartTarkovMonitorMinimized" xml:space="preserve">
-    <value>Start Tarkov Monitor Minimized</value>
+    <value>Start Tarkov Monitor minimized</value>
   </data>
   <data name="MinimizeToSystemTray" xml:space="preserve">
-    <value>Minimize to System Tray</value>
+    <value>Minimize to the system tray</value>
   </data>
   <data name="StayOnTop" xml:space="preserve">
-    <value>Stay on Top</value>
+    <value>Stay on top</value>
   </data>
   <data name="SkipTarkovDevSplashLogo" xml:space="preserve">
-    <value>Skip Tarkov.dev Splash Logo</value>
+    <value>Skip the Tarkov.dev splash logo</value>
   </data>
   <data name="DataCollection" xml:space="preserve">
-    <value>Data Collection</value>
+    <value>Data collection</value>
   </data>
   <data name="SubmitQueueTimeData" xml:space="preserve">
-    <value>Submit Queue Time Data</value>
+    <value>Submit queue-time data</value>
   </data>
   <data name="TarkovTracker" xml:space="preserve">
     <value>TarkovTracker</value>
   </data>
   <data name="GetAToken" xml:space="preserve">
-    <value>Get A Token</value>
+    <value>Get a token</value>
   </data>
   <data name="TestToken" xml:space="preserve">
-    <value>Test Token</value>
+    <value>Test token</value>
   </data>
   <data name="APIToken" xml:space="preserve">
-    <value>API Token</value>
+    <value>API token</value>
   </data>
   <data name="TarkovTrackerService" xml:space="preserve">
-    <value>Tarkov Tracker Service</value>
+    <value>Tarkov Tracker service</value>
   </data>
   <data name="TarkovTrackerServiceHelperText" xml:space="preserve">
-    <value>Tarkov Tracker service to use</value>
+    <value>Choose the Tarkov Tracker service</value>
   </data>
   <data name="TarkovDevWebsiteRemote" xml:space="preserve">
-    <value>Tarkov.dev Website Remote</value>
+    <value>Tarkov.dev website remote</value>
   </data>
   <data name="RemoteID" xml:space="preserve">
     <value>Remote ID</value>
   </data>
   <data name="SwitchToTarkovDevMapOnRaidLoad" xml:space="preserve">
-    <value>Switch to Tarkov.dev map on raid load</value>
+    <value>Switch to the Tarkov.dev map when a raid loads</value>
   </data>
   <data name="SwitchToTarkovDevMapOnPositionUpdate" xml:space="preserve">
-    <value>Switch to Tarkov.dev map on position update (via screenshot)</value>
+    <value>Switch to the Tarkov.dev map when your position updates (via screenshot)</value>
   </data>
   <data name="AutomaticallyDeleteScreenshotsAfterRaid" xml:space="preserve">
-    <value>Automatically delete taken screenshots after raid</value>
+    <value>Delete raid screenshots automatically</value>
   </data>
   <data name="OfflineMap" xml:space="preserve">
-    <value>Offline Map</value>
+    <value>Offline map</value>
   </data>
   <data name="MapToUseForOfflineRaids" xml:space="preserve">
-    <value>Map to use for offline raids</value>
+    <value>Map used for offline raids</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>None</value>
   </data>
   <data name="LogsFolder" xml:space="preserve">
-    <value>Logs Folder</value>
+    <value>Logs folder</value>
   </data>
   <data name="DontChangeThisUnlessYouReallyKnowWhatYoureDoing" xml:space="preserve">
     <value>Don't change this unless you really know what you're doing.</value>
   </data>
   <data name="ResetToDefault" xml:space="preserve">
-    <value>Reset to Default</value>
+    <value>Reset to default</value>
   </data>
   <data name="InitialSetup" xml:space="preserve">
-    <value>Initial Setup</value>
+    <value>Initial setup</value>
   </data>
   <data name="ReadPastLogs" xml:space="preserve">
-    <value>Read Past Logs</value>
+    <value>Read past logs</value>
   </data>
   <data name="Language" xml:space="preserve">
     <value>Language</value>
   </data>
   <data name="SelectLanguage" xml:space="preserve">
-    <value>Select Language</value>
+    <value>Language</value>
   </data>
   <data name="Dashboard" xml:space="preserve">
     <value>Dashboard</value>
@@ -247,7 +247,7 @@
     <value>Group</value>
   </data>
   <data name="RawLogs" xml:space="preserve">
-    <value>Raw Logs</value>
+    <value>Raw logs</value>
   </data>
   <data name="Sounds" xml:space="preserve">
     <value>Sounds</value>
@@ -292,28 +292,28 @@
     <value>Submit</value>
   </data>
   <data name="Ok" xml:space="preserve">
-    <value>Ok</value>
+    <value>OK</value>
   </data>
   <data name="ClearData" xml:space="preserve">
-    <value>Clear Data</value>
+    <value>Clear data</value>
   </data>
   <data name="FleaMarketSales" xml:space="preserve">
-    <value>Flea Market Sales</value>
+    <value>Flea market sales</value>
   </data>
   <data name="Raids" xml:space="preserve">
     <value>Raids</value>
   </data>
   <data name="CustomLogData" xml:space="preserve">
-    <value>Custom Log Data</value>
+    <value>Custom log data</value>
   </data>
   <data name="ReadPreviousLogs" xml:space="preserve">
-    <value>Read Previous Logs</value>
+    <value>Read previous logs</value>
   </data>
   <data name="OpenLogsFolder" xml:space="preserve">
-    <value>Open Logs Folder</value>
+    <value>Open logs folder</value>
   </data>
   <data name="CurrentProfile" xml:space="preserve">
-    <value>Current profile</value>
+    <value>Active profile</value>
   </data>
   <data name="IfYouWantToUpdateProgressForDifferentProfile" xml:space="preserve">
     <value>If you want to update progress for a different profile, activate that profile in the game.</value>
@@ -322,16 +322,16 @@
     <value>Read previous logs</value>
   </data>
   <data name="ChooseStartingPointHelperText" xml:space="preserve">
-    <value>Choose the starting point from which to read logs</value>
+    <value>Choose where to start reading logs</value>
   </data>
   <data name="SelectStartingPointDescription" xml:space="preserve">
-    <value>Select a starting point to read previous logs and update your quest progress. All logs from that point forward for the same profile will be read and that cumulative progress will be synced to Tarkov Tracker.</value>
+    <value>Choose a starting point. Tarkov Monitor will read logs from that point forward for the active profile and sync the resulting quest progress to Tarkov Tracker.</value>
   </data>
   <data name="WarningMessage" xml:space="preserve">
-    <value>WARNING: You can mess up your Tarkov Tracker saved quest progress if you pick an invalid starting date, so proceed with caution.</value>
+    <value>Warning: Choosing the wrong starting date can overwrite your saved Tarkov Tracker quest progress.</value>
   </data>
   <data name="CouldNotFindEFTInstallation" xml:space="preserve">
-    <value>Could not find the Escape From Tarkov installation location, or no logs exist.</value>
+    <value>Couldn’t find the Escape from Tarkov installation or any log files.</value>
   </data>
   <data name="NotFound" xml:space="preserve">
     <value>Not found</value>
@@ -340,43 +340,43 @@
     <value>Are you sure you want to clear all data? This cannot be undone.</value>
   </data>
   <data name="CustomRaidStartingSound" xml:space="preserve">
-    <value>Custom Raid Starting Sound</value>
+    <value>Custom sound for raid start</value>
   </data>
   <data name="CustomMatchFoundSound" xml:space="preserve">
-    <value>Custom Match Found Sound</value>
+    <value>Custom sound for match found</value>
   </data>
   <data name="CustomRestartTasksSound" xml:space="preserve">
-    <value>Custom Restart Tasks Sound</value>
+    <value>Custom sound for task restart</value>
   </data>
   <data name="CustomRunthroughPeriodSound" xml:space="preserve">
-    <value>Custom Runthrough Period Sound</value>
+    <value>Custom sound for run-through</value>
   </data>
   <data name="CustomAirFilterOnSound" xml:space="preserve">
-    <value>Custom Air Filter On Sound</value>
+    <value>Custom sound for air filter on</value>
   </data>
   <data name="CustomAirFilterOffSound" xml:space="preserve">
-    <value>Custom Air Filter Off Sound</value>
+    <value>Custom sound for air filter off</value>
   </data>
   <data name="CustomScavCooldownSound" xml:space="preserve">
-    <value>Custom Scav Cooldown Sound</value>
+    <value>Custom sound for Scav availability</value>
   </data>
   <data name="YouArentInAGroupOrHavePartyMembersYet" xml:space="preserve">
-    <value>You aren't in a group or have party members yet.</value>
+    <value>You are not in a group, and no party members are available.</value>
   </data>
   <data name="TimeInRaid" xml:space="preserve">
-    <value>Time In Raid</value>
+    <value>Time in raid</value>
   </data>
   <data name="RunthroughPeriod" xml:space="preserve">
-    <value>Runthrough Period</value>
+    <value>Run-through period</value>
   </data>
   <data name="ScavCooldown" xml:space="preserve">
-    <value>Scav Cooldown</value>
+    <value>Scav cooldown</value>
   </data>
   <data name="ThereArentAnyMessagesYet" xml:space="preserve">
-    <value>There aren't any messages yet.</value>
+    <value>No messages yet.</value>
   </data>
   <data name="FleaMarketSale" xml:space="preserve">
-    <value>Flea Market Sale</value>
+    <value>Flea market sale</value>
   </data>
   <data name="Debug" xml:space="preserve">
     <value>Debug</value>
@@ -391,15 +391,15 @@
     <value>Quest</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from tarkov.dev</value>
+    <value>Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from Tarkov.dev.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>To automatically track task progress, set your Tarkov Tracker token in Settings</value>
+    <value>To track task progress automatically, set your Tarkov Tracker token in Settings.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
-    <value>Using {0} profile</value>
+    <value>Using the {0} profile.</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>Retrieved {0} level {1} {2} progress from Tarkov Tracker</value>
+    <value>Retrieved Tarkov Tracker progress for {0} (level {1}, {2}).</value>
   </data>
 </root>

--- a/TarkovMonitor/Properties/Strings.ru.resx
+++ b/TarkovMonitor/Properties/Strings.ru.resx
@@ -391,10 +391,10 @@
     <value>Квест</value>
   </data>
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>Получено {0} предметов, {1} карт, {2} торговцев, {3} заданий и {4} станций убежища с tarkov.dev</value>
+    <value>Получено {0} предметов, {1} карт, {2} торговцев, {3} заданий и {4} станций убежища с tarkov.dev для режима {5}</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>Для автоматического отслеживания прогресса заданий установите токен Tarkov Tracker в настройках</value>
+    <value>Для автоматического отслеживания прогресса заданий назначьте токен Tarkov Tracker в настройках</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Используется {0} профиль</value>

--- a/TarkovMonitor/Properties/Strings.zh.resx
+++ b/TarkovMonitor/Properties/Strings.zh.resx
@@ -363,15 +363,15 @@
 
   <!-- Dynamic Messages -->
   <data name="RetrievedDataFromTarkovDev" xml:space="preserve">
-    <value>从 tarkov.dev 获取了 {0} 个物品, {1} 张地图, {2} 个商人, {3} 个任务, 和 {4} 个藏身处工作站</value>
+    <value>从 tarkov.dev 获取了 {0} 个物品, {1} 张地图, {2} 个商人, {3} 个任务, 和 {4} 个藏身处工作站（{5}）</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>要自动追踪任务进度，请在设置中设置你的 Tarkov Tracker 令牌</value>
+    <value>要自动追踪任务进度，请在设置中分配你的 Tarkov Tracker 令牌</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>正在使用 {0} 档案</value>
   </data>
   <data name="RetrievedDataFromTarkovTracker" xml:space="preserve">
-    <value>从 Tarkov Tracker 获取了 {0} 等级 {1} {2} 进度</value>
+    <value>从 Tarkov Tracker 获取了 {0} 等级 {1} {2}（{3}）进度</value>
   </data>
 </root>

--- a/TarkovMonitor/SocketClient.cs
+++ b/TarkovMonitor/SocketClient.cs
@@ -69,6 +69,7 @@ namespace TarkovMonitor
             var remoteid = Properties.Settings.Default.remoteId;
             socket = new();
             socket.Options.SetRequestHeader("User-Agent", $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}/{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
+            socket.Options.SetRequestHeader("origin", $"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name}/{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
             await socket.ConnectAsync(new Uri(wsUrl + $"?sessionid={remoteid}-tm"), new());
             idleTimer.Stop();
             idleTimer.Start();

--- a/TarkovMonitor/Splash.cs
+++ b/TarkovMonitor/Splash.cs
@@ -17,7 +17,10 @@ class Splash : Form
         @"HKEY_CURRENT_USER\Software\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
     };
 
-    private System.Timers.Timer splashTimer = new System.Timers.Timer();
+    private System.Windows.Forms.Timer splashTimer = new System.Windows.Forms.Timer();
+    private readonly bool waitForReadiness;
+    private bool minimumTimeElapsed;
+    private bool readyToClose;
 
     [System.ComponentModel.Browsable(false)]
     [System.ComponentModel.DesignerSerializationVisibility(System.ComponentModel.DesignerSerializationVisibility.Hidden)]
@@ -37,22 +40,21 @@ class Splash : Form
         }
     }
 
-    public Splash(Bitmap bitmap, int splashTime)
+    public Splash(Bitmap bitmap, int splashTime, bool waitForReadiness = false)
     {
+        this.waitForReadiness = waitForReadiness;
         // Window settings
         this.TopMost = true;
         this.ShowInTaskbar = false;
+        // Keep the branding window at the logo's native size. The splash is
+        // intentionally a separate window; it must not become a full-screen
+        // black canvas or cover the application while the UI is starting.
         this.Size = bitmap.Size;
         this.StartPosition = FormStartPosition.Manual;
-        this.Top = (Screen.PrimaryScreen.Bounds.Height - this.Height) / 2;
-        this.Left = (Screen.PrimaryScreen.Bounds.Width - this.Width) / 2;
-        if (splashTime > 1)
-		{
-			// Must be called before setting bitmap
-			this.BackgroundBitmap = bitmap;
-			this.SelectBitmap(BackgroundBitmap);
-		}
-		this.BackColor = Color.Red;
+		// Must be called before the splash is shown.
+		this.BackgroundBitmap = bitmap;
+		this.SelectBitmap(BackgroundBitmap);
+		this.BackColor = Color.Black;
 
 		// Set current working directory to executable location
 		Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
@@ -61,17 +63,58 @@ class Splash : Form
         var existing = _webview2RegKeys.Any(key => Registry.GetValue(key, "pv", null) != null);
         if (!existing) InstallWebview2Runtime();
 
-		splashTimer = new System.Timers.Timer(splashTime);
-		splashTimer.AutoReset = false;
-		splashTimer.Elapsed += (sender, e) =>
+		splashTimer = new System.Windows.Forms.Timer { Interval = splashTime };
+		splashTimer.Tick += (sender, e) =>
 		{
-			this.Invoke((MethodInvoker)delegate
+			minimumTimeElapsed = true;
+			splashTimer.Stop();
+			if (!waitForReadiness || readyToClose)
 			{
-				this.Close();
-			});
+				Close();
+			}
 		};
-		splashTimer.Start();
-	}
+    }
+
+    protected override void OnShown(EventArgs e)
+    {
+        base.OnShown(e);
+
+        // Start the minimum-display timer only after the splash is actually
+        // visible. Starting it in the constructor lets WebView startup work
+        // consume part of the interval and can make the splash flash away.
+        if (!minimumTimeElapsed && !splashTimer.Enabled)
+        {
+            splashTimer.Start();
+        }
+    }
+
+    public void CloseWhenReady()
+    {
+        readyToClose = true;
+        if (!minimumTimeElapsed || IsDisposed)
+        {
+            return;
+        }
+
+        if (InvokeRequired)
+        {
+            BeginInvoke((MethodInvoker)CloseWhenReady);
+            return;
+        }
+
+        Close();
+    }
+
+    public void SetStartupLocation(Point location)
+    {
+        Location = location;
+        if (BackgroundBitmap != null && IsHandleCreated)
+        {
+            // UpdateLayeredWindow receives the native location explicitly;
+            // refresh it after the launcher places the separate splash window.
+            SelectBitmap(BackgroundBitmap);
+        }
+    }
 
     private void InstallWebview2Runtime()
     {

--- a/TarkovMonitor/Splash.cs
+++ b/TarkovMonitor/Splash.cs
@@ -10,7 +10,7 @@ class Splash : Form
     private float _opacity = 1.0f;
     public Bitmap? BackgroundBitmap;
 
-    private readonly string[] _webview2RegKeys = new[]
+    private static readonly string[] _webview2RegKeys = new[]
     {
         @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
         @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
@@ -57,13 +57,6 @@ class Splash : Form
 		this.BackgroundBitmap = bitmap;
 		this.SelectBitmap(BackgroundBitmap);
 		this.BackColor = Color.Black;
-
-		// Set current working directory to executable location
-		Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
-
-        // Install webview2 runtime if it is not already
-        var existing = _webview2RegKeys.Any(key => Registry.GetValue(key, "pv", null) != null);
-        if (!existing) InstallWebview2Runtime();
 
 		splashTimer = new System.Windows.Forms.Timer { Interval = splashTime };
 		splashTimer.Tick += (sender, e) =>
@@ -118,7 +111,16 @@ class Splash : Form
         }
     }
 
-    private void InstallWebview2Runtime()
+    public static void EnsureWebView2Runtime(DiagnosticsService diagnostics)
+    {
+        var existing = _webview2RegKeys.Any(key => Registry.GetValue(key, "pv", null) != null);
+        if (!existing)
+        {
+            InstallWebview2Runtime(diagnostics);
+        }
+    }
+
+    private static void InstallWebview2Runtime(DiagnosticsService diagnostics)
     {
         try
         {

--- a/TarkovMonitor/TarkovDev.cs
+++ b/TarkovMonitor/TarkovDev.cs
@@ -72,23 +72,80 @@ namespace TarkovMonitor
             Interval = TimeSpan.FromMinutes(20).TotalMilliseconds
         };
 
-        public static List<Task> Tasks { get; private set; } = new();
-        public static List<Map> Maps { get; private set; } = new();
-        public static List<Item> Items { get; private set; } = new();
-        public static List<Trader> Traders { get; private set; } = new();
-        public static List<HideoutStation> Stations { get; private set; } = new();
-        public static List<PlayerLevel> PlayerLevels { get; private set; } = new();
+        internal sealed class ApiDataSnapshot
+        {
+            internal ApiDataSnapshot(
+                ProfileType profileType,
+                List<Task> tasks,
+                List<Map> maps,
+                List<Item> items,
+                List<Trader> traders,
+                List<HideoutStation> stations,
+                List<PlayerLevel> playerLevels,
+                int scavCooldownSeconds)
+            {
+                ProfileType = profileType;
+                Tasks = tasks;
+                Maps = maps;
+                Items = items;
+                Traders = traders;
+                Stations = stations;
+                PlayerLevels = playerLevels;
+                ScavCooldownSeconds = scavCooldownSeconds;
+            }
+
+            internal ProfileType ProfileType { get; }
+            internal List<Task> Tasks { get; }
+            internal List<Map> Maps { get; }
+            internal List<Item> Items { get; }
+            internal List<Trader> Traders { get; }
+            internal List<HideoutStation> Stations { get; }
+            internal List<PlayerLevel> PlayerLevels { get; }
+            internal int ScavCooldownSeconds { get; }
+
+            internal static ApiDataSnapshot Empty => new(
+                ProfileType.Unknown,
+                new(),
+                new(),
+                new(),
+                new(),
+                new(),
+                new(),
+                1500);
+        }
+
+        private sealed class ItemsData
+        {
+            internal ItemsData(List<Item> items, List<PlayerLevel> playerLevels, int scavCooldownSeconds)
+            {
+                Items = items;
+                PlayerLevels = playerLevels;
+                ScavCooldownSeconds = scavCooldownSeconds;
+            }
+
+            internal List<Item> Items { get; }
+            internal List<PlayerLevel> PlayerLevels { get; }
+            internal int ScavCooldownSeconds { get; }
+        }
+
+        private static ApiDataSnapshot apiData = ApiDataSnapshot.Empty;
+        private static ApiDataSnapshot CurrentApiData => Volatile.Read(ref apiData);
+
+        public static List<Task> Tasks => CurrentApiData.Tasks;
+        public static List<Map> Maps => CurrentApiData.Maps;
+        public static List<Item> Items => CurrentApiData.Items;
+        public static List<Trader> Traders => CurrentApiData.Traders;
+        public static List<HideoutStation> Stations => CurrentApiData.Stations;
+        public static List<PlayerLevel> PlayerLevels => CurrentApiData.PlayerLevels;
+        public static ProfileType LoadedProfileType => CurrentApiData.ProfileType;
         public static DateTime ScavAvailableTime { get; set; } = DateTime.Now;
         public static DateTime LastActivity { get; set; } = DateTime.MinValue;
         public static Dictionary<ProfileType, Dictionary<string, string>> PlayerNames { get; private set; } = new();
-
-        private static Dictionary<ProfileType, int> ScavCooldownBaseValues = new();
 
         static TarkovDev()
         {
             foreach (ProfileType profileType in Enum.GetValues<ProfileType>())
             {
-                ScavCooldownBaseValues[profileType] = 1500;
                 PlayerNames.Add(profileType, new());
             }
         }
@@ -99,11 +156,11 @@ namespace TarkovMonitor
             NullValueHandling = NullValueHandling.Ignore,
         };
 
-        private async static Task<T> GetJson<T>(string path)
+        private async static Task<T> GetJson<T>(string path, CancellationToken cancellationToken = default)
         {
-            using var response = await jsonClient.GetAsync(path, HttpCompletionOption.ResponseHeadersRead);
+            using var response = await jsonClient.GetAsync(path, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
-            await using var stream = await response.Content.ReadAsStreamAsync();
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
             using var reader = new StreamReader(stream);
             using var jsonReader = new JsonTextReader(reader);
             var serializer = JsonSerializer.Create(jsonSerializerSettings);
@@ -111,23 +168,23 @@ namespace TarkovMonitor
                 ?? throw new InvalidDataException($"The tarkov.dev response for '{path}' was empty.");
         }
 
-        private async static Task<T> JsonApiRequest<T>(string path, string? lang = null) where T : class
+        private async static Task<T> JsonApiRequest<T>(string path, string? lang = null, CancellationToken cancellationToken = default) where T : class
         {
             if (string.IsNullOrWhiteSpace(lang))
             {
                 lang = null;
             }
 
-            var dataTask = GetJson<JsonApiEnvelope<T>>(path);
+            var dataTask = GetJson<JsonApiEnvelope<T>>(path, cancellationToken);
             if (lang == null)
             {
                 var response = await dataTask;
                 return RequireApiData(response.data, path);
             }
 
-            var langDataTask = GetJson<JsonApiEnvelope<Dictionary<string, string>>>($"{path}_{lang}");
+            var langDataTask = GetJson<JsonApiEnvelope<Dictionary<string, string>>>($"{path}_{lang}", cancellationToken);
             var langDataFallbackTask = lang != "en"
-                ? GetJson<JsonApiEnvelope<Dictionary<string, string>>>($"{path}_en")
+                ? GetJson<JsonApiEnvelope<Dictionary<string, string>>>($"{path}_en", cancellationToken)
                 : System.Threading.Tasks.Task.FromResult<JsonApiEnvelope<Dictionary<string, string>>>(null!);
             await System.Threading.Tasks.Task.WhenAll(dataTask, langDataTask, langDataFallbackTask);
 
@@ -181,28 +238,49 @@ namespace TarkovMonitor
 
         public async static Task<List<Task>> GetTasks()
         {
-            var response = await JsonApiRequest<TasksResponse>($"{GameWatcher.CurrentProfile.Type.ToApiString()}/tasks", Properties.Settings.Default.language);
-            Tasks = response.tasks.Values.ToList();
-            return Tasks;
+            return await GetTasks(GameWatcher.CurrentProfile.Type);
+        }
+
+        public async static Task<List<Task>> GetTasks(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            var response = await JsonApiRequest<TasksResponse>($"{profileType.ToApiString()}/tasks", Properties.Settings.Default.language, cancellationToken);
+            return response.tasks.Values.ToList();
         }
 
         public async static Task<List<Map>> GetMaps()
         {
-            var response = await JsonApiRequest<MapsResponse>($"{GameWatcher.CurrentProfile.Type.ToApiString()}/maps", Properties.Settings.Default.language);
-            Maps = response.maps.Values.ToList();
-            return Maps;
+            return await GetMaps(GameWatcher.CurrentProfile.Type);
         }
+
+        public async static Task<List<Map>> GetMaps(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            var response = await JsonApiRequest<MapsResponse>($"{profileType.ToApiString()}/maps", Properties.Settings.Default.language, cancellationToken);
+            return response.maps.Values.ToList();
+        }
+
         public async static Task<List<Item>> GetItems()
         {
-            var response = await JsonApiRequest<ItemsResponse>($"{GameWatcher.CurrentProfile.Type.ToApiString()}/items", Properties.Settings.Default.language);
-            Items = response.items.Values.ToList();
-            foreach (var item in Items)
+            var data = await GetItemsData(GameWatcher.CurrentProfile.Type);
+            return data.Items;
+        }
+
+        public async static Task<List<Item>> GetItems(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            var data = await GetItemsData(profileType, cancellationToken);
+            return data.Items;
+        }
+
+        private async static Task<ItemsData> GetItemsData(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            var response = await JsonApiRequest<ItemsResponse>($"{profileType.ToApiString()}/items", Properties.Settings.Default.language, cancellationToken);
+            var items = response.items.Values.ToList();
+            foreach (var item in items)
             {
                 if (item.types?.Contains("gun") == true)
                 {
                     if (item.properties?.defaultPreset != null)
                     {
-                        var defaultPreset = Items.Find(i => i.id == item.properties.defaultPreset);
+                        var defaultPreset = items.Find(i => i.id == item.properties.defaultPreset);
                         if (defaultPreset == null)
                         {
                             continue;
@@ -214,32 +292,86 @@ namespace TarkovMonitor
                     }
                 }
             }
-            PlayerLevels = response.playerLevels;
-            ScavCooldownBaseValues[GameWatcher.CurrentProfile.Type] = response.settings.scavCooldownSeconds;
-            return Items;
+            return new ItemsData(items, response.playerLevels, response.settings.scavCooldownSeconds);
         }
+
         public async static Task<List<Trader>> GetTraders()
         {
-            var response = await JsonApiRequest<Dictionary<string, Trader>>($"{GameWatcher.CurrentProfile.Type.ToApiString()}/traders", Properties.Settings.Default.language);
-            Traders = response.Values.ToList();
-            return Traders;
+            return await GetTraders(GameWatcher.CurrentProfile.Type);
         }
+
+        public async static Task<List<Trader>> GetTraders(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            var response = await JsonApiRequest<Dictionary<string, Trader>>($"{profileType.ToApiString()}/traders", Properties.Settings.Default.language, cancellationToken);
+            return response.Values.ToList();
+        }
+
         public async static Task<List<HideoutStation>> GetHideout()
         {
-            var response = await JsonApiRequest<Dictionary<string, HideoutStation>>($"{GameWatcher.CurrentProfile.Type.ToApiString()}/hideout", Properties.Settings.Default.language);
-            Stations = response.Values.ToList();
-            return Stations;
+            return await GetHideout(GameWatcher.CurrentProfile.Type);
         }
+
+        public async static Task<List<HideoutStation>> GetHideout(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            var response = await JsonApiRequest<Dictionary<string, HideoutStation>>($"{profileType.ToApiString()}/hideout", Properties.Settings.Default.language, cancellationToken);
+            return response.Values.ToList();
+        }
+
+        internal async static System.Threading.Tasks.Task<ApiDataSnapshot> LoadApiData(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            if (profileType == ProfileType.Unknown)
+            {
+                throw new InvalidOperationException("Tarkov.dev data cannot be loaded for an unknown EFT session.");
+            }
+
+            var tasksTask = GetTasks(profileType, cancellationToken);
+            var mapsTask = GetMaps(profileType, cancellationToken);
+            var itemsTask = GetItemsData(profileType, cancellationToken);
+            var tradersTask = GetTraders(profileType, cancellationToken);
+            var hideoutTask = GetHideout(profileType, cancellationToken);
+            await System.Threading.Tasks.Task.WhenAll(tasksTask, mapsTask, itemsTask, tradersTask, hideoutTask);
+            var items = await itemsTask;
+            return new ApiDataSnapshot(
+                profileType,
+                await tasksTask,
+                await mapsTask,
+                items.Items,
+                await tradersTask,
+                await hideoutTask,
+                items.PlayerLevels,
+                items.ScavCooldownSeconds);
+        }
+
+        internal static void PublishApiData(ApiDataSnapshot snapshot)
+        {
+            Volatile.Write(ref apiData, snapshot);
+        }
+
+        internal static void ClearApiData()
+        {
+            Volatile.Write(ref apiData, ApiDataSnapshot.Empty);
+        }
+
+        public async static System.Threading.Tasks.Task<bool> UpdateApiData(ProfileType profileType, CancellationToken cancellationToken = default)
+        {
+            if (profileType == ProfileType.Unknown)
+            {
+                return false;
+            }
+
+            var snapshot = await LoadApiData(profileType, cancellationToken);
+            if (GameWatcher.CurrentProfile.Type != profileType)
+            {
+                return false;
+            }
+
+            PublishApiData(snapshot);
+            return true;
+        }
+
         public async static System.Threading.Tasks.Task UpdateApiData()
         {
-            List<System.Threading.Tasks.Task> tasks = new() { 
-                GetTasks(),
-                GetMaps(),
-                GetItems(),
-                GetTraders(),
-                GetHideout(),
-            };
-            await System.Threading.Tasks.Task.WhenAll(tasks);
+            await UpdateApiData(GameWatcher.CurrentProfile.Type);
         }
 
         public async static Task<DataSubmissionResponse> PostQueueTime(string mapNameId, int queueTime, string type, ProfileType gameMode)
@@ -430,13 +562,26 @@ namespace TarkovMonitor
             {
                 return;
             }
+            var profileType = GameWatcher.CurrentProfile.Type;
+            if (profileType == ProfileType.Unknown)
+            {
+                return;
+            }
             var startedUtc = DateTime.UtcNow;
             try
             {
-                await UpdateApiData();
+                await UpdateApiData(profileType);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
             }
             catch (Exception ex)
             {
+                if (GameWatcher.CurrentProfile.Type != profileType)
+                {
+                    return;
+                }
                 ExceptionThrown?.Invoke(null, new ExceptionEventArgs(
                     ex,
                     "auto-updating tarkov.dev data",
@@ -609,7 +754,7 @@ namespace TarkovMonitor
 
         public static int ScavCooldownSeconds()
         {
-            decimal baseTimer = Convert.ToDecimal(ScavCooldownBaseValues[GameWatcher.CurrentProfile.Type]);
+            decimal baseTimer = Convert.ToDecimal(CurrentApiData.ScavCooldownSeconds);
 
             decimal hideoutBonus = 0;
             foreach (var station in Stations)

--- a/TarkovMonitor/TarkovDev.cs
+++ b/TarkovMonitor/TarkovDev.cs
@@ -1,12 +1,15 @@
 using Newtonsoft.Json.Linq;
 using Refit;
 using Newtonsoft.Json;
+using System.Collections.Concurrent;
 
 namespace TarkovMonitor
 {
     public class TarkovDev
     {
         public static event EventHandler<ExceptionEventArgs>? ExceptionThrown;
+        private static readonly object playerNameCacheLock = new();
+        private static readonly ConcurrentDictionary<(ProfileType ProfileType, string AccountId), Lazy<Task<string>>> playerNameLookups = new();
         private static readonly HttpClient jsonClient = new(new HttpClientHandler
         {
             AutomaticDecompression = System.Net.DecompressionMethods.GZip
@@ -279,40 +282,77 @@ namespace TarkovMonitor
             }
         }
 
-        public async static Task<string> GetPlayerName(Profile profile)
+        public static async System.Threading.Tasks.Task<string> GetPlayerName(Profile profile)
         {
-            if (PlayerNames[profile.Type].ContainsKey(profile.AccountId))
-            {
-                return PlayerNames[profile.Type][profile.AccountId];
-            }
-            if (profile.Type == ProfileType.Unknown)
+            if (profile.Type == ProfileType.Unknown || string.IsNullOrWhiteSpace(profile.AccountId))
             {
                 return profile.AccountId;
             }
-            if (string.IsNullOrWhiteSpace(profile.AccountId))
+
+            lock (playerNameCacheLock)
             {
-                return profile.AccountId;
+                if (PlayerNames[profile.Type].TryGetValue(profile.AccountId, out var cachedName))
+                {
+                    return cachedName;
+                }
             }
+
+            var lookupKey = (profile.Type, profile.AccountId);
+            var lookup = playerNameLookups.GetOrAdd(
+                lookupKey,
+                static key => new Lazy<Task<string>>(
+                    () => LoadPlayerName(key.ProfileType, key.AccountId),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
             try
             {
-                var p = await playerJsonApi.GetPlayerProfile(profile.Type.ToPlayersApiString(), profile.AccountId);
-                PlayerNames[profile.Type].Add(profile.AccountId, p.info.nickname);
-                return p.info.nickname;
+                return await lookup.Value;
+            }
+            finally
+            {
+                var pair = new KeyValuePair<(ProfileType ProfileType, string AccountId), Lazy<Task<string>>>(lookupKey, lookup);
+                ((ICollection<KeyValuePair<(ProfileType ProfileType, string AccountId), Lazy<Task<string>>>>)playerNameLookups).Remove(pair);
+            }
+        }
+
+        private static async Task<string> LoadPlayerName(ProfileType profileType, string accountId)
+        {
+            var startedUtc = DateTime.UtcNow;
+            try
+            {
+                var p = await playerJsonApi.GetPlayerProfile(profileType.ToPlayersApiString(), accountId);
+                var nickname = p.info.nickname;
+                lock (playerNameCacheLock)
+                {
+                    if (!PlayerNames[profileType].TryGetValue(accountId, out var cachedName))
+                    {
+                        PlayerNames[profileType][accountId] = nickname;
+                        cachedName = nickname;
+                    }
+                    return cachedName;
+                }
             }
             catch (Refit.ApiException ex)
             {
-                // don't throw an error if the profile isn't available
+                // A missing public profile is expected and should use the account ID.
                 if (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
-                    return profile.AccountId;
+                    return accountId;
                 }
-                ExceptionThrown?.Invoke(null, new ExceptionEventArgs(ex, "player profile lookup"));
+                ExceptionThrown?.Invoke(null, new ExceptionEventArgs(
+                    ex,
+                    "player profile lookup",
+                    "https://players.tarkov.dev",
+                    DiagnosticsService.ElapsedMilliseconds(startedUtc)));
             }
             catch (Exception ex)
             {
-                ExceptionThrown?.Invoke(null, new ExceptionEventArgs(ex, "player profile lookup"));
+                ExceptionThrown?.Invoke(null, new ExceptionEventArgs(
+                    ex,
+                    "player profile lookup",
+                    "https://players.tarkov.dev",
+                    DiagnosticsService.ElapsedMilliseconds(startedUtc)));
             }
-            return profile.AccountId;
+            return accountId;
         }
 
         /*public async static Task<int> GetExperience(int accountId)
@@ -390,13 +430,18 @@ namespace TarkovMonitor
             {
                 return;
             }
+            var startedUtc = DateTime.UtcNow;
             try
             {
                 await UpdateApiData();
             }
             catch (Exception ex)
             {
-                ExceptionThrown?.Invoke(null, new ExceptionEventArgs(ex, "auto-updating tarkov.dev data"));
+                ExceptionThrown?.Invoke(null, new ExceptionEventArgs(
+                    ex,
+                    "auto-updating tarkov.dev data",
+                    "https://json.tarkov.dev",
+                    DiagnosticsService.ElapsedMilliseconds(startedUtc)));
             }
         }
 

--- a/TarkovMonitor/TarkovDev.cs
+++ b/TarkovMonitor/TarkovDev.cs
@@ -71,6 +71,8 @@ namespace TarkovMonitor
             Enabled = false, 
             Interval = TimeSpan.FromMinutes(20).TotalMilliseconds
         };
+        private static readonly object updateTimerLock = new();
+        private static bool updateTimerHandlerAttached;
 
         internal sealed class ApiDataSnapshot
         {
@@ -360,7 +362,32 @@ namespace TarkovMonitor
             }
 
             var snapshot = await LoadApiData(profileType, cancellationToken);
-            if (GameWatcher.CurrentProfile.Type != profileType)
+            var currentProfile = GameWatcher.CurrentProfile.Snapshot();
+            if (!currentProfile.HasTarkovDevPlayerRoute
+                || currentProfile.Type != profileType)
+            {
+                return false;
+            }
+
+            PublishApiData(snapshot);
+            return true;
+        }
+
+        private async static System.Threading.Tasks.Task<bool> UpdateApiData(Profile expectedProfile, CancellationToken cancellationToken = default)
+        {
+            if (!expectedProfile.HasTarkovDevPlayerRoute
+                || expectedProfile.Type == ProfileType.Unknown)
+            {
+                return false;
+            }
+
+            var snapshot = await LoadApiData(expectedProfile.Type, cancellationToken);
+            var currentProfile = GameWatcher.CurrentProfile.Snapshot();
+            if (!currentProfile.HasTarkovDevPlayerRoute
+                || currentProfile.Type != expectedProfile.Type
+                || currentProfile.SessionMode != expectedProfile.SessionMode
+                || !string.Equals(currentProfile.AccountId, expectedProfile.AccountId, StringComparison.Ordinal)
+                || !string.Equals(currentProfile.Id, expectedProfile.Id, StringComparison.Ordinal))
             {
                 return false;
             }
@@ -552,8 +579,23 @@ namespace TarkovMonitor
 
         public static void StartAutoUpdates()
         {
-            updateTimer.Enabled = true;
-            updateTimer.Elapsed += UpdateTimer_Elapsed;
+            lock (updateTimerLock)
+            {
+                if (!updateTimerHandlerAttached)
+                {
+                    updateTimer.Elapsed += UpdateTimer_Elapsed;
+                    updateTimerHandlerAttached = true;
+                }
+                updateTimer.Enabled = true;
+            }
+        }
+
+        public static void StopAutoUpdates()
+        {
+            lock (updateTimerLock)
+            {
+                updateTimer.Enabled = false;
+            }
         }
 
         private static async void UpdateTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
@@ -562,15 +604,16 @@ namespace TarkovMonitor
             {
                 return;
             }
-            var profileType = GameWatcher.CurrentProfile.Type;
-            if (profileType == ProfileType.Unknown)
+            var profile = GameWatcher.CurrentProfile.Snapshot();
+            if (!profile.HasTarkovDevPlayerRoute || profile.Type == ProfileType.Unknown)
             {
                 return;
             }
+            var profileType = profile.Type;
             var startedUtc = DateTime.UtcNow;
             try
             {
-                await UpdateApiData(profileType);
+                await UpdateApiData(profile);
             }
             catch (OperationCanceledException)
             {
@@ -578,7 +621,10 @@ namespace TarkovMonitor
             }
             catch (Exception ex)
             {
-                if (GameWatcher.CurrentProfile.Type != profileType)
+                if (GameWatcher.CurrentProfile.Type != profileType
+                    || GameWatcher.CurrentProfile.SessionMode != profile.SessionMode
+                    || GameWatcher.CurrentProfile.AccountId != profile.AccountId
+                    || GameWatcher.CurrentProfile.Id != profile.Id)
                 {
                     return;
                 }

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -64,13 +64,15 @@ namespace TarkovMonitor
             public string ProfileId { get; }
             public string AccountId { get; }
             public EftSessionMode SessionMode { get; }
+            public string ApiKey { get; }
             public ProgressResponse Progress { get; }
 
-            public ProgressRetrievedEventArgs(string profileId, string accountId, EftSessionMode sessionMode, ProgressResponse progress)
+            public ProgressRetrievedEventArgs(string profileId, string accountId, EftSessionMode sessionMode, string apiKey, ProgressResponse progress)
             {
                 ProfileId = profileId;
                 AccountId = accountId;
                 SessionMode = sessionMode;
+                ApiKey = apiKey;
                 Progress = progress;
             }
         }
@@ -1269,11 +1271,11 @@ namespace TarkovMonitor
             }
             if (string.Equals(normalizedMode, "Regular", StringComparison.OrdinalIgnoreCase))
             {
-                return "Regular (PVP)";
+                return "Non-Seasonal PVP";
             }
             if (string.Equals(normalizedMode, "Seasonal", StringComparison.OrdinalIgnoreCase))
             {
-                return "Seasonal";
+                return "Seasonal PVP";
             }
             return "Unknown";
         }
@@ -2026,7 +2028,7 @@ namespace TarkovMonitor
                 var progress = await request.Api.GetProgress(Bearer(request.Token), request.CancellationToken);
                 if (TryPublishProgress(request, progress))
                 {
-                    ProgressRetrieved?.Invoke(null, new(request.ProfileId, request.AccountId, request.SessionMode, progress));
+                    ProgressRetrieved?.Invoke(null, new(request.ProfileId, request.AccountId, request.SessionMode, request.Token, progress));
                 }
                 return progress;
             }
@@ -2160,7 +2162,7 @@ namespace TarkovMonitor
                 if (TryPublishProgress(request, progress))
                 {
                     TokenValidated?.Invoke(null, new EventArgs());
-                    ProgressRetrieved?.Invoke(null, new(request.ProfileId, request.AccountId, request.SessionMode, progress));
+                    ProgressRetrieved?.Invoke(null, new(request.ProfileId, request.AccountId, request.SessionMode, request.Token, progress));
                 }
                 return response;
             }

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -1,5 +1,7 @@
-﻿using System.Net;
+using System.Net;
+using System.Security.Cryptography;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Transactions;
 using Refit;
@@ -14,35 +16,152 @@ namespace TarkovMonitor
         {
             HttpClient Client { get; }
 
+            [Get("/token")]
+            Task<TokenResponse> TestToken([Header("Authorization")] string authorization, CancellationToken cancellationToken = default);
+
             [Get("/progress")]
-            [Headers("Authorization: Bearer")]
-            Task<ProgressResponse> GetProgress();
+            Task<ProgressResponse> GetProgress([Header("Authorization")] string authorization, CancellationToken cancellationToken = default);
 
             [Post("/progress/task/{id}")]
-            [Headers("Authorization: Bearer")]
-            Task<string> SetTaskStatus(string id, [Body] TaskStatusBody body);
+            Task<string> SetTaskStatus(string id, [Body] TaskStatusBody body, [Header("Authorization")] string authorization, CancellationToken cancellationToken = default);
 
             [Post("/progress/tasks")]
-            [Headers("Authorization: Bearer")]
-            Task<string> SetTaskStatuses([Body] List<TaskStatusBody> body);
+            Task<string> SetTaskStatuses([Body] List<TaskStatusBody> body, [Header("Authorization")] string authorization, CancellationToken cancellationToken = default);
         }
 
         private static readonly HttpClient tokenInspectionClient = new();
+        internal readonly record struct ActiveRequest(
+            string ProfileId,
+            string AccountId,
+            EftSessionMode SessionMode,
+            string Token,
+            long Generation,
+            ITarkovTrackerAPI Api,
+            CancellationToken CancellationToken);
+
+        internal sealed class ProfileActivationLease
+        {
+            internal ActiveRequest Request { get; }
+            public ProgressResponse Progress { get; }
+
+            internal ProfileActivationLease(ActiveRequest request, ProgressResponse progress)
+            {
+                Request = request;
+                Progress = progress;
+            }
+        }
+
+        public sealed class ProgressRetrievedEventArgs : EventArgs
+        {
+            public string ProfileId { get; }
+            public string AccountId { get; }
+            public EftSessionMode SessionMode { get; }
+            public ProgressResponse Progress { get; }
+
+            public ProgressRetrievedEventArgs(string profileId, string accountId, EftSessionMode sessionMode, ProgressResponse progress)
+            {
+                ProfileId = profileId;
+                AccountId = accountId;
+                SessionMode = sessionMode;
+                Progress = progress;
+            }
+        }
+
+        private static readonly object stateLock = new();
+        private static long activationGeneration;
+        private static long serviceGeneration;
+        private static CancellationTokenSource activeRequestCancellation = new();
+        private static string activeDomain = Properties.Settings.Default.tarkovTrackerDomain;
         private static ITarkovTrackerAPI api = InitAPI();
 
         public static ProgressResponse Progress { get; private set; } = new();
         public static bool ValidToken { get; private set; } = false;
-        public static bool IsLegacyService => string.Equals(
-            Properties.Settings.Default.tarkovTrackerDomain,
-            "tarkovtracker.io",
-            StringComparison.OrdinalIgnoreCase);
+        // TarkovTracker.io compatibility store. Keys are EFT profile IDs.
         private static Dictionary<string, string> tokens = new();
+        // Pre-split TarkovTracker.org store. It is read only for one-at-a-time
+        // recovery into the versioned profile-bound store below.
+        private static Dictionary<string, string> modeTokens = new(StringComparer.OrdinalIgnoreCase);
+        // Fingerprints for the pre-split .org recovery store.
+        private static Dictionary<string, string> verifiedModeTokenHashes = new(StringComparer.OrdinalIgnoreCase);
+        private static TarkovTrackerOrgStore orgTokenStore = TarkovTrackerOrgStore.Empty();
+        private static bool legacyTokenStoreLoaded;
+        private static bool modeTokenStoreLoaded;
+        private static bool verificationStoreLoaded;
+        private static bool orgTokenStoreLoaded;
+        private static readonly List<string> storageWarnings = new();
         private static string currentProfile = "";
-        public static string CurrentProfileId { get { return currentProfile; } }
+        private static string currentAccountId = "";
+        private static EftSessionMode currentSessionMode = EftSessionMode.Unknown;
+        private static string activeToken = "";
+        private static readonly object importValidationLock = new();
+        private static DateTimeOffset nextImportValidationAllowedAt = DateTimeOffset.MinValue;
+        private static bool importValidationInProgress;
+        private static readonly TimeSpan importValidationInterval = TimeSpan.FromMinutes(1);
+        public static string CurrentProfileId
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return currentProfile;
+                }
+            }
+        }
+        public static EftSessionMode CurrentSessionMode
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return currentSessionMode;
+                }
+            }
+        }
+
+        public sealed class OrgKeyAutoAssignedEventArgs : EventArgs
+        {
+            public string DisplayName { get; }
+            public string AccountId { get; }
+            public string ProfileId { get; }
+            public EftSessionMode SessionMode { get; }
+
+            public OrgKeyAutoAssignedEventArgs(
+                string displayName,
+                string accountId,
+                string profileId,
+                EftSessionMode sessionMode)
+            {
+                DisplayName = displayName;
+                AccountId = accountId;
+                ProfileId = profileId;
+                SessionMode = sessionMode;
+            }
+        }
+        public static string CurrentAccountId
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return currentAccountId;
+                }
+            }
+        }
+        public static bool IsLegacyService
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return IsLegacyServiceLocked();
+                }
+            }
+        }
 
         public static event EventHandler<EventArgs>? TokenValidated;
         public static event EventHandler<EventArgs>? TokenInvalid;
-        public static event EventHandler<EventArgs>? ProgressRetrieved;
+        public static event EventHandler<ProgressRetrievedEventArgs>? ProgressRetrieved;
+        public static event EventHandler<OrgKeyAutoAssignedEventArgs>? OrgKeyAutoAssigned;
         public static Dictionary<string, string> Domains = new() {
             { "tarkovtracker.io", "TarkovTracker.io" },
             { "tarkovtracker.org", "TarkovTracker.org" },
@@ -50,7 +169,116 @@ namespace TarkovMonitor
 
         static TarkovTracker() {
             tokenInspectionClient.DefaultRequestHeaders.UserAgent.TryParseAdd($"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name} {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
-            tokens = JsonSerializer.Deserialize<Dictionary<string, string>>(Properties.Settings.Default.tarkovTrackerTokens) ?? tokens;
+            legacyTokenStoreLoaded = TryDeserializeTokenStore(
+                Properties.Settings.Default.tarkovTrackerTokens,
+                StringComparer.Ordinal,
+                nameof(Properties.Settings.Default.tarkovTrackerTokens),
+                out tokens);
+            modeTokenStoreLoaded = TryDeserializeTokenStore(
+                Properties.Settings.Default.tarkovTrackerModeTokens,
+                StringComparer.OrdinalIgnoreCase,
+                nameof(Properties.Settings.Default.tarkovTrackerModeTokens),
+                out modeTokens);
+            verificationStoreLoaded = TryDeserializeTokenStore(
+                Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes,
+                StringComparer.OrdinalIgnoreCase,
+                nameof(Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes),
+                out verifiedModeTokenHashes);
+            orgTokenStoreLoaded = TarkovTrackerOrgStore.TryParse(
+                Properties.Settings.Default.tarkovTrackerOrgTokenStore,
+                out orgTokenStore,
+                out var orgStoreError);
+            if (!orgTokenStoreLoaded)
+            {
+                storageWarnings.Add(
+                    $"TarkovTracker.org key storage could not be read. Its original value was preserved and key changes are disabled until it is repaired. {orgStoreError}");
+            }
+            if (modeTokenStoreLoaded && verificationStoreLoaded)
+            {
+                RemoveStaleVerificationRecords();
+            }
+        }
+
+        private static bool TryDeserializeTokenStore(
+            string rawValue,
+            IEqualityComparer<string> comparer,
+            string settingName,
+            out Dictionary<string, string> store)
+        {
+            store = new Dictionary<string, string>(comparer);
+            try
+            {
+                if (string.IsNullOrWhiteSpace(rawValue))
+                {
+                    throw new JsonException("The stored value is empty.");
+                }
+
+                var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(rawValue)
+                    ?? throw new JsonException("The stored value is null.");
+                if (parsed.Any(pair => pair.Key is null || pair.Value is null))
+                {
+                    throw new JsonException("The stored value contains a null key or value.");
+                }
+
+                store = new Dictionary<string, string>(parsed, comparer);
+                return true;
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+            {
+                var blockedAction = settingName == nameof(Properties.Settings.Default.tarkovTrackerTokens)
+                    ? "Legacy TarkovTracker.io key changes and profile-keyed TarkovTracker.org recovery are disabled"
+                    : "Recovery of previously saved TarkovTracker.org keys is unavailable";
+                storageWarnings.Add(
+                    $"Tarkov Tracker storage setting {settingName} could not be read. Its original value was preserved and Tarkov Monitor will not overwrite it. {blockedAction} until the setting is repaired.");
+                return false;
+            }
+        }
+
+        public static IReadOnlyList<string> GetStorageWarnings()
+        {
+            lock (stateLock)
+            {
+                return storageWarnings.ToList();
+            }
+        }
+
+        public static bool CanChangeOrgKeyStorage
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return orgTokenStoreLoaded;
+                }
+            }
+        }
+
+        private static void RemoveStaleVerificationRecords()
+        {
+            var stalePrefixes = verifiedModeTokenHashes
+                .Where(pair => !modeTokens.TryGetValue(pair.Key, out var storedToken)
+                    || !string.Equals(pair.Value, ComputeTokenFingerprint(storedToken), StringComparison.Ordinal))
+                .Select(pair => pair.Key)
+                .ToList();
+            if (stalePrefixes.Count == 0)
+            {
+                return;
+            }
+            foreach (var prefix in stalePrefixes)
+            {
+                verifiedModeTokenHashes.Remove(prefix);
+            }
+        }
+
+        private static bool IsTokenVerified(string prefix, string token)
+        {
+            return verifiedModeTokenHashes.TryGetValue(prefix, out var verifiedTokenHash)
+                && string.Equals(verifiedTokenHash, ComputeTokenFingerprint(token), StringComparison.Ordinal);
+        }
+
+        private static string ComputeTokenFingerprint(string token)
+        {
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token.Trim())));
         }
 
         public static string GetApiBaseUrl(string trackerDomain)
@@ -70,7 +298,7 @@ namespace TarkovMonitor
                 return false;
             }
 
-            var prefix = value[..3].ToUpperInvariant();
+            var prefix = value[..3];
             if (prefix is not ("PVE" or "PVP" or "SZN"))
             {
                 return false;
@@ -94,6 +322,12 @@ namespace TarkovMonitor
         {
             var value = token.Trim();
             return value[..3].ToUpperInvariant();
+        }
+
+        private static string GetVerifiedPrefix(string submittedToken, TokenResponse response)
+        {
+            VerifyOrgTokenResponse(submittedToken, response);
+            return GetOrgTokenPrefix(submittedToken);
         }
 
         private static void VerifyOrgTokenResponse(string submittedToken, TokenResponse response)
@@ -124,7 +358,7 @@ namespace TarkovMonitor
             {
                 "pve" => "PVE",
                 "pvp" or "regular" => "PVP",
-                "seasonal" or "pvpseason" or "sn1" => "SZN",
+                "seasonal" or "pvpseason" or "pvp-season" or "sn1" or "szn" => "SZN",
                 _ => throw new Exception("TarkovTracker returned an unsupported game mode for this API key."),
             };
             var submittedPrefix = GetOrgTokenPrefix(submitted);
@@ -134,37 +368,1035 @@ namespace TarkovMonitor
             }
         }
 
+        private static long BeginNewActivationLocked()
+        {
+            activeRequestCancellation.Cancel();
+            activeRequestCancellation.Dispose();
+            activeRequestCancellation = new CancellationTokenSource();
+            return ++activationGeneration;
+        }
+
         public static ITarkovTrackerAPI InitAPI()
         {
-            api = RestService.For<ITarkovTrackerAPI>(GetApiBaseUrl(Properties.Settings.Default.tarkovTrackerDomain),
-                new RefitSettings {
-                    AuthorizationHeaderValueGetter = (rq, cr) => {
-                        return new ValueTask<string>(Task.Run<string>(() => {
-                            return GetToken(currentProfile ?? "");
-                        }));
-                    },
-                }
-            );
-            api.Client.DefaultRequestHeaders.UserAgent.TryParseAdd($"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name} {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
-            return api;
+            var nextDomain = Properties.Settings.Default.tarkovTrackerDomain;
+            var nextApi = RestService.For<ITarkovTrackerAPI>(GetApiBaseUrl(nextDomain));
+            nextApi.Client.DefaultRequestHeaders.UserAgent.TryParseAdd($"{System.Reflection.Assembly.GetExecutingAssembly().GetName().Name} {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
+
+            lock (stateLock)
+            {
+                api = nextApi;
+                activeDomain = nextDomain;
+                serviceGeneration++;
+                BeginNewActivationLocked();
+                currentProfile = "";
+                currentAccountId = "";
+                currentSessionMode = EftSessionMode.Unknown;
+                activeToken = "";
+                ValidToken = false;
+                Progress = new();
+                return api;
+            }
+        }
+
+        public static void ResetActiveProfile()
+        {
+            DeactivateProfile();
         }
 
         public static void ResetActiveState()
         {
-            currentProfile = "";
-            ValidToken = false;
-            Progress = new();
+            DeactivateProfile();
         }
 
         public static string GetToken(string profileId)
         {
-            if (!tokens.ContainsKey(profileId))
+            lock (stateLock)
+            {
+                return tokens.TryGetValue(profileId, out var token) && !IsImportableToken(token)
+                    ? token
+                    : "";
+            }
+        }
+
+        public static string NormalizeSessionMode(string sessionMode)
+        {
+            var trimmedMode = sessionMode?.Trim() ?? "";
+            if (string.Equals(trimmedMode, "PVP", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(trimmedMode, "Regular", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Regular";
+            }
+            if (string.Equals(trimmedMode, "PVE", StringComparison.OrdinalIgnoreCase))
+            {
+                return "PVE";
+            }
+            if (string.Equals(trimmedMode, "Seasonal", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(trimmedMode, "PvpSeason", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Seasonal";
+            }
+            return string.IsNullOrWhiteSpace(trimmedMode) ? "Unknown" : trimmedMode;
+        }
+
+        public static string NormalizeSessionMode(EftSessionMode sessionMode)
+        {
+            return sessionMode.ToString();
+        }
+
+        public static string GetPrefixForSessionMode(string sessionMode)
+        {
+            var normalizedMode = NormalizeSessionMode(sessionMode);
+            if (string.Equals(normalizedMode, "Regular", StringComparison.OrdinalIgnoreCase))
+            {
+                return "PVP";
+            }
+            if (string.Equals(normalizedMode, "PVE", StringComparison.OrdinalIgnoreCase))
+            {
+                return "PVE";
+            }
+            if (string.Equals(normalizedMode, "Seasonal", StringComparison.OrdinalIgnoreCase))
+            {
+                return "SZN";
+            }
+            return "";
+        }
+
+        public static string GetPrefixForSessionMode(EftSessionMode sessionMode)
+        {
+            return GetPrefixForSessionMode(NormalizeSessionMode(sessionMode));
+        }
+
+        private const string LegacyOrgKeyIdPrefix = "legacy-org:";
+
+        private enum LegacyOrgSourceKind
+        {
+            Mode,
+            Profile,
+            Singleton,
+        }
+
+        private sealed record LegacyOrgSource(LegacyOrgSourceKind Kind, string Key);
+
+        private sealed record LegacyOrgCandidate(
+            string Id,
+            string Prefix,
+            string Token,
+            bool Verified,
+            IReadOnlyList<LegacyOrgSource> Sources);
+
+        public sealed record OrgKeySummary(
+            string Id,
+            string Prefix,
+            string DisplayName,
+            string MaskedToken,
+            bool IsBound,
+            string AccountId,
+            string ProfileId,
+            EftSessionMode SessionMode,
+            string AccountNickname,
+            string ProfileNickname,
+            bool IsVerified,
+            bool HasPendingConflict,
+            bool IsLegacyRecovery,
+            bool IsQuarantined);
+
+        public sealed record OrgProfileSummary(
+            string AccountId,
+            string ProfileId,
+            EftSessionMode SessionMode,
+            string DisplayName,
+            string AccountNickname,
+            DateTimeOffset? FirstSeenUtc,
+            DateTimeOffset? LastSeenUtc,
+            bool HasBoundKey,
+            bool IsCurrent);
+
+        public sealed record OrgReassignmentSummary(
+            OrgKeySummary Key,
+            OrgKeySummary? SwappedKey);
+
+        public static IReadOnlyList<OrgKeySummary> GetOrgKeys()
+        {
+            lock (stateLock)
+            {
+                var storedKeys = orgTokenStore.GetKeys();
+                var legacyCandidates = orgTokenStoreLoaded
+                    ? GetLegacyOrgCandidatesLocked()
+                    : Array.Empty<LegacyOrgCandidate>();
+                var conflictedPendingPrefixes = storedKeys
+                    .Where(key => !key.IsBound)
+                    .Select(key => key.Prefix)
+                    .Concat(legacyCandidates.Select(candidate => candidate.Prefix))
+                    .GroupBy(prefix => prefix, StringComparer.OrdinalIgnoreCase)
+                    .Where(group => group.Count() > 1)
+                    .Select(group => group.Key)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var summaries = storedKeys
+                    .Select(key =>
+                    {
+                        var summary = ToSummary(key);
+                        return !key.IsBound && conflictedPendingPrefixes.Contains(key.Prefix)
+                            ? summary with { HasPendingConflict = true }
+                            : summary;
+                    })
+                    .ToList();
+
+                foreach (var legacyCandidate in legacyCandidates)
+                {
+                    var summary = ToLegacySummary(legacyCandidate);
+                    summaries.Add(conflictedPendingPrefixes.Contains(legacyCandidate.Prefix)
+                        ? summary with { HasPendingConflict = true }
+                        : summary);
+                }
+                return summaries;
+            }
+        }
+
+        public static IReadOnlyList<OrgProfileSummary> GetKnownOrgProfiles()
+        {
+            lock (stateLock)
+            {
+                var boundKeys = orgTokenStore.GetKeys().Where(key => key.IsBound).ToList();
+                return orgTokenStore.GetProfiles()
+                    .Select(profile =>
+                    {
+                        var sessionMode = GameWatcher.ResolveSessionMode(profile.SessionMode);
+                        return new OrgProfileSummary(
+                            profile.AccountId,
+                            profile.ProfileId,
+                            sessionMode,
+                            profile.ToProfile().DisplayName,
+                            orgTokenStore.GetAccountNickname(profile.AccountId),
+                            profile.FirstSeenUtc,
+                            profile.LastSeenUtc,
+                            boundKeys.Any(key => string.Equals(key.AccountId, profile.AccountId, StringComparison.Ordinal)
+                                && string.Equals(key.ProfileId, profile.ProfileId, StringComparison.Ordinal)
+                                && string.Equals(key.SessionMode, profile.SessionMode, StringComparison.OrdinalIgnoreCase)),
+                            string.Equals(profile.AccountId, currentAccountId, StringComparison.Ordinal)
+                                && string.Equals(profile.ProfileId, currentProfile, StringComparison.Ordinal)
+                                && sessionMode == currentSessionMode);
+                    })
+                    .OrderByDescending(profile => profile.IsCurrent)
+                    .ThenByDescending(profile => profile.LastSeenUtc)
+                    .ToList();
+            }
+        }
+
+        public static int SaveDiscoveredOrgProfiles(IEnumerable<DiscoveredEftProfile> discoveredProfiles)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+            var records = discoveredProfiles.Select(discovered => new TarkovTrackerOrgProfile
+            {
+                AccountId = discovered.Profile.AccountId,
+                ProfileId = discovered.Profile.Id,
+                SessionMode = NormalizeSessionMode(discovered.Profile.SessionMode),
+                FirstSeenUtc = discovered.FirstSeenUtc,
+                LastSeenUtc = discovered.LastSeenUtc,
+            }).ToList();
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                return PersistOrgStoreChangeLocked(store => store.RememberProfiles(records));
+            }
+        }
+
+        private static bool IsLegacyServiceLocked()
+        {
+            return string.Equals(activeDomain, "tarkovtracker.io", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static long CaptureOrgServiceGeneration()
+        {
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(serviceGeneration);
+                return serviceGeneration;
+            }
+        }
+
+        private static void EnsureOrgServiceGenerationLocked(long expectedGeneration)
+        {
+            if (IsLegacyServiceLocked() || serviceGeneration != expectedGeneration)
+            {
+                throw new InvalidOperationException("The Tarkov Tracker service changed. Switch to TarkovTracker.org and try again.");
+            }
+        }
+
+        public static bool HasPendingOrgKey()
+        {
+            lock (stateLock)
+            {
+                return orgTokenStore.HasPendingKey()
+                    || (orgTokenStoreLoaded && GetNextLegacyOrgCandidateLocked() != null);
+            }
+        }
+
+        public static async Task<ImportedToken> ImportOrgToken(string apiToken)
+        {
+            ValidateImportTokenLocally(apiToken);
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            var trimmedToken = apiToken.Trim();
+            var suppliedPrefix = GetTokenPrefix(trimmedToken);
+
+            EnsureOrgProfileStoreWritable();
+            lock (stateLock)
+            {
+                if (orgTokenStore.HasPendingKey(suppliedPrefix)
+                    || GetLegacyOrgCandidateLocked(suppliedPrefix) != null)
+                {
+                    throw new InvalidOperationException(
+                        $"Assign or remove the unassigned {GetPrefixDisplayName(suppliedPrefix)} API key before importing another one.");
+                }
+            }
+
+            lock (stateLock)
+            {
+                if (orgTokenStore.ContainsToken(trimmedToken))
+                {
+                    throw new DuplicateImportedTokenException(
+                        $"This {GetPrefixDisplayName(suppliedPrefix)} API key is already saved locally.");
+                }
+            }
+            BeginImportValidationCall();
+            try
+            {
+                var response = await InspectToken(trimmedToken, "tarkovtracker.org");
+                if (!response.permissions.Contains("WP"))
+                {
+                    throw new Exception("This API key is valid but does not have write permission.");
+                }
+                var prefix = GetVerifiedPrefix(trimmedToken, response);
+                TarkovTrackerOrgKey savedKey;
+                lock (stateLock)
+                {
+                    EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                    if (orgTokenStore.HasPendingKey(prefix)
+                        || GetLegacyOrgCandidateLocked(prefix) != null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Another unassigned {GetPrefixDisplayName(prefix)} API key was added before this import finished.");
+                    }
+                    savedKey = PersistOrgStoreChangeLocked(store =>
+                        store.AddVerifiedToken(trimmedToken, prefix, null));
+                }
+                CompleteImportValidationCall(true);
+                return new ImportedToken(
+                    savedKey.Id,
+                    prefix,
+                    GetPrefixDisplayName(prefix));
+            }
+            catch
+            {
+                CompleteImportValidationCall(false);
+                throw;
+            }
+        }
+
+        public static Task<OrgKeySummary> BindOrgKey(string id, Profile profile)
+        {
+            return BindOrgKeyCore(id, profile, requireCurrentProfile: true);
+        }
+
+        public static Task<OrgKeySummary> AssignOrgKey(
+            string id,
+            string accountId,
+            string profileId,
+            EftSessionMode sessionMode)
+        {
+            return BindOrgKeyCore(id, new Profile
+            {
+                AccountId = accountId,
+                Id = profileId,
+                SessionMode = sessionMode,
+                Type = GameWatcher.ResolveProfileType(sessionMode),
+            }, requireCurrentProfile: false);
+        }
+
+        private static async Task<OrgKeySummary> BindOrgKeyCore(
+            string id,
+            Profile profile,
+            bool requireCurrentProfile)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+
+            if (id.StartsWith(LegacyOrgKeyIdPrefix, StringComparison.Ordinal))
+            {
+                string prefix;
+                string token;
+                bool alreadyVerified;
+                lock (stateLock)
+                {
+                    var candidate = GetLegacyOrgCandidateByIdLocked(id);
+                    if (candidate == null)
+                    {
+                        throw new KeyNotFoundException("The pending API key was not found.");
+                    }
+                    prefix = candidate.Prefix;
+                    token = candidate.Token;
+                    alreadyVerified = candidate.Verified;
+                }
+
+                if (!alreadyVerified)
+                {
+                    BeginImportValidationCall();
+                    try
+                    {
+                        var response = await InspectToken(token, "tarkovtracker.org");
+                        if (!response.permissions.Contains("WP"))
+                        {
+                            throw new Exception("This API key is valid but does not have write permission.");
+                        }
+                        var verifiedPrefix = GetVerifiedPrefix(token, response);
+                        if (!string.Equals(prefix, verifiedPrefix, StringComparison.OrdinalIgnoreCase))
+                        {
+                            throw new Exception("The saved API key mode no longer matches its verified mode.");
+                        }
+                        CompleteImportValidationCall(true);
+                    }
+                    catch
+                    {
+                        CompleteImportValidationCall(false);
+                        throw;
+                    }
+                }
+
+                lock (stateLock)
+                {
+                    EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                    var bindingProfile = requireCurrentProfile
+                        ? EnsureCurrentBindingProfileLocked(profile)
+                        : orgTokenStore.GetKnownProfile(profile.AccountId, profile.Id, profile.SessionMode);
+                    var candidate = GetLegacyOrgCandidateByIdLocked(id);
+                    if (candidate == null
+                        || !string.Equals(candidate.Prefix, prefix, StringComparison.OrdinalIgnoreCase)
+                        || !string.Equals(candidate.Token, token, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException("The unassigned API key changed before assignment finished.");
+                    }
+
+                    var savedKey = PersistLegacyRecoveryBindingLocked(candidate, bindingProfile);
+                    return ToSummary(savedKey);
+                }
+            }
+
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                TarkovTrackerOrgKey boundKey;
+                if (requireCurrentProfile)
+                {
+                    var bindingProfile = EnsureCurrentBindingProfileLocked(profile);
+                    boundKey = PersistOrgStoreChangeLocked(store =>
+                    {
+                        store.RememberAndAutoBind(bindingProfile, DateTimeOffset.UtcNow);
+                        var existing = store.GetKey(id);
+                        return existing?.IsBound == true
+                            ? existing
+                            : store.Bind(id, bindingProfile);
+                    });
+                }
+                else
+                {
+                    boundKey = PersistOrgStoreChangeLocked(store => store.BindKnownProfile(
+                        id,
+                        profile.AccountId,
+                        profile.Id,
+                        profile.SessionMode));
+                }
+                return ToSummary(boundKey);
+            }
+        }
+
+        public static OrgReassignmentSummary ReassignOrgKey(
+            string id,
+            string accountId,
+            string profileId,
+            EftSessionMode sessionMode)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                var result = PersistOrgStoreChangeLocked(store => store.ReassignKnownProfile(
+                    id,
+                    accountId,
+                    profileId,
+                    sessionMode));
+                return new OrgReassignmentSummary(
+                    ToSummary(result.Key),
+                    result.SwappedKey == null ? null : ToSummary(result.SwappedKey));
+            }
+        }
+
+        public static bool RemoveOrgKey(string id)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                if (id.StartsWith(LegacyOrgKeyIdPrefix, StringComparison.Ordinal))
+                {
+                    var candidate = GetLegacyOrgCandidateByIdLocked(id);
+                    return candidate != null && RemoveLegacyOrgCandidateLocked(candidate);
+                }
+
+                return PersistOrgStoreChangeLocked(store => store.Remove(id));
+            }
+        }
+
+        public static OrgKeySummary UnbindOrgKey(string id)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                var key = orgTokenStore.GetKey(id)
+                    ?? throw new KeyNotFoundException("The saved API key was not found.");
+                if (GetLegacyOrgCandidateLocked(key.Prefix) != null)
+                {
+                    throw new InvalidOperationException(
+                        $"Assign or remove the unassigned {GetPrefixDisplayName(key.Prefix)} API key before unbinding another one.");
+                }
+                var unboundKey = PersistOrgStoreChangeLocked(store => store.Unbind(id));
+                return ToSummary(unboundKey);
+            }
+        }
+
+        public static string SetOrgAccountNickname(string accountId, string nickname)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                return PersistOrgStoreChangeLocked(store => store.SetAccountNickname(accountId, nickname));
+            }
+        }
+
+        public static string SetOrgProfileNickname(string id, string nickname)
+        {
+            var expectedServiceGeneration = CaptureOrgServiceGeneration();
+            EnsureOrgProfileStoreWritable();
+
+            lock (stateLock)
+            {
+                EnsureOrgServiceGenerationLocked(expectedServiceGeneration);
+                return PersistOrgStoreChangeLocked(store => store.SetProfileNickname(id, nickname));
+            }
+        }
+
+        private static OrgKeySummary ToSummary(TarkovTrackerOrgKey key)
+        {
+            var sessionMode = key.IsBound
+                ? GameWatcher.ResolveSessionMode(key.SessionMode)
+                : EftSessionMode.Unknown;
+            return new OrgKeySummary(
+                key.Id,
+                key.Prefix,
+                GetPrefixDisplayName(key.Prefix),
+                MaskToken(key.Token),
+                key.IsBound,
+                key.AccountId,
+                key.ProfileId,
+                sessionMode,
+                key.IsBound ? orgTokenStore.GetAccountNickname(key.AccountId) : "",
+                key.IsBound ? key.ProfileNickname : "",
+                TarkovTrackerOrgStore.IsVerified(key),
+                false,
+                false,
+                !string.IsNullOrEmpty(orgTokenStore.GetStoreIssue(key)));
+        }
+
+        private static OrgKeySummary ToLegacySummary(LegacyOrgCandidate candidate)
+        {
+            return new OrgKeySummary(
+                candidate.Id,
+                candidate.Prefix,
+                GetPrefixDisplayName(candidate.Prefix),
+                MaskToken(candidate.Token),
+                false,
+                "",
+                "",
+                EftSessionMode.Unknown,
+                "",
+                "",
+                candidate.Verified,
+                false,
+                true,
+                false);
+        }
+
+        private static string MaskToken(string token)
+        {
+            var prefix = GetTokenPrefix(token);
+            return token.Length <= 4 ? $"{prefix}_••••" : $"{prefix}_••••{token[^4..]}";
+        }
+
+        private static IReadOnlyList<LegacyOrgCandidate> GetLegacyOrgCandidatesLocked()
+        {
+            var sources = new List<(string Prefix, string Token, LegacyOrgSource Source)>();
+            if (modeTokenStoreLoaded)
+            {
+                foreach (var pair in modeTokens)
+                {
+                    var token = pair.Value?.Trim() ?? "";
+                    if (!IsImportableToken(token))
+                    {
+                        continue;
+                    }
+                    sources.Add((
+                        GetTokenPrefix(token),
+                        token,
+                        new LegacyOrgSource(LegacyOrgSourceKind.Mode, pair.Key)));
+                }
+            }
+            if (legacyTokenStoreLoaded)
+            {
+                foreach (var pair in tokens)
+                {
+                    var token = pair.Value?.Trim() ?? "";
+                    if (!IsImportableToken(token))
+                    {
+                        continue;
+                    }
+                    sources.Add((
+                        GetTokenPrefix(token),
+                        token,
+                        new LegacyOrgSource(LegacyOrgSourceKind.Profile, pair.Key)));
+                }
+            }
+
+            var singletonToken = Properties.Settings.Default.tarkovTrackerToken?.Trim() ?? "";
+            if (IsImportableToken(singletonToken))
+            {
+                sources.Add((
+                    GetTokenPrefix(singletonToken),
+                    singletonToken,
+                    new LegacyOrgSource(LegacyOrgSourceKind.Singleton, "")));
+            }
+
+            var storedFingerprints = orgTokenStore.GetKeys()
+                .Select(key => TarkovTrackerOrgStore.ComputeTokenFingerprint(key.Token))
+                .ToHashSet(StringComparer.Ordinal);
+            return sources
+                .GroupBy(
+                    source => TarkovTrackerOrgStore.ComputeTokenFingerprint(source.Token),
+                    StringComparer.Ordinal)
+                .Where(group => !storedFingerprints.Contains(group.Key))
+                .Select(group =>
+                {
+                    var source = group.First();
+                    return new LegacyOrgCandidate(
+                        $"{LegacyOrgKeyIdPrefix}{group.Key}",
+                        source.Prefix,
+                        source.Token,
+                        verificationStoreLoaded && IsTokenVerified(source.Prefix, source.Token),
+                        group.Select(item => item.Source).Distinct().ToList());
+                })
+                .OrderBy(candidate => candidate.Prefix, StringComparer.Ordinal)
+                .ThenBy(candidate => candidate.Id, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        private static LegacyOrgCandidate? GetNextLegacyOrgCandidateLocked()
+        {
+            return GetLegacyOrgCandidatesLocked().FirstOrDefault();
+        }
+
+        private static LegacyOrgCandidate? GetLegacyOrgCandidateLocked(string prefix)
+        {
+            return GetLegacyOrgCandidatesLocked().FirstOrDefault(candidate => string.Equals(
+                candidate.Prefix,
+                prefix,
+                StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static LegacyOrgCandidate? GetLegacyOrgCandidateByIdLocked(string id)
+        {
+            return GetLegacyOrgCandidatesLocked().FirstOrDefault(candidate => string.Equals(
+                candidate.Id,
+                id,
+                StringComparison.Ordinal));
+        }
+
+        private static T PersistOrgStoreChangeLocked<T>(Func<TarkovTrackerOrgStore, T> mutation)
+        {
+            EnsureOrgProfileStoreWritable();
+            var currentSerialized = orgTokenStore.Serialize();
+            var candidateStore = orgTokenStore.Clone();
+            var result = mutation(candidateStore);
+            var candidateSerialized = candidateStore.Serialize();
+            if (string.Equals(currentSerialized, candidateSerialized, StringComparison.Ordinal))
+            {
+                return result;
+            }
+            var previousSetting = Properties.Settings.Default.tarkovTrackerOrgTokenStore;
+            try
+            {
+                Properties.Settings.Default.tarkovTrackerOrgTokenStore = candidateSerialized;
+                Properties.Settings.Default.Save();
+                orgTokenStore = candidateStore;
+                InvalidateChangedOrgActivationLocked();
+                return result;
+            }
+            catch
+            {
+                Properties.Settings.Default.tarkovTrackerOrgTokenStore = previousSetting;
+                throw;
+            }
+        }
+
+        private static TarkovTrackerOrgKey PersistLegacyRecoveryBindingLocked(
+            LegacyOrgCandidate candidate,
+            Profile profile)
+        {
+            var candidateStore = orgTokenStore.Clone();
+            var savedKey = candidateStore.AddVerifiedBoundToken(candidate.Token, candidate.Prefix, profile);
+            var previousOrgSetting = Properties.Settings.Default.tarkovTrackerOrgTokenStore;
+            var previousModeSetting = Properties.Settings.Default.tarkovTrackerModeTokens;
+            var previousLegacySetting = Properties.Settings.Default.tarkovTrackerTokens;
+            var previousSingletonSetting = Properties.Settings.Default.tarkovTrackerToken;
+            var previousVerificationSetting = Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes;
+            var previousModeTokens = new Dictionary<string, string>(modeTokens, StringComparer.OrdinalIgnoreCase);
+            var previousTokens = new Dictionary<string, string>(tokens, StringComparer.Ordinal);
+            var previousVerificationHashes = new Dictionary<string, string>(verifiedModeTokenHashes, StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                RemoveLegacyOrgSourcesInMemoryLocked(candidate);
+                Properties.Settings.Default.tarkovTrackerOrgTokenStore = candidateStore.Serialize();
+                if (modeTokenStoreLoaded)
+                {
+                    Properties.Settings.Default.tarkovTrackerModeTokens = JsonSerializer.Serialize(modeTokens);
+                }
+                if (legacyTokenStoreLoaded)
+                {
+                    Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
+                }
+                if (verificationStoreLoaded)
+                {
+                    Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes = JsonSerializer.Serialize(verifiedModeTokenHashes);
+                }
+                Properties.Settings.Default.Save();
+                orgTokenStore = candidateStore;
+                InvalidateChangedOrgActivationLocked();
+                return savedKey;
+            }
+            catch
+            {
+                modeTokens = previousModeTokens;
+                tokens = previousTokens;
+                verifiedModeTokenHashes = previousVerificationHashes;
+                Properties.Settings.Default.tarkovTrackerOrgTokenStore = previousOrgSetting;
+                Properties.Settings.Default.tarkovTrackerModeTokens = previousModeSetting;
+                Properties.Settings.Default.tarkovTrackerTokens = previousLegacySetting;
+                Properties.Settings.Default.tarkovTrackerToken = previousSingletonSetting;
+                Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes = previousVerificationSetting;
+                throw;
+            }
+        }
+
+        private static bool RemoveLegacyOrgCandidateLocked(LegacyOrgCandidate candidate)
+        {
+            var previousModeSetting = Properties.Settings.Default.tarkovTrackerModeTokens;
+            var previousLegacySetting = Properties.Settings.Default.tarkovTrackerTokens;
+            var previousSingletonSetting = Properties.Settings.Default.tarkovTrackerToken;
+            var previousVerificationSetting = Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes;
+            var previousModeTokens = new Dictionary<string, string>(modeTokens, StringComparer.OrdinalIgnoreCase);
+            var previousTokens = new Dictionary<string, string>(tokens, StringComparer.Ordinal);
+            var previousVerificationHashes = new Dictionary<string, string>(verifiedModeTokenHashes, StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                RemoveLegacyOrgSourcesInMemoryLocked(candidate);
+                if (modeTokenStoreLoaded)
+                {
+                    Properties.Settings.Default.tarkovTrackerModeTokens = JsonSerializer.Serialize(modeTokens);
+                }
+                if (legacyTokenStoreLoaded)
+                {
+                    Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
+                }
+                if (verificationStoreLoaded)
+                {
+                    Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes = JsonSerializer.Serialize(verifiedModeTokenHashes);
+                }
+                Properties.Settings.Default.Save();
+                return true;
+            }
+            catch
+            {
+                modeTokens = previousModeTokens;
+                tokens = previousTokens;
+                verifiedModeTokenHashes = previousVerificationHashes;
+                Properties.Settings.Default.tarkovTrackerModeTokens = previousModeSetting;
+                Properties.Settings.Default.tarkovTrackerTokens = previousLegacySetting;
+                Properties.Settings.Default.tarkovTrackerToken = previousSingletonSetting;
+                Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes = previousVerificationSetting;
+                throw;
+            }
+        }
+
+        private static void RemoveLegacyOrgSourcesInMemoryLocked(LegacyOrgCandidate candidate)
+        {
+            foreach (var source in candidate.Sources)
+            {
+                switch (source.Kind)
+                {
+                    case LegacyOrgSourceKind.Mode:
+                        if (!modeTokens.TryGetValue(source.Key, out var modeToken)
+                            || !string.Equals(modeToken?.Trim(), candidate.Token, StringComparison.Ordinal))
+                        {
+                            throw new InvalidOperationException("The saved API key changed before its recovery source could be updated.");
+                        }
+                        modeTokens.Remove(source.Key);
+                        if (verificationStoreLoaded)
+                        {
+                            verifiedModeTokenHashes.Remove(candidate.Prefix);
+                        }
+                        break;
+                    case LegacyOrgSourceKind.Profile:
+                        if (!tokens.TryGetValue(source.Key, out var profileToken)
+                            || !string.Equals(profileToken?.Trim(), candidate.Token, StringComparison.Ordinal))
+                        {
+                            throw new InvalidOperationException("The saved API key changed before its recovery source could be updated.");
+                        }
+                        tokens.Remove(source.Key);
+                        break;
+                    case LegacyOrgSourceKind.Singleton:
+                        if (!string.Equals(
+                            Properties.Settings.Default.tarkovTrackerToken?.Trim(),
+                            candidate.Token,
+                            StringComparison.Ordinal))
+                        {
+                            throw new InvalidOperationException("The saved API key changed before its recovery source could be updated.");
+                        }
+                        Properties.Settings.Default.tarkovTrackerToken = "";
+                        break;
+                }
+            }
+        }
+
+        private static void EnsureOrgProfileStoreWritable()
+        {
+            if (!orgTokenStoreLoaded)
+            {
+                throw new InvalidOperationException("TarkovTracker.org key storage needs repair before keys can be changed. The unreadable saved value was preserved.");
+            }
+        }
+
+        private static Profile EnsureCurrentBindingProfileLocked(Profile profile)
+        {
+            if (!profile.SupportsTarkovTrackerWrites
+                || !string.Equals(profile.Id, currentProfile, StringComparison.Ordinal)
+                || !string.Equals(profile.AccountId, currentAccountId, StringComparison.Ordinal)
+                || profile.SessionMode != currentSessionMode)
+            {
+                throw new InvalidOperationException("The selected EFT profile changed. Select the matching profile and try again.");
+            }
+            return profile.Snapshot();
+        }
+
+        private static void InvalidateChangedOrgActivationLocked()
+        {
+            if (IsLegacyServiceLocked() || string.IsNullOrWhiteSpace(currentProfile))
+            {
+                return;
+            }
+
+            var selectedToken = orgTokenStore.GetForProfile(new Profile
+            {
+                Id = currentProfile,
+                AccountId = currentAccountId,
+                SessionMode = currentSessionMode,
+                Type = GameWatcher.ResolveProfileType(currentSessionMode),
+            })?.Token ?? "";
+            if (string.Equals(activeToken, selectedToken, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            activeToken = "";
+            BeginNewActivationLocked();
+            ValidToken = false;
+            Progress = new();
+        }
+
+        public static string GetTokenPrefix(string apiToken)
+        {
+            var trimmedToken = apiToken.Trim();
+            var separatorIndex = trimmedToken.IndexOf('_');
+            if (separatorIndex <= 0)
             {
                 return "";
             }
-            return tokens[profileId];
+            return trimmedToken[..separatorIndex].ToUpperInvariant();
         }
 
+        public static string GetPrefixDisplayName(string prefix)
+        {
+            return prefix.ToUpperInvariant() switch
+            {
+                "PVP" => "Regular (PVP)",
+                "PVE" => "PVE",
+                "SZN" => "Seasonal",
+                _ => "Unknown",
+            };
+        }
+
+        public static string GetSessionDisplayName(string sessionMode)
+        {
+            var normalizedMode = NormalizeSessionMode(sessionMode);
+            if (string.Equals(normalizedMode, "PVE", StringComparison.OrdinalIgnoreCase))
+            {
+                return "PVE";
+            }
+            if (string.Equals(normalizedMode, "Regular", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Regular (PVP)";
+            }
+            if (string.Equals(normalizedMode, "Seasonal", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Seasonal";
+            }
+            return "Unknown";
+        }
+
+        public static string GetSessionDisplayName(EftSessionMode sessionMode)
+        {
+            return GetSessionDisplayName(NormalizeSessionMode(sessionMode));
+        }
+
+        public static bool IsSupportedPrefix(string prefix)
+        {
+            return prefix.Equals("PVP", StringComparison.OrdinalIgnoreCase)
+                || prefix.Equals("PVE", StringComparison.OrdinalIgnoreCase)
+                || prefix.Equals("SZN", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool IsImportablePrefix(string prefix)
+        {
+            return prefix is "PVP" or "PVE" or "SZN";
+        }
+
+        public static bool IsImportableToken(string apiToken)
+        {
+            try
+            {
+                ValidateImportTokenLocally(apiToken);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void ValidateImportTokenLocally(string apiToken)
+        {
+            if (string.IsNullOrEmpty(apiToken))
+            {
+                throw new Exception("Paste a TarkovTracker.org API key before validating.");
+            }
+            if (!string.Equals(apiToken, apiToken.Trim(), StringComparison.Ordinal))
+            {
+                throw new Exception("The API key contains a space before or after the key. Copy it directly from TarkovTracker.org and try again.");
+            }
+            if (apiToken.Any(character => character > 127))
+            {
+                throw new Exception("The API key contains a non-ASCII character. Copy it directly from TarkovTracker.org instead of typing or editing it manually.");
+            }
+
+            var separatorIndex = apiToken.IndexOf('_');
+            var hasOneSeparator = separatorIndex == apiToken.LastIndexOf('_');
+            var prefix = separatorIndex > 0 ? apiToken[..separatorIndex] : "";
+            var identifier = separatorIndex >= 0 && separatorIndex < apiToken.Length - 1
+                ? apiToken[(separatorIndex + 1)..]
+                : "";
+            var identifierIsHexadecimal = identifier.All(Uri.IsHexDigit);
+            if (separatorIndex != 3
+                || !hasOneSeparator
+                || !IsImportablePrefix(prefix)
+                || identifier.Length != 18
+                || !identifierIsHexadecimal)
+            {
+                throw new Exception("The API key format is invalid. Expected PVP_, PVE_, or SZN_ followed by an 18-character hexadecimal identifier. Copy the key directly from TarkovTracker.org and try again.");
+            }
+        }
+
+        private static void BeginImportValidationCall()
+        {
+            lock (importValidationLock)
+            {
+                var now = DateTimeOffset.UtcNow;
+                if (now < nextImportValidationAllowedAt)
+                {
+                    var secondsRemaining = Math.Max(1, (int)Math.Ceiling((nextImportValidationAllowedAt - now).TotalSeconds));
+                    throw new Exception($"Please wait {secondsRemaining} seconds before verifying another API key.");
+                }
+                if (importValidationInProgress)
+                {
+                    throw new Exception("An API key verification is already in progress.");
+                }
+                importValidationInProgress = true;
+            }
+        }
+
+        private static void CompleteImportValidationCall(bool succeeded)
+        {
+            lock (importValidationLock)
+            {
+                importValidationInProgress = false;
+                nextImportValidationAllowedAt = succeeded
+                    ? DateTimeOffset.MinValue
+                    : DateTimeOffset.UtcNow.Add(importValidationInterval);
+            }
+        }
+
+        public static int GetImportValidationCooldownSeconds()
+        {
+            lock (importValidationLock)
+            {
+                return Math.Max(0, (int)Math.Ceiling((nextImportValidationAllowedAt - DateTimeOffset.UtcNow).TotalSeconds));
+            }
+        }
+
+        public static string GetTokenForProfile(Profile profile)
+        {
+            lock (stateLock)
+            {
+                return GetTokenForProfileLocked(profile);
+            }
+        }
+
+        private static string GetTokenForProfileLocked(Profile profile)
+        {
+            if (IsLegacyServiceLocked())
+            {
+                return tokens.TryGetValue(profile.Id, out var token) && !IsImportableToken(token)
+                    ? token
+                    : "";
+            }
+            return orgTokenStore.GetForProfile(profile)?.Token ?? "";
+        }
+
+        public record ImportedToken(
+            string Id,
+            string Prefix,
+            string DisplayName);
+
+        public sealed class DuplicateImportedTokenException : Exception
+        {
+            public DuplicateImportedTokenException(string message) : base(message)
+            {
+            }
+        }
         public static void SetToken(string profileId, string token)
         {
             if (IsLegacyService)
@@ -173,45 +1405,321 @@ namespace TarkovMonitor
             }
             if (profileId == "")
             {
-                throw new Exception("No PVP or PVE profile initialized, please launch Escape from Tarkov first");
+                throw new Exception("No EFT profile initialized, please launch Escape from Tarkov first");
             }
-            tokens[profileId] = token;
-            Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
-            Properties.Settings.Default.Save();
+            if (!legacyTokenStoreLoaded)
+            {
+                throw new InvalidOperationException("Legacy Tarkov Tracker token storage could not be read, so it was not overwritten.");
+            }
+            if (IsImportableToken(token))
+            {
+                throw new InvalidOperationException("This is a TarkovTracker.org API key. Switch to TarkovTracker.org to recover or manage it.");
+            }
+
+            lock (stateLock)
+            {
+                var originalTokens = new Dictionary<string, string>(tokens, StringComparer.Ordinal);
+                var originalSetting = Properties.Settings.Default.tarkovTrackerTokens;
+                var previousToken = tokens.TryGetValue(profileId, out var storedToken) ? storedToken : "";
+                tokens[profileId] = token;
+                try
+                {
+                    Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
+                    Properties.Settings.Default.Save();
+                }
+                catch
+                {
+                    tokens = originalTokens;
+                    Properties.Settings.Default.tarkovTrackerTokens = originalSetting;
+                    throw;
+                }
+
+                // Editing the active legacy profile's token immediately revokes the
+                // previous activation. The separate .org store is unaffected.
+                if (IsLegacyServiceLocked() && profileId == currentProfile && previousToken != token)
+                {
+                    BeginNewActivationLocked();
+                    ValidToken = false;
+                    Progress = new();
+                }
+            }
         }
 
-        public static async Task<ProgressResponse> SetProfile(string profileId)
+        public static void DeactivateProfile()
+        {
+            lock (stateLock)
+            {
+                currentProfile = "";
+                currentAccountId = "";
+                currentSessionMode = EftSessionMode.Unknown;
+                activeToken = "";
+                BeginNewActivationLocked();
+                ValidToken = false;
+                Progress = new();
+            }
+        }
+
+        public static ProgressResponse? GetActiveProgressSnapshot(Profile expectedProfile)
+        {
+            lock (stateLock)
+            {
+                return ValidToken
+                    && currentProfile == expectedProfile.Id
+                    && currentAccountId == expectedProfile.AccountId
+                    && currentSessionMode == expectedProfile.SessionMode
+                    ? Progress
+                    : null;
+            }
+        }
+
+        public static async Task<ProgressResponse> SetProfile(Profile profile, bool forceRefresh = false)
         {
             if (IsLegacyService)
             {
-                ResetActiveState();
+                DeactivateProfile();
                 return Progress;
             }
-            if (profileId == "") {
-                throw new Exception("Can't set PVP or PVE profile, please launch Escape from Tarkov and then restart this application");
+            if (!profile.HasIdentity || !profile.SupportsTarkovTrackerWrites)
+            {
+                DeactivateProfile();
+                return Progress;
             }
 
-            if (currentProfile == profileId)
+            var profileSnapshot = profile.Snapshot();
+            string newToken;
+            long generation = 0;
+            ITarkovTrackerAPI targetApi = null!;
+            CancellationToken requestCancellation = default;
+            ProgressResponse? unchangedProgress = null;
+            OrgKeyAutoAssignedEventArgs? autoAssignment = null;
+            lock (stateLock)
+            {
+                if (!IsLegacyServiceLocked()
+                    && orgTokenStoreLoaded
+                    && profileSnapshot.HasIdentity
+                    && !string.IsNullOrWhiteSpace(profileSnapshot.Id)
+                    && profileSnapshot.SessionMode is EftSessionMode.PVE or EftSessionMode.Regular or EftSessionMode.Seasonal)
+                {
+                    var existingKey = orgTokenStore.GetForProfile(profileSnapshot);
+                    var prefix = GetPrefixForSessionMode(profileSnapshot.SessionMode);
+                    var allowAutoBind = GetLegacyOrgCandidateLocked(prefix) == null;
+                    var selectedKey = PersistOrgStoreChangeLocked(store =>
+                        store.RememberAndAutoBind(profileSnapshot, DateTimeOffset.UtcNow, allowAutoBind));
+                    newToken = selectedKey?.Token ?? "";
+                    if (existingKey == null && selectedKey?.IsBound == true)
+                    {
+                        autoAssignment = new OrgKeyAutoAssignedEventArgs(
+                            GetPrefixDisplayName(selectedKey.Prefix),
+                            selectedKey.AccountId,
+                            selectedKey.ProfileId,
+                            GameWatcher.ResolveSessionMode(selectedKey.SessionMode));
+                    }
+                }
+                else
+                {
+                    newToken = GetTokenForProfileLocked(profileSnapshot);
+                }
+                if (currentProfile == profileSnapshot.Id
+                    && currentAccountId == profileSnapshot.AccountId
+                    && currentSessionMode == profileSnapshot.SessionMode
+                    && activeToken == newToken
+                    && !forceRefresh
+                    && (ValidToken || string.IsNullOrWhiteSpace(newToken)))
+                {
+                    unchangedProgress = Progress;
+                }
+                else
+                {
+                    currentProfile = profileSnapshot.Id;
+                    currentAccountId = profileSnapshot.AccountId;
+                    currentSessionMode = profileSnapshot.SessionMode;
+                    activeToken = newToken;
+                    generation = BeginNewActivationLocked();
+                    targetApi = api;
+                    requestCancellation = activeRequestCancellation.Token;
+
+                    // Clear the previous profile before the first await. Until both token
+                    // inspection and progress retrieval finish, writes must remain disabled.
+                    ValidToken = false;
+                    Progress = new();
+                }
+            }
+
+            if (autoAssignment != null)
+            {
+                foreach (EventHandler<OrgKeyAutoAssignedEventArgs> handler in
+                    OrgKeyAutoAssigned?.GetInvocationList().Cast<EventHandler<OrgKeyAutoAssignedEventArgs>>()
+                    ?? Array.Empty<EventHandler<OrgKeyAutoAssignedEventArgs>>())
+                {
+                    try
+                    {
+                        handler(null, autoAssignment);
+                    }
+                    catch
+                    {
+                        // Assignment is already persisted. A presentation observer must
+                        // never prevent the matching key from continuing activation.
+                    }
+                }
+            }
+            if (unchangedProgress != null)
+            {
+                return unchangedProgress;
+            }
+
+            if (string.IsNullOrWhiteSpace(newToken))
             {
                 return Progress;
             }
-            var newToken = GetToken(profileId);
-            var oldToken = GetToken(currentProfile);
-            currentProfile = profileId;
-            if (oldToken == newToken)
+
+            await ActivateProfile(new ActiveRequest(
+                profileSnapshot.Id,
+                profileSnapshot.AccountId,
+                profileSnapshot.SessionMode,
+                newToken,
+                generation,
+                targetApi,
+                requestCancellation));
+            lock (stateLock)
             {
                 return Progress;
             }
-            if (newToken == "" || newToken.Length != 22)
-            {
-                ValidToken = false;
-                Progress = new();
-                return Progress;
-            }
-            await TestToken(newToken);
-            return Progress;
         }
 
+        public static Task<ProgressResponse> SetProfile(string profileId)
+        {
+            var profile = GameWatcher.CurrentProfile.Snapshot();
+            if (!string.Equals(profile.Id, profileId, StringComparison.Ordinal))
+            {
+                profile.Id = profileId;
+                profile.AccountId = "";
+                profile.SessionMode = EftSessionMode.Unknown;
+                profile.Type = ProfileType.Regular;
+            }
+            return SetProfile(profile);
+        }
+
+        public static async Task<ProfileActivationLease> AcquireProfileLease(Profile profile)
+        {
+            var profileSnapshot = profile.Snapshot();
+            await SetProfile(profileSnapshot, forceRefresh: true);
+            var request = CaptureActiveRequest(
+                profileSnapshot.Id,
+                profileSnapshot.SessionMode,
+                profileSnapshot.AccountId);
+            lock (stateLock)
+            {
+                if (!IsCurrentLocked(request))
+                {
+                    throw new Exception("Tarkov Tracker profile changed before historical processing could begin");
+                }
+                return new ProfileActivationLease(request, Progress);
+            }
+        }
+
+        public static void ReleaseProfileLease(ProfileActivationLease lease)
+        {
+            lock (stateLock)
+            {
+                if (!IsCurrentLocked(lease.Request))
+                {
+                    return;
+                }
+
+                currentProfile = "";
+                currentAccountId = "";
+                currentSessionMode = EftSessionMode.Unknown;
+                activeToken = "";
+                BeginNewActivationLocked();
+                ValidToken = false;
+                Progress = new();
+            }
+        }
+
+        private static string Bearer(string token) => $"Bearer {token}";
+
+        private static ActiveRequest CaptureActiveRequest(
+            string? expectedProfileId = null,
+            EftSessionMode? expectedSessionMode = null,
+            string? expectedAccountId = null)
+        {
+            lock (stateLock)
+            {
+                if (expectedProfileId != null && expectedProfileId != currentProfile)
+                {
+                    throw new Exception("Tarkov Tracker profile changed before the task update; the update was not sent");
+                }
+                if (expectedSessionMode != null && expectedSessionMode != currentSessionMode)
+                {
+                    throw new Exception("Tarkov Tracker session mode changed before the task update; the update was not sent");
+                }
+                if (expectedAccountId != null && expectedAccountId != currentAccountId)
+                {
+                    throw new Exception("Tarkov Tracker account changed before the task update; the update was not sent");
+                }
+                if (!ValidToken
+                    || string.IsNullOrWhiteSpace(currentProfile)
+                    || string.IsNullOrWhiteSpace(activeToken))
+                {
+                    throw new Exception("Invalid token");
+                }
+
+                return new ActiveRequest(
+                    currentProfile,
+                    currentAccountId,
+                    currentSessionMode,
+                    activeToken,
+                    activationGeneration,
+                    api,
+                    activeRequestCancellation.Token);
+            }
+        }
+
+        private static bool IsCurrentLocked(ActiveRequest request)
+        {
+            var selectedToken = GetTokenForProfileLocked(new Profile
+            {
+                Id = request.ProfileId,
+                AccountId = request.AccountId,
+                SessionMode = request.SessionMode,
+                Type = GameWatcher.ResolveProfileType(request.SessionMode),
+            });
+            return request.Generation == activationGeneration
+                && !request.CancellationToken.IsCancellationRequested
+                && request.ProfileId == currentProfile
+                && request.AccountId == currentAccountId
+                && request.SessionMode == currentSessionMode
+                && request.Token == activeToken
+                && request.Token == selectedToken
+                && ReferenceEquals(request.Api, api);
+        }
+
+        private static bool IsCurrent(ActiveRequest request)
+        {
+            lock (stateLock)
+            {
+                return IsCurrentLocked(request);
+            }
+        }
+
+        private static bool TryInvalidate(ActiveRequest request)
+        {
+            lock (stateLock)
+            {
+                if (!IsCurrentLocked(request))
+                {
+                    return false;
+                }
+
+                Progress = new();
+                ValidToken = false;
+                BeginNewActivationLocked();
+                return true;
+            }
+        }
+
+        // stateLock must be held by the caller so an old request cannot update a
+        // newly activated profile's in-memory progress.
         private static void SyncStoredStatus(string questId, TaskStatus status)
         {
             var storedStatus = Progress.data.tasksProgress.Find(ts => ts.id == questId);
@@ -243,22 +1751,198 @@ namespace TarkovMonitor
             }
         }
 
-        public static async Task<string> SetTaskStatus(string questId, TaskStatus status)
+        private static async Task SendTaskStatus(ActiveRequest request, string questId, TaskStatus status)
         {
-            if (IsLegacyService || !ValidToken)
+            if (!IsCurrent(request))
             {
-                throw new Exception("Invalid token");
+                throw new Exception("Tarkov Tracker profile changed before the task update could be sent");
             }
             try
             {
-                await api.SetTaskStatus(questId, TaskStatusBody.From(status));
-                SyncStoredStatus(questId, status);
+                await request.Api.SetTaskStatus(
+                    questId,
+                    TaskStatusBody.From(status),
+                    Bearer(request.Token),
+                    request.CancellationToken);
+                lock (stateLock)
+                {
+                    if (IsCurrent(request))
+                    {
+                        SyncStoredStatus(questId, status);
+                    }
+                }
             }
             catch (ApiException ex)
             {
                 if (ex.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    InvalidTokenException();
+                    InvalidTokenException(request);
+                }
+                if (ex.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    throw new Exception("Rate limited by Tarkov Tracker API");
+                }
+                throw new Exception($"Invalid TarkovTracker API response code: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"TarkovTracker API error: {ex.Message}");
+            }
+        }
+
+        public static async Task<string> SetTaskStatus(
+            string questId,
+            TaskStatus status,
+            string? expectedProfileId = null,
+            EftSessionMode? expectedSessionMode = null,
+            string? expectedAccountId = null)
+        {
+            await SendTaskStatus(
+                CaptureActiveRequest(expectedProfileId, expectedSessionMode, expectedAccountId),
+                questId,
+                status);
+            return "success";
+        }
+
+        public static async Task<string> SetTaskComplete(
+            string questId,
+            string? expectedProfileId = null,
+            EftSessionMode? expectedSessionMode = null,
+            string? expectedAccountId = null)
+        {
+            var request = CaptureActiveRequest(expectedProfileId, expectedSessionMode, expectedAccountId);
+            await SendTaskStatus(request, questId, TaskStatus.Finished);
+            try
+            {
+                lock (stateLock)
+                {
+                    if (!IsCurrent(request))
+                    {
+                        return "success";
+                    }
+
+                    TarkovDev.Tasks.ForEach(task => {
+                        foreach (var failCondition in task.failConditions)
+                        {
+                            if (failCondition.task == null)
+                            {
+                                continue;
+                            }
+                            if (failCondition.task == questId && failCondition.status?.Contains("complete") == true)
+                            {
+                                foreach (var taskStatus in Progress.data.tasksProgress)
+                                {
+                                    if (taskStatus.id == failCondition.task)
+                                    {
+                                        taskStatus.failed = true;
+                                        break;
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    });
+                }
+            }
+            catch (Exception)
+            {
+                // Preserve the successful remote update if optional local inference fails.
+            }
+            return "success";
+        }
+
+        public static async Task<string> SetTaskFailed(
+            string questId,
+            string? expectedProfileId = null,
+            EftSessionMode? expectedSessionMode = null,
+            string? expectedAccountId = null)
+        {
+            return await SetTaskStatus(
+                questId,
+                TaskStatus.Failed,
+                expectedProfileId,
+                expectedSessionMode,
+                expectedAccountId);
+        }
+
+        public static async Task<string> SetTaskStarted(
+            string questId,
+            string? expectedProfileId = null,
+            EftSessionMode? expectedSessionMode = null,
+            string? expectedAccountId = null)
+        {
+            ActiveRequest request;
+            bool shouldWrite;
+            lock (stateLock)
+            {
+                request = CaptureActiveRequest(expectedProfileId, expectedSessionMode, expectedAccountId);
+                shouldWrite = Progress.data.tasksProgress.Any(taskStatus => taskStatus.id == questId && taskStatus.failed);
+            }
+
+            if (!shouldWrite)
+            {
+                return "task not marked as failed";
+            }
+
+            await SendTaskStatus(request, questId, TaskStatus.Started);
+            return "success";
+        }
+
+        public static async Task<string> SetTaskStatuses(
+            Dictionary<string, TaskStatus> statuses,
+            string? expectedProfileId = null,
+            EftSessionMode? expectedSessionMode = null,
+            string? expectedAccountId = null)
+        {
+            var request = CaptureActiveRequest(expectedProfileId, expectedSessionMode, expectedAccountId);
+            return await SetTaskStatuses(statuses, request);
+        }
+
+        public static async Task<string> SetTaskStatuses(
+            Dictionary<string, TaskStatus> statuses,
+            ProfileActivationLease lease)
+        {
+            if (!IsCurrent(lease.Request))
+            {
+                throw new Exception("Tarkov Tracker profile changed before historical task updates could be sent");
+            }
+            return await SetTaskStatuses(statuses, lease.Request);
+        }
+
+        private static async Task<string> SetTaskStatuses(
+            Dictionary<string, TaskStatus> statuses,
+            ActiveRequest request)
+        {
+            List<TaskStatusBody> body = new();
+            foreach (var kvp in statuses)
+            {
+                TaskStatusBody status = TaskStatusBody.From(kvp.Value);
+                status.id = kvp.Key;
+                body.Add(status);
+            }
+            if (!IsCurrent(request))
+            {
+                throw new Exception("Tarkov Tracker profile changed before task updates could be sent");
+            }
+            try
+            {
+                await request.Api.SetTaskStatuses(body, Bearer(request.Token), request.CancellationToken);
+                lock (stateLock)
+                {
+                    if (IsCurrent(request))
+                    {
+                        foreach (var kvp in statuses)
+                        {
+                            SyncStoredStatus(kvp.Key, kvp.Value);
+                        }
+                    }
+                }
+            }
+            catch (ApiException ex)
+            {
+                if (ex.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    InvalidTokenException(request);
                 }
                 if (ex.StatusCode == HttpStatusCode.TooManyRequests)
                 {
@@ -273,124 +1957,23 @@ namespace TarkovMonitor
             return "success";
         }
 
-        public static async Task<string> SetTaskComplete(string questId)
-        {
-            await SetTaskStatus(questId, TaskStatus.Finished);
-            try
-            {
-                TarkovDev.Tasks.ForEach(task => {
-                    foreach (var failCondition in task.failConditions)
-                    {
-                        if (failCondition.task == null)
-                        {
-                            continue;
-                        }
-                        if (failCondition.task == questId && failCondition.status.Contains("complete"))
-                        {
-                            foreach (var taskStatus in Progress.data.tasksProgress)
-                            {
-                                if (taskStatus.id == failCondition.task)
-                                {
-                                    taskStatus.failed = true;
-                                    break;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                });
-            } 
-            catch (Exception)
-            {
-                // do something?
-            }
-            return "success";
-        }
-
-        public static async Task<string> SetTaskFailed(string questId)
-        {
-            return await SetTaskStatus(questId, TaskStatus.Failed);
-        }
-
-        public static async Task<string> SetTaskStarted(string questId)
-        {
-            foreach (var taskStatus in Progress.data.tasksProgress)
-            {
-                if (taskStatus.id != questId)
-                {
-                    continue;
-                }
-                if (taskStatus.failed)
-                {
-                    return await SetTaskStatus(questId, TaskStatus.Started);
-                }
-                break;
-            }
-            return "task not marked as failed";
-        }
-
-        public static async Task<string> SetTaskStatuses(Dictionary<string, TaskStatus> statuses)
-        {
-			if (IsLegacyService || !ValidToken)
-			{
-				throw new Exception("Invalid token");
-			}
-            List<TaskStatusBody> body = new();
-            foreach (var kvp in statuses)
-            {
-                TaskStatusBody status = TaskStatusBody.From(kvp.Value);
-                status.id = kvp.Key;
-                body.Add(status);
-            }
-			try
-			{
-				await api.SetTaskStatuses(body);
-                foreach( var kvp in statuses)
-                {
-                    SyncStoredStatus(kvp.Key, kvp.Value);
-                }
-			}
-			catch (ApiException ex)
-			{
-				if (ex.StatusCode == HttpStatusCode.Unauthorized)
-				{
-					InvalidTokenException();
-                }
-                if (ex.StatusCode == HttpStatusCode.TooManyRequests)
-                {
-                    throw new Exception("Rate limited by Tarkov Tracker API");
-                }
-                throw new Exception($"Invalid TarkovTracker API response code: {ex.Message}");
-			}
-			catch (Exception ex)
-			{
-				throw new Exception($"TarkovTracker API error: {ex.Message}");
-			}
-			return "success";
-		}
-
         public static async Task<ProgressResponse> GetProgress()
-		{
-			if (IsLegacyService)
-			{
-				ResetActiveState();
-				return Progress;
-			}
-			if (!ValidToken)
-			{
-				throw new Exception("Invalid token");
-			}
+        {
+            var request = CaptureActiveRequest();
             try
             {
-                Progress = await api.GetProgress();
-                ProgressRetrieved?.Invoke(null, new EventArgs());
-                return Progress;
+                var progress = await request.Api.GetProgress(Bearer(request.Token), request.CancellationToken);
+                if (TryPublishProgress(request, progress))
+                {
+                    ProgressRetrieved?.Invoke(null, new(request.ProfileId, request.AccountId, request.SessionMode, progress));
+                }
+                return progress;
             }
             catch (ApiException ex)
             {
                 if (ex.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    InvalidTokenException();
+                    InvalidTokenException(request);
                 }
                 if (ex.StatusCode == HttpStatusCode.TooManyRequests)
                 {
@@ -404,18 +1987,56 @@ namespace TarkovMonitor
             }
         }
 
-        public static async Task<TokenResponse> TestToken(string apiToken)
+        public static async Task<TokenResponse> TestToken(string apiToken, bool activate = false)
         {
             if (IsLegacyService)
             {
                 throw new InvalidOperationException(
                     "Support for TarkovTracker.io has been retired. Switch to TarkovTracker.org.");
             }
+            var trimmedToken = apiToken.Trim();
+            if (!activate)
+            {
+                string domain;
+                lock (stateLock)
+                {
+                    domain = activeDomain;
+                }
+                var response = await InspectToken(trimmedToken, domain);
+                VerifyOrgTokenResponse(trimmedToken, response);
+                return response;
+            }
 
+            ActiveRequest request;
+            lock (stateLock)
+            {
+                if (string.IsNullOrWhiteSpace(currentProfile))
+                {
+                    throw new Exception("No EFT profile initialized, please launch Escape from Tarkov first");
+                }
+
+                activeToken = trimmedToken;
+                ValidToken = false;
+                Progress = new();
+                request = new ActiveRequest(
+                    currentProfile,
+                    currentAccountId,
+                    currentSessionMode,
+                    trimmedToken,
+                    BeginNewActivationLocked(),
+                    api,
+                    activeRequestCancellation.Token);
+            }
+
+            return await ActivateProfile(request);
+        }
+
+        private static async Task<TokenResponse> InspectToken(string apiToken, string trackerDomain)
+        {
             using var request = new HttpRequestMessage(
                 HttpMethod.Get,
-                $"{GetApiBaseUrl(Properties.Settings.Default.tarkovTrackerDomain).TrimEnd('/')}/token");
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken.Trim());
+                $"{GetApiBaseUrl(trackerDomain).TrimEnd('/')}/token");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
 
             HttpResponseMessage httpResponse;
             try
@@ -431,7 +2052,7 @@ namespace TarkovMonitor
             {
                 if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    InvalidTokenException();
+                    throw new Exception("Tarkov Tracker API token is invalid");
                 }
                 if (httpResponse.StatusCode == HttpStatusCode.TooManyRequests)
                 {
@@ -445,28 +2066,93 @@ namespace TarkovMonitor
                 var responseBody = await httpResponse.Content.ReadAsStringAsync();
                 var response = JsonSerializer.Deserialize<TokenResponse>(responseBody)
                     ?? throw new Exception("TarkovTracker returned an empty token response.");
-                VerifyOrgTokenResponse(apiToken, response);
-                if (response.permissions.Contains("WP"))
-                {
-                    ValidToken = true;
-                    await GetProgress();
-                    TokenValidated?.Invoke(null, new EventArgs());
-                }
-                else
-                {
-                    Progress = new();
-                    ValidToken = false;
-                    TokenInvalid?.Invoke(null, new EventArgs());
-                }
                 return response;
             }
         }
 
-        private static void InvalidTokenException()
+        private static async Task<TokenResponse> ActivateProfile(ActiveRequest request)
         {
-            Progress = new();
-            ValidToken = false;
-            TokenInvalid?.Invoke(null, new EventArgs());
+            try
+            {
+                EnsureCurrentRequest(request);
+                var response = await request.Api.TestToken(Bearer(request.Token), request.CancellationToken);
+                VerifyOrgTokenResponse(request.Token, response);
+                var expectedPrefix = GetPrefixForSessionMode(request.SessionMode);
+                if (string.IsNullOrWhiteSpace(expectedPrefix)
+                    || !string.Equals(expectedPrefix, GetOrgTokenPrefix(request.Token), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new Exception("The active API key does not match the current EFT mode.");
+                }
+                if (!response.permissions.Contains("WP"))
+                {
+                    if (TryInvalidate(request))
+                    {
+                        TokenInvalid?.Invoke(null, new EventArgs());
+                    }
+                    return response;
+                }
+
+                // A token is not active until its matching progress has also loaded.
+                // This prevents old progress from being exposed during a mode switch.
+                EnsureCurrentRequest(request);
+                var progress = await request.Api.GetProgress(Bearer(request.Token), request.CancellationToken);
+                if (TryPublishProgress(request, progress))
+                {
+                    TokenValidated?.Invoke(null, new EventArgs());
+                    ProgressRetrieved?.Invoke(null, new(request.ProfileId, request.AccountId, request.SessionMode, progress));
+                }
+                return response;
+            }
+            catch (ApiException ex)
+            {
+                if (ex.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    InvalidTokenException(request);
+                }
+                if (ex.StatusCode == HttpStatusCode.TooManyRequests)
+                {
+                    throw new Exception("Rate limited by Tarkov Tracker API");
+                }
+                throw new Exception($"Invalid TarkovTracker API response code: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"TarkovTracker API error: {ex.Message}");
+            }
+        }
+
+        private static void EnsureCurrentRequest(ActiveRequest request)
+        {
+            request.CancellationToken.ThrowIfCancellationRequested();
+            if (!IsCurrent(request))
+            {
+                throw new OperationCanceledException(
+                    "Tarkov Tracker profile, key, or service changed before the request could be sent.",
+                    request.CancellationToken);
+            }
+        }
+
+        private static bool TryPublishProgress(ActiveRequest request, ProgressResponse progress)
+        {
+            lock (stateLock)
+            {
+                if (!IsCurrentLocked(request))
+                {
+                    return false;
+                }
+
+                Progress = progress;
+                ValidToken = true;
+                return true;
+            }
+        }
+
+        private static void InvalidTokenException(ActiveRequest request)
+        {
+            if (TryInvalidate(request))
+            {
+                TokenInvalid?.Invoke(null, new EventArgs());
+            }
             throw new Exception("Tarkov Tracker API token is invalid");
         }
 

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -10,6 +10,14 @@ using Refit;
 
 namespace TarkovMonitor
 {
+    internal sealed class ProfileActivationSupersededException : OperationCanceledException
+    {
+        internal ProfileActivationSupersededException(Exception innerException)
+            : base("The tracker activation was superseded by a newer profile, key, or service activation.", innerException)
+        {
+        }
+    }
+
     internal class TarkovTracker
     {
         internal interface ITarkovTrackerAPI
@@ -71,6 +79,8 @@ namespace TarkovMonitor
         private static long activationGeneration;
         private static long serviceGeneration;
         private static CancellationTokenSource activeRequestCancellation = new();
+        private static Task<ProgressResponse>? activeActivationTask;
+        private static long activeActivationGeneration;
         private static string activeDomain = Properties.Settings.Default.tarkovTrackerDomain;
         private static ITarkovTrackerAPI api = InitAPI();
 
@@ -1491,6 +1501,9 @@ namespace TarkovMonitor
             ITarkovTrackerAPI targetApi = null!;
             CancellationToken requestCancellation = default;
             ProgressResponse? unchangedProgress = null;
+            Task<ProgressResponse>? activationTask = null;
+            TaskCompletionSource<ProgressResponse>? activationCompletion = null;
+            ActiveRequest? requestToStart = null;
             OrgKeyAutoAssignedEventArgs? autoAssignment = null;
             lock (stateLock)
             {
@@ -1523,12 +1536,22 @@ namespace TarkovMonitor
                     && currentAccountId == profileSnapshot.AccountId
                     && currentSessionMode == profileSnapshot.SessionMode
                     && activeToken == newToken
-                    && !forceRefresh
-                    && (ValidToken || string.IsNullOrWhiteSpace(newToken)))
+                    && !forceRefresh)
                 {
-                    unchangedProgress = Progress;
+                    if (ValidToken || string.IsNullOrWhiteSpace(newToken))
+                    {
+                        unchangedProgress = Progress;
+                    }
+                    else if (activeActivationTask != null
+                        && activeActivationGeneration == activationGeneration)
+                    {
+                        // Repeated ProfileChanged notifications for the same identity
+                        // share the in-flight activation instead of cancelling it.
+                        activationTask = activeActivationTask;
+                    }
                 }
-                else
+
+                if (unchangedProgress == null && activationTask == null)
                 {
                     currentProfile = profileSnapshot.Id;
                     currentAccountId = profileSnapshot.AccountId;
@@ -1542,6 +1565,23 @@ namespace TarkovMonitor
                     // inspection and progress retrieval finish, writes must remain disabled.
                     ValidToken = false;
                     Progress = new();
+
+                    if (!string.IsNullOrWhiteSpace(newToken))
+                    {
+                        activationCompletion = new TaskCompletionSource<ProgressResponse>(
+                            TaskCreationOptions.RunContinuationsAsynchronously);
+                        activeActivationTask = activationCompletion.Task;
+                        activeActivationGeneration = generation;
+                        activationTask = activationCompletion.Task;
+                        requestToStart = new ActiveRequest(
+                            profileSnapshot.Id,
+                            profileSnapshot.AccountId,
+                            profileSnapshot.SessionMode,
+                            newToken,
+                            generation,
+                            targetApi,
+                            requestCancellation);
+                    }
                 }
             }
 
@@ -1572,17 +1612,39 @@ namespace TarkovMonitor
                 return Progress;
             }
 
-            await ActivateProfile(new ActiveRequest(
-                profileSnapshot.Id,
-                profileSnapshot.AccountId,
-                profileSnapshot.SessionMode,
-                newToken,
-                generation,
-                targetApi,
-                requestCancellation));
-            lock (stateLock)
+            if (requestToStart.HasValue)
             {
-                return Progress;
+                _ = CompleteProfileActivationAsync(requestToStart.Value, activationCompletion!);
+            }
+
+            return await activationTask!;
+        }
+
+        private static async Task CompleteProfileActivationAsync(
+            ActiveRequest request,
+            TaskCompletionSource<ProgressResponse> completion)
+        {
+            try
+            {
+                await ActivateProfile(request);
+                lock (stateLock)
+                {
+                    completion.TrySetResult(Progress);
+                }
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+            finally
+            {
+                lock (stateLock)
+                {
+                    if (ReferenceEquals(activeActivationTask, completion.Task))
+                    {
+                        activeActivationTask = null;
+                    }
+                }
             }
         }
 
@@ -2112,11 +2174,19 @@ namespace TarkovMonitor
                 {
                     throw new Exception("Rate limited by Tarkov Tracker API");
                 }
-                throw new Exception($"Invalid TarkovTracker API response code: {ex.Message}");
+                throw new Exception($"Invalid TarkovTracker API response code: {ex.StatusCode}.", ex);
+            }
+            catch (OperationCanceledException ex) when (!IsCurrent(request))
+            {
+                throw new ProfileActivationSupersededException(ex);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new Exception("TarkovTracker API request was canceled.", ex);
             }
             catch (Exception ex)
             {
-                throw new Exception($"TarkovTracker API error: {ex.Message}");
+                throw new Exception("TarkovTracker API error.", ex);
             }
         }
 

--- a/TarkovMonitor/TarkovTracker.cs
+++ b/TarkovMonitor/TarkovTracker.cs
@@ -100,6 +100,10 @@ namespace TarkovMonitor
         private static bool modeTokenStoreLoaded;
         private static bool verificationStoreLoaded;
         private static bool orgTokenStoreLoaded;
+        private static bool legacyTokenStoreNeedsProtectionMigration;
+        private static bool modeTokenStoreNeedsProtectionMigration;
+        private static bool singletonTokenNeedsProtectionMigration;
+        private static string singletonToken = "";
         private static readonly List<string> storageWarnings = new();
         private static string currentProfile = "";
         private static string currentAccountId = "";
@@ -130,25 +134,6 @@ namespace TarkovMonitor
             }
         }
 
-        public sealed class OrgKeyAutoAssignedEventArgs : EventArgs
-        {
-            public string DisplayName { get; }
-            public string AccountId { get; }
-            public string ProfileId { get; }
-            public EftSessionMode SessionMode { get; }
-
-            public OrgKeyAutoAssignedEventArgs(
-                string displayName,
-                string accountId,
-                string profileId,
-                EftSessionMode sessionMode)
-            {
-                DisplayName = displayName;
-                AccountId = accountId;
-                ProfileId = profileId;
-                SessionMode = sessionMode;
-            }
-        }
         public static string CurrentAccountId
         {
             get
@@ -173,7 +158,6 @@ namespace TarkovMonitor
         public static event EventHandler<EventArgs>? TokenValidated;
         public static event EventHandler<EventArgs>? TokenInvalid;
         public static event EventHandler<ProgressRetrievedEventArgs>? ProgressRetrieved;
-        public static event EventHandler<OrgKeyAutoAssignedEventArgs>? OrgKeyAutoAssigned;
         public static Dictionary<string, string> Domains = new() {
             { "tarkovtracker.io", "TarkovTracker.io" },
             { "tarkovtracker.org", "TarkovTracker.org" },
@@ -185,17 +169,20 @@ namespace TarkovMonitor
                 Properties.Settings.Default.tarkovTrackerTokens,
                 StringComparer.Ordinal,
                 nameof(Properties.Settings.Default.tarkovTrackerTokens),
-                out tokens);
+                out tokens,
+                out legacyTokenStoreNeedsProtectionMigration);
             modeTokenStoreLoaded = TryDeserializeTokenStore(
                 Properties.Settings.Default.tarkovTrackerModeTokens,
                 StringComparer.OrdinalIgnoreCase,
                 nameof(Properties.Settings.Default.tarkovTrackerModeTokens),
-                out modeTokens);
+                out modeTokens,
+                out modeTokenStoreNeedsProtectionMigration);
             verificationStoreLoaded = TryDeserializeTokenStore(
                 Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes,
                 StringComparer.OrdinalIgnoreCase,
                 nameof(Properties.Settings.Default.tarkovTrackerVerifiedModeTokenHashes),
-                out verifiedModeTokenHashes);
+                out verifiedModeTokenHashes,
+                out _);
             orgTokenStoreLoaded = TarkovTrackerOrgStore.TryParse(
                 Properties.Settings.Default.tarkovTrackerOrgTokenStore,
                 out orgTokenStore,
@@ -205,9 +192,84 @@ namespace TarkovMonitor
                 storageWarnings.Add(
                     $"TarkovTracker.org key storage could not be read. Its original value was preserved and key changes are disabled until it is repaired. {orgStoreError}");
             }
+            else if (orgTokenStore.NeedsTokenProtectionMigration)
+            {
+                var previousOrgStoreSetting = Properties.Settings.Default.tarkovTrackerOrgTokenStore;
+                try
+                {
+                    // Migrate legacy plaintext records immediately so a successful
+                    // startup never leaves the new org key store persisted in cleartext.
+                    Properties.Settings.Default.tarkovTrackerOrgTokenStore = orgTokenStore.Serialize();
+                    Properties.Settings.Default.Save();
+                }
+                catch (Exception ex)
+                {
+                    Properties.Settings.Default.tarkovTrackerOrgTokenStore = previousOrgStoreSetting;
+                    orgTokenStore = TarkovTrackerOrgStore.Empty();
+                    orgTokenStoreLoaded = false;
+                    storageWarnings.Add(
+                        $"TarkovTracker.org API keys could not be protected for this Windows user. The original value was preserved and key changes remain disabled until storage is repaired. {ex.Message}");
+                }
+            }
             if (modeTokenStoreLoaded && verificationStoreLoaded)
             {
                 RemoveStaleVerificationRecords();
+            }
+
+            try
+            {
+                singletonToken = TokenStoreProtection.Unprotect(
+                    Properties.Settings.Default.tarkovTrackerToken,
+                    out singletonTokenNeedsProtectionMigration);
+            }
+            catch (Exception ex)
+            {
+                storageWarnings.Add(
+                    $"The saved TarkovTracker singleton key could not be decrypted and will remain unavailable until storage is repaired. {ex.Message}");
+                singletonToken = "";
+                singletonTokenNeedsProtectionMigration = false;
+            }
+
+            if ((legacyTokenStoreLoaded && legacyTokenStoreNeedsProtectionMigration)
+                || (modeTokenStoreLoaded && modeTokenStoreNeedsProtectionMigration)
+                || singletonTokenNeedsProtectionMigration)
+            {
+                var previousModeSetting = Properties.Settings.Default.tarkovTrackerModeTokens;
+                var previousLegacySetting = Properties.Settings.Default.tarkovTrackerTokens;
+                var previousSingletonSetting = Properties.Settings.Default.tarkovTrackerToken;
+                try
+                {
+                    if (modeTokenStoreLoaded && modeTokenStoreNeedsProtectionMigration)
+                    {
+                        Properties.Settings.Default.tarkovTrackerModeTokens = ProtectTokenStore(modeTokens);
+                    }
+                    if (legacyTokenStoreLoaded && legacyTokenStoreNeedsProtectionMigration)
+                    {
+                        Properties.Settings.Default.tarkovTrackerTokens = ProtectTokenStore(tokens);
+                    }
+                    if (singletonTokenNeedsProtectionMigration)
+                    {
+                        Properties.Settings.Default.tarkovTrackerToken = TokenStoreProtection.Protect(singletonToken);
+                    }
+                    Properties.Settings.Default.Save();
+                    if (legacyTokenStoreLoaded)
+                    {
+                        legacyTokenStoreNeedsProtectionMigration = false;
+                    }
+                    if (modeTokenStoreLoaded)
+                    {
+                        modeTokenStoreNeedsProtectionMigration = false;
+                    }
+                    singletonTokenNeedsProtectionMigration = false;
+                }
+                catch (Exception ex)
+                {
+                    Properties.Settings.Default.tarkovTrackerModeTokens = previousModeSetting;
+                    Properties.Settings.Default.tarkovTrackerTokens = previousLegacySetting;
+                    Properties.Settings.Default.tarkovTrackerToken = previousSingletonSetting;
+                    storageWarnings.Add(
+                        $"Legacy TarkovTracker keys could not be protected for this Windows user. Their original values were preserved. {ex.Message}");
+                }
             }
         }
 
@@ -215,9 +277,11 @@ namespace TarkovMonitor
             string rawValue,
             IEqualityComparer<string> comparer,
             string settingName,
-            out Dictionary<string, string> store)
+            out Dictionary<string, string> store,
+            out bool needsProtectionMigration)
         {
             store = new Dictionary<string, string>(comparer);
+            needsProtectionMigration = false;
             try
             {
                 if (string.IsNullOrWhiteSpace(rawValue))
@@ -225,7 +289,9 @@ namespace TarkovMonitor
                     throw new JsonException("The stored value is empty.");
                 }
 
-                var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(rawValue)
+                var unprotectedValue = TokenStoreProtection.Unprotect(rawValue, out var wasProtected);
+                needsProtectionMigration = !wasProtected;
+                var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(unprotectedValue)
                     ?? throw new JsonException("The stored value is null.");
                 if (parsed.Any(pair => pair.Key is null || pair.Value is null))
                 {
@@ -235,7 +301,7 @@ namespace TarkovMonitor
                 store = new Dictionary<string, string>(parsed, comparer);
                 return true;
             }
-            catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+            catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException or InvalidDataException)
             {
                 var blockedAction = settingName == nameof(Properties.Settings.Default.tarkovTrackerTokens)
                     ? "Legacy TarkovTracker.io key changes and profile-keyed TarkovTracker.org recovery are disabled"
@@ -244,6 +310,11 @@ namespace TarkovMonitor
                     $"Tarkov Tracker storage setting {settingName} could not be read. Its original value was preserved and Tarkov Monitor will not overwrite it. {blockedAction} until the setting is repaired.");
                 return false;
             }
+        }
+
+        private static string ProtectTokenStore(Dictionary<string, string> store)
+        {
+            return TokenStoreProtection.Protect(JsonSerializer.Serialize(store));
         }
 
         public static IReadOnlyList<string> GetStorageWarnings()
@@ -508,6 +579,7 @@ namespace TarkovMonitor
             string AccountNickname,
             string ProfileNickname,
             bool IsVerified,
+            bool IsAutoBindBlocked,
             bool HasPendingConflict,
             bool IsLegacyRecovery,
             bool IsQuarantined);
@@ -591,6 +663,16 @@ namespace TarkovMonitor
                     .OrderByDescending(profile => profile.IsCurrent)
                     .ThenByDescending(profile => profile.LastSeenUtc)
                     .ToList();
+            }
+        }
+
+        public static Profile? GetLastKnownOrgProfile()
+        {
+            lock (stateLock)
+            {
+                return orgTokenStoreLoaded
+                    ? orgTokenStore.GetMostRecentlySeenProfile()
+                    : null;
             }
         }
 
@@ -689,14 +771,20 @@ namespace TarkovMonitor
                         throw new InvalidOperationException(
                             $"Another unassigned {GetPrefixDisplayName(prefix)} API key was added before this import finished.");
                     }
+                    var activeProfile = GetActiveOrgBindingProfileLocked();
+                    if (activeProfile != null && orgTokenStore.GetForProfile(activeProfile) != null)
+                    {
+                        activeProfile = null;
+                    }
                     savedKey = PersistOrgStoreChangeLocked(store =>
-                        store.AddVerifiedToken(trimmedToken, prefix, null));
+                        store.AddVerifiedToken(trimmedToken, prefix, activeProfile));
                 }
                 CompleteImportValidationCall(true);
                 return new ImportedToken(
                     savedKey.Id,
                     prefix,
-                    GetPrefixDisplayName(prefix));
+                    GetPrefixDisplayName(prefix),
+                    savedKey.IsBound);
             }
             catch
             {
@@ -802,7 +890,7 @@ namespace TarkovMonitor
                     var bindingProfile = EnsureCurrentBindingProfileLocked(profile);
                     boundKey = PersistOrgStoreChangeLocked(store =>
                     {
-                        store.RememberAndAutoBind(bindingProfile, DateTimeOffset.UtcNow);
+                        store.RememberAndAutoBindFirstProfile(bindingProfile, DateTimeOffset.UtcNow);
                         var existing = store.GetKey(id);
                         return existing?.IsBound == true
                             ? existing
@@ -922,6 +1010,7 @@ namespace TarkovMonitor
                 key.IsBound ? orgTokenStore.GetAccountNickname(key.AccountId) : "",
                 key.IsBound ? key.ProfileNickname : "",
                 TarkovTrackerOrgStore.IsVerified(key),
+                !key.IsBound && (!string.IsNullOrWhiteSpace(key.AutoBindBlockedAccountId) || key.LegacyAutoBindSuppressed),
                 false,
                 false,
                 !string.IsNullOrEmpty(orgTokenStore.GetStoreIssue(key)));
@@ -941,6 +1030,7 @@ namespace TarkovMonitor
                 "",
                 "",
                 candidate.Verified,
+                false,
                 false,
                 true,
                 false);
@@ -986,12 +1076,12 @@ namespace TarkovMonitor
                 }
             }
 
-            var singletonToken = Properties.Settings.Default.tarkovTrackerToken?.Trim() ?? "";
-            if (IsImportableToken(singletonToken))
+            var recoveredSingletonToken = singletonToken?.Trim() ?? "";
+            if (IsImportableToken(recoveredSingletonToken))
             {
                 sources.Add((
-                    GetTokenPrefix(singletonToken),
-                    singletonToken,
+                    GetTokenPrefix(recoveredSingletonToken),
+                    recoveredSingletonToken,
                     new LegacyOrgSource(LegacyOrgSourceKind.Singleton, "")));
             }
 
@@ -1042,14 +1132,13 @@ namespace TarkovMonitor
         private static T PersistOrgStoreChangeLocked<T>(Func<TarkovTrackerOrgStore, T> mutation)
         {
             EnsureOrgProfileStoreWritable();
-            var currentSerialized = orgTokenStore.Serialize();
             var candidateStore = orgTokenStore.Clone();
             var result = mutation(candidateStore);
-            var candidateSerialized = candidateStore.Serialize();
-            if (string.Equals(currentSerialized, candidateSerialized, StringComparison.Ordinal))
+            if (orgTokenStore.HasSameState(candidateStore))
             {
                 return result;
             }
+            var candidateSerialized = candidateStore.Serialize();
             var previousSetting = Properties.Settings.Default.tarkovTrackerOrgTokenStore;
             try
             {
@@ -1080,17 +1169,18 @@ namespace TarkovMonitor
             var previousModeTokens = new Dictionary<string, string>(modeTokens, StringComparer.OrdinalIgnoreCase);
             var previousTokens = new Dictionary<string, string>(tokens, StringComparer.Ordinal);
             var previousVerificationHashes = new Dictionary<string, string>(verifiedModeTokenHashes, StringComparer.OrdinalIgnoreCase);
+            var previousSingletonToken = singletonToken;
             try
             {
                 RemoveLegacyOrgSourcesInMemoryLocked(candidate);
                 Properties.Settings.Default.tarkovTrackerOrgTokenStore = candidateStore.Serialize();
                 if (modeTokenStoreLoaded)
                 {
-                    Properties.Settings.Default.tarkovTrackerModeTokens = JsonSerializer.Serialize(modeTokens);
+                    Properties.Settings.Default.tarkovTrackerModeTokens = ProtectTokenStore(modeTokens);
                 }
                 if (legacyTokenStoreLoaded)
                 {
-                    Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
+                    Properties.Settings.Default.tarkovTrackerTokens = ProtectTokenStore(tokens);
                 }
                 if (verificationStoreLoaded)
                 {
@@ -1106,6 +1196,7 @@ namespace TarkovMonitor
                 modeTokens = previousModeTokens;
                 tokens = previousTokens;
                 verifiedModeTokenHashes = previousVerificationHashes;
+                singletonToken = previousSingletonToken;
                 Properties.Settings.Default.tarkovTrackerOrgTokenStore = previousOrgSetting;
                 Properties.Settings.Default.tarkovTrackerModeTokens = previousModeSetting;
                 Properties.Settings.Default.tarkovTrackerTokens = previousLegacySetting;
@@ -1124,16 +1215,17 @@ namespace TarkovMonitor
             var previousModeTokens = new Dictionary<string, string>(modeTokens, StringComparer.OrdinalIgnoreCase);
             var previousTokens = new Dictionary<string, string>(tokens, StringComparer.Ordinal);
             var previousVerificationHashes = new Dictionary<string, string>(verifiedModeTokenHashes, StringComparer.OrdinalIgnoreCase);
+            var previousSingletonToken = singletonToken;
             try
             {
                 RemoveLegacyOrgSourcesInMemoryLocked(candidate);
                 if (modeTokenStoreLoaded)
                 {
-                    Properties.Settings.Default.tarkovTrackerModeTokens = JsonSerializer.Serialize(modeTokens);
+                    Properties.Settings.Default.tarkovTrackerModeTokens = ProtectTokenStore(modeTokens);
                 }
                 if (legacyTokenStoreLoaded)
                 {
-                    Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
+                    Properties.Settings.Default.tarkovTrackerTokens = ProtectTokenStore(tokens);
                 }
                 if (verificationStoreLoaded)
                 {
@@ -1147,6 +1239,7 @@ namespace TarkovMonitor
                 modeTokens = previousModeTokens;
                 tokens = previousTokens;
                 verifiedModeTokenHashes = previousVerificationHashes;
+                singletonToken = previousSingletonToken;
                 Properties.Settings.Default.tarkovTrackerModeTokens = previousModeSetting;
                 Properties.Settings.Default.tarkovTrackerTokens = previousLegacySetting;
                 Properties.Settings.Default.tarkovTrackerToken = previousSingletonSetting;
@@ -1183,12 +1276,13 @@ namespace TarkovMonitor
                         break;
                     case LegacyOrgSourceKind.Singleton:
                         if (!string.Equals(
-                            Properties.Settings.Default.tarkovTrackerToken?.Trim(),
+                            singletonToken?.Trim(),
                             candidate.Token,
                             StringComparison.Ordinal))
                         {
                             throw new InvalidOperationException("The saved API key changed before its recovery source could be updated.");
                         }
+                        singletonToken = "";
                         Properties.Settings.Default.tarkovTrackerToken = "";
                         break;
                 }
@@ -1213,6 +1307,25 @@ namespace TarkovMonitor
                 throw new InvalidOperationException("The selected EFT profile changed. Select the matching profile and try again.");
             }
             return profile.Snapshot();
+        }
+
+        private static Profile? GetActiveOrgBindingProfileLocked()
+        {
+            if (IsLegacyServiceLocked()
+                || string.IsNullOrWhiteSpace(currentProfile)
+                || string.IsNullOrWhiteSpace(currentAccountId)
+                || currentSessionMode is not (EftSessionMode.PVE or EftSessionMode.Regular or EftSessionMode.Seasonal))
+            {
+                return null;
+            }
+
+            return new Profile
+            {
+                Id = currentProfile,
+                AccountId = currentAccountId,
+                SessionMode = currentSessionMode,
+                Type = GameWatcher.ResolveProfileType(currentSessionMode),
+            };
         }
 
         private static void InvalidateChangedOrgActivationLocked()
@@ -1401,7 +1514,8 @@ namespace TarkovMonitor
         public record ImportedToken(
             string Id,
             string Prefix,
-            string DisplayName);
+            string DisplayName,
+            bool IsBound);
 
         public sealed class DuplicateImportedTokenException : Exception
         {
@@ -1436,7 +1550,7 @@ namespace TarkovMonitor
                 tokens[profileId] = token;
                 try
                 {
-                    Properties.Settings.Default.tarkovTrackerTokens = JsonSerializer.Serialize(tokens);
+                    Properties.Settings.Default.tarkovTrackerTokens = ProtectTokenStore(tokens);
                     Properties.Settings.Default.Save();
                 }
                 catch
@@ -1506,7 +1620,6 @@ namespace TarkovMonitor
             Task<ProgressResponse>? activationTask = null;
             TaskCompletionSource<ProgressResponse>? activationCompletion = null;
             ActiveRequest? requestToStart = null;
-            OrgKeyAutoAssignedEventArgs? autoAssignment = null;
             lock (stateLock)
             {
                 if (!IsLegacyServiceLocked()
@@ -1515,20 +1628,9 @@ namespace TarkovMonitor
                     && !string.IsNullOrWhiteSpace(profileSnapshot.Id)
                     && profileSnapshot.SessionMode is EftSessionMode.PVE or EftSessionMode.Regular or EftSessionMode.Seasonal)
                 {
-                    var existingKey = orgTokenStore.GetForProfile(profileSnapshot);
-                    var prefix = GetPrefixForSessionMode(profileSnapshot.SessionMode);
-                    var allowAutoBind = GetLegacyOrgCandidateLocked(prefix) == null;
                     var selectedKey = PersistOrgStoreChangeLocked(store =>
-                        store.RememberAndAutoBind(profileSnapshot, DateTimeOffset.UtcNow, allowAutoBind));
+                        store.RememberAndAutoBindFirstProfile(profileSnapshot, DateTimeOffset.UtcNow));
                     newToken = selectedKey?.Token ?? "";
-                    if (existingKey == null && selectedKey?.IsBound == true)
-                    {
-                        autoAssignment = new OrgKeyAutoAssignedEventArgs(
-                            GetPrefixDisplayName(selectedKey.Prefix),
-                            selectedKey.AccountId,
-                            selectedKey.ProfileId,
-                            GameWatcher.ResolveSessionMode(selectedKey.SessionMode));
-                    }
                 }
                 else
                 {
@@ -1587,23 +1689,6 @@ namespace TarkovMonitor
                 }
             }
 
-            if (autoAssignment != null)
-            {
-                foreach (EventHandler<OrgKeyAutoAssignedEventArgs> handler in
-                    OrgKeyAutoAssigned?.GetInvocationList().Cast<EventHandler<OrgKeyAutoAssignedEventArgs>>()
-                    ?? Array.Empty<EventHandler<OrgKeyAutoAssignedEventArgs>>())
-                {
-                    try
-                    {
-                        handler(null, autoAssignment);
-                    }
-                    catch
-                    {
-                        // Assignment is already persisted. A presentation observer must
-                        // never prevent the matching key from continuing activation.
-                    }
-                }
-            }
             if (unchangedProgress != null)
             {
                 return unchangedProgress;

--- a/TarkovMonitor/TarkovTrackerOrgStore.cs
+++ b/TarkovMonitor/TarkovTrackerOrgStore.cs
@@ -7,7 +7,7 @@ namespace TarkovMonitor
 {
     internal sealed class TarkovTrackerOrgStoreDocument
     {
-        public const int CurrentVersion = 4;
+        public const int CurrentVersion = 6;
 
         [JsonPropertyName("version")]
         [JsonRequired]
@@ -89,7 +89,17 @@ namespace TarkovMonitor
         [JsonPropertyName("id")]
         public string Id { get; set; } = "";
 
+        // Version 1-4 stored this field as plaintext. Keep it read-compatible
+        // for one-way migration, but never write it again.
         [JsonPropertyName("token")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? LegacyToken { get; set; }
+
+        [JsonPropertyName("protectedToken")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ProtectedToken { get; set; }
+
+        [JsonIgnore]
         public string Token { get; set; } = "";
 
         [JsonPropertyName("prefix")]
@@ -110,6 +120,16 @@ namespace TarkovMonitor
         [JsonPropertyName("profileNickname")]
         public string ProfileNickname { get; set; } = "";
 
+        // An explicit unbind blocks automatic reassignment only for the
+        // account that previously owned this key. Keep the old boolean as a
+        // read-compatible safety flag for pre-release local stores created by
+        // the earlier suppression draft; new records use the account ID.
+        [JsonPropertyName("autoBindBlockedAccountId")]
+        public string AutoBindBlockedAccountId { get; set; } = "";
+
+        [JsonPropertyName("autoBindSuppressed")]
+        public bool LegacyAutoBindSuppressed { get; set; }
+
         // Version 1 stored nicknames on individual keys. This read-only
         // compatibility property is consumed during the version 2 migration.
         [JsonPropertyName("nickname")]
@@ -126,6 +146,8 @@ namespace TarkovMonitor
             return new TarkovTrackerOrgKey
             {
                 Id = Id,
+                LegacyToken = LegacyToken,
+                ProtectedToken = ProtectedToken,
                 Token = Token,
                 Prefix = Prefix,
                 AccountId = AccountId,
@@ -133,6 +155,8 @@ namespace TarkovMonitor
                 SessionMode = SessionMode,
                 VerifiedTokenHash = VerifiedTokenHash,
                 ProfileNickname = ProfileNickname,
+                AutoBindBlockedAccountId = AutoBindBlockedAccountId,
+                LegacyAutoBindSuppressed = LegacyAutoBindSuppressed,
                 LegacyNickname = LegacyNickname,
             };
         }
@@ -143,15 +167,21 @@ namespace TarkovMonitor
         private readonly List<TarkovTrackerOrgKey> keys;
         private readonly List<TarkovTrackerOrgAccount> accounts;
         private readonly List<TarkovTrackerOrgProfile> profiles;
+        internal bool NeedsTokenProtectionMigration { get; }
+
+        private static readonly byte[] tokenProtectionEntropy = SHA256.HashData(
+            Encoding.UTF8.GetBytes("TarkovMonitor:TarkovTracker.org:token-store:v1"));
 
         private TarkovTrackerOrgStore(
             IEnumerable<TarkovTrackerOrgKey>? keys = null,
             IEnumerable<TarkovTrackerOrgAccount>? accounts = null,
-            IEnumerable<TarkovTrackerOrgProfile>? profiles = null)
+            IEnumerable<TarkovTrackerOrgProfile>? profiles = null,
+            bool needsTokenProtectionMigration = false)
         {
             this.keys = keys?.Select(key => key.Clone()).ToList() ?? new();
             this.accounts = accounts?.Select(account => account.Clone()).ToList() ?? new();
             this.profiles = profiles?.Select(profile => profile.Clone()).ToList() ?? new();
+            NeedsTokenProtectionMigration = needsTokenProtectionMigration;
         }
 
         public static TarkovTrackerOrgStore Empty() => new();
@@ -169,7 +199,7 @@ namespace TarkovMonitor
 
                 var document = JsonSerializer.Deserialize<TarkovTrackerOrgStoreDocument>(rawValue)
                     ?? throw new JsonException("The stored value is null.");
-                if (document.Version is not (1 or 2 or 3 or TarkovTrackerOrgStoreDocument.CurrentVersion))
+                if (document.Version is not (1 or 2 or 3 or 4 or 5 or TarkovTrackerOrgStoreDocument.CurrentVersion))
                 {
                     throw new JsonException($"Unsupported store version {document.Version}.");
                 }
@@ -183,7 +213,12 @@ namespace TarkovMonitor
                     throw new JsonException("The key list contains a null record.");
                 }
 
-                var normalizedKeys = document.Keys.Select(Normalize).ToList();
+                var needsTokenProtectionMigration = document.Keys.Any(key =>
+                    !string.IsNullOrWhiteSpace(key.LegacyToken));
+                var normalizedKeys = document.Keys
+                    .Select(DecryptToken)
+                    .Select(Normalize)
+                    .ToList();
                 if (document.Version < 4)
                 {
                     normalizedKeys.ForEach(key => key.ProfileNickname = "");
@@ -287,23 +322,63 @@ namespace TarkovMonitor
                 {
                     key.LegacyNickname = null;
                 }
-                store = new TarkovTrackerOrgStore(normalizedKeys, normalizedAccounts, normalizedProfiles);
+                store = new TarkovTrackerOrgStore(
+                    normalizedKeys,
+                    normalizedAccounts,
+                    normalizedProfiles,
+                    needsTokenProtectionMigration);
                 return true;
             }
-            catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+            catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException or CryptographicException)
             {
                 error = ex.Message;
                 return false;
             }
         }
 
-        public TarkovTrackerOrgStore Clone() => new(keys, accounts, profiles);
+        public TarkovTrackerOrgStore Clone() => new(
+            keys,
+            accounts,
+            profiles,
+            NeedsTokenProtectionMigration);
+
+        internal bool HasSameState(TarkovTrackerOrgStore other)
+        {
+            return keys.Count == other.keys.Count
+                && keys.Zip(other.keys).All(pair => KeysMatch(pair.First, pair.Second))
+                && accounts.Count == other.accounts.Count
+                && accounts.Zip(other.accounts).All(pair =>
+                    string.Equals(pair.First.AccountId, pair.Second.AccountId, StringComparison.Ordinal)
+                    && string.Equals(pair.First.Nickname, pair.Second.Nickname, StringComparison.Ordinal))
+                && profiles.Count == other.profiles.Count
+                && profiles.Zip(other.profiles).All(pair =>
+                    string.Equals(pair.First.AccountId, pair.Second.AccountId, StringComparison.Ordinal)
+                    && string.Equals(pair.First.ProfileId, pair.Second.ProfileId, StringComparison.Ordinal)
+                    && string.Equals(pair.First.SessionMode, pair.Second.SessionMode, StringComparison.Ordinal)
+                    && pair.First.FirstSeenUtc == pair.Second.FirstSeenUtc
+                    && pair.First.LastSeenUtc == pair.Second.LastSeenUtc);
+        }
+
+        private static bool KeysMatch(TarkovTrackerOrgKey left, TarkovTrackerOrgKey right)
+        {
+            return string.Equals(left.Id, right.Id, StringComparison.Ordinal)
+                && string.Equals(left.Token, right.Token, StringComparison.Ordinal)
+                && string.Equals(left.Prefix, right.Prefix, StringComparison.Ordinal)
+                && string.Equals(left.AccountId, right.AccountId, StringComparison.Ordinal)
+                && string.Equals(left.ProfileId, right.ProfileId, StringComparison.Ordinal)
+                && string.Equals(left.SessionMode, right.SessionMode, StringComparison.Ordinal)
+                && string.Equals(left.VerifiedTokenHash, right.VerifiedTokenHash, StringComparison.Ordinal)
+                && string.Equals(left.ProfileNickname, right.ProfileNickname, StringComparison.Ordinal)
+                && string.Equals(left.AutoBindBlockedAccountId, right.AutoBindBlockedAccountId, StringComparison.Ordinal)
+                && left.LegacyAutoBindSuppressed == right.LegacyAutoBindSuppressed
+                && string.Equals(left.LegacyNickname, right.LegacyNickname, StringComparison.Ordinal);
+        }
 
         public string Serialize()
         {
             return JsonSerializer.Serialize(new TarkovTrackerOrgStoreDocument
             {
-                Keys = keys.Select(key => key.Clone()).ToList(),
+                Keys = keys.Select(ProtectToken).ToList(),
                 Accounts = accounts.Select(account => account.Clone()).ToList(),
                 Profiles = profiles.Select(profile => profile.Clone()).ToList(),
             });
@@ -322,6 +397,15 @@ namespace TarkovMonitor
         public IReadOnlyList<TarkovTrackerOrgProfile> GetProfiles()
         {
             return profiles.Select(profile => profile.Clone()).ToList();
+        }
+
+        public Profile? GetMostRecentlySeenProfile()
+        {
+            return profiles
+                .Where(IsValidProfile)
+                .OrderByDescending(profile => profile.LastSeenUtc ?? profile.FirstSeenUtc ?? DateTimeOffset.MinValue)
+                .Select(profile => profile.ToProfile())
+                .FirstOrDefault(profile => profile.HasTarkovDevPlayerRoute);
         }
 
         public string GetAccountNickname(string accountId)
@@ -445,25 +529,85 @@ namespace TarkovMonitor
             return Bind(id, profile);
         }
 
-        public TarkovTrackerOrgKey? RememberAndAutoBind(
+        public TarkovTrackerOrgKey? RememberAndAutoBindFirstProfile(
             Profile profile,
-            DateTimeOffset seenAt,
-            bool allowAutoBind = true)
+            DateTimeOffset seenAt)
         {
             RememberProfile(profile, seenAt, seenAt);
+
             var existing = GetForProfile(profile);
-            if (existing != null || !profile.SupportsTarkovTrackerWrites || !allowAutoBind)
+            if (existing != null)
             {
                 return existing;
             }
 
+            // Automatic onboarding is intentionally narrow. A mode prefix is
+            // not an identity, so only one verified, non-suppressed key may
+            // claim the first complete EFT account/profile observed for that
+            // mode. Multiple candidates always fall back to manual assignment.
             var prefix = TarkovTracker.GetPrefixForSessionMode(profile.SessionMode);
-            var pending = keys
+            var candidates = keys
                 .Where(key => !key.IsBound
+                    && !key.LegacyAutoBindSuppressed
+                    && !string.Equals(key.AutoBindBlockedAccountId, profile.AccountId, StringComparison.Ordinal)
+                    && IsVerified(key)
                     && string.IsNullOrEmpty(GetStoreIssue(key))
                     && string.Equals(key.Prefix, prefix, StringComparison.OrdinalIgnoreCase))
                 .ToList();
-            return pending.Count == 1 ? Bind(pending[0].Id, profile) : null;
+            if (candidates.Count != 1)
+            {
+                return null;
+            }
+
+            var candidate = candidates[0];
+            if (!CanBindToProfile(candidate, profile))
+            {
+                return null;
+            }
+
+            ApplyBinding(candidate, profile);
+            EnsureBindingAvailable(candidate);
+            return candidate.Clone();
+        }
+
+        private static TarkovTrackerOrgKey DecryptToken(TarkovTrackerOrgKey key)
+        {
+            if (!string.IsNullOrWhiteSpace(key.ProtectedToken))
+            {
+                try
+                {
+                    key.Token = Encoding.UTF8.GetString(ProtectedData.Unprotect(
+                        Convert.FromBase64String(key.ProtectedToken),
+                        tokenProtectionEntropy,
+                        DataProtectionScope.CurrentUser));
+                }
+                catch (Exception ex) when (ex is CryptographicException or FormatException)
+                {
+                    throw new JsonException("A stored TarkovTracker.org API key could not be decrypted.", ex);
+                }
+            }
+            else
+            {
+                key.Token = key.LegacyToken ?? "";
+            }
+
+            key.LegacyToken = null;
+            key.ProtectedToken = null;
+            return key;
+        }
+
+        private static TarkovTrackerOrgKey ProtectToken(TarkovTrackerOrgKey key)
+        {
+            var protectedKey = key.Clone();
+            protectedKey.LegacyToken = null;
+            protectedKey.ProtectedToken = string.IsNullOrEmpty(key.Token)
+                ? null
+                : Convert.ToBase64String(ProtectedData.Protect(
+                    Encoding.UTF8.GetBytes(key.Token),
+                    tokenProtectionEntropy,
+                    DataProtectionScope.CurrentUser));
+            protectedKey.Token = "";
+            return protectedKey;
         }
 
         public int RememberProfiles(IEnumerable<TarkovTrackerOrgProfile> discoveredProfiles)
@@ -554,10 +698,13 @@ namespace TarkovMonitor
                     $"Assign or remove the unassigned {TarkovTracker.GetPrefixDisplayName(key.Prefix)} API key before unbinding another one.");
             }
 
+            var previousAccountId = key.AccountId;
             key.AccountId = "";
             key.ProfileId = "";
             key.SessionMode = "";
             key.ProfileNickname = "";
+            key.AutoBindBlockedAccountId = previousAccountId;
+            key.LegacyAutoBindSuppressed = false;
             return key.Clone();
         }
 
@@ -827,6 +974,8 @@ namespace TarkovMonitor
             key.AccountId = profile.AccountId;
             key.ProfileId = profile.Id;
             key.SessionMode = TarkovTracker.NormalizeSessionMode(profile.SessionMode);
+            key.AutoBindBlockedAccountId = "";
+            key.LegacyAutoBindSuppressed = false;
         }
 
         private void EnsureBindingAvailable(TarkovTrackerOrgKey proposedKey)

--- a/TarkovMonitor/TarkovTrackerOrgStore.cs
+++ b/TarkovMonitor/TarkovTrackerOrgStore.cs
@@ -1,0 +1,913 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TarkovMonitor
+{
+    internal sealed class TarkovTrackerOrgStoreDocument
+    {
+        public const int CurrentVersion = 4;
+
+        [JsonPropertyName("version")]
+        [JsonRequired]
+        public int Version { get; set; } = CurrentVersion;
+
+        [JsonPropertyName("keys")]
+        [JsonRequired]
+        public List<TarkovTrackerOrgKey> Keys { get; set; } = new();
+
+        [JsonPropertyName("accounts")]
+        public List<TarkovTrackerOrgAccount>? Accounts { get; set; }
+
+        [JsonPropertyName("profiles")]
+        public List<TarkovTrackerOrgProfile>? Profiles { get; set; }
+    }
+
+    internal sealed class TarkovTrackerOrgProfile
+    {
+        [JsonPropertyName("accountId")]
+        public string AccountId { get; set; } = "";
+
+        [JsonPropertyName("profileId")]
+        public string ProfileId { get; set; } = "";
+
+        [JsonPropertyName("sessionMode")]
+        public string SessionMode { get; set; } = "";
+
+        [JsonPropertyName("firstSeenUtc")]
+        public DateTimeOffset? FirstSeenUtc { get; set; }
+
+        [JsonPropertyName("lastSeenUtc")]
+        public DateTimeOffset? LastSeenUtc { get; set; }
+
+        internal TarkovTrackerOrgProfile Clone()
+        {
+            return new TarkovTrackerOrgProfile
+            {
+                AccountId = AccountId,
+                ProfileId = ProfileId,
+                SessionMode = SessionMode,
+                FirstSeenUtc = FirstSeenUtc,
+                LastSeenUtc = LastSeenUtc,
+            };
+        }
+
+        internal Profile ToProfile()
+        {
+            var resolvedMode = GameWatcher.ResolveSessionMode(SessionMode);
+            return new Profile
+            {
+                AccountId = AccountId,
+                Id = ProfileId,
+                SessionMode = resolvedMode,
+                Type = GameWatcher.ResolveProfileType(resolvedMode),
+            };
+        }
+    }
+
+    internal sealed class TarkovTrackerOrgAccount
+    {
+        [JsonPropertyName("accountId")]
+        public string AccountId { get; set; } = "";
+
+        [JsonPropertyName("nickname")]
+        public string Nickname { get; set; } = "";
+
+        internal TarkovTrackerOrgAccount Clone()
+        {
+            return new TarkovTrackerOrgAccount
+            {
+                AccountId = AccountId,
+                Nickname = Nickname,
+            };
+        }
+    }
+
+    internal sealed class TarkovTrackerOrgKey
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+
+        [JsonPropertyName("token")]
+        public string Token { get; set; } = "";
+
+        [JsonPropertyName("prefix")]
+        public string Prefix { get; set; } = "";
+
+        [JsonPropertyName("accountId")]
+        public string AccountId { get; set; } = "";
+
+        [JsonPropertyName("profileId")]
+        public string ProfileId { get; set; } = "";
+
+        [JsonPropertyName("sessionMode")]
+        public string SessionMode { get; set; } = "";
+
+        [JsonPropertyName("verifiedTokenHash")]
+        public string VerifiedTokenHash { get; set; } = "";
+
+        [JsonPropertyName("profileNickname")]
+        public string ProfileNickname { get; set; } = "";
+
+        // Version 1 stored nicknames on individual keys. This read-only
+        // compatibility property is consumed during the version 2 migration.
+        [JsonPropertyName("nickname")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? LegacyNickname { get; set; }
+
+        [JsonIgnore]
+        public bool IsBound => !string.IsNullOrWhiteSpace(AccountId)
+            && !string.IsNullOrWhiteSpace(ProfileId)
+            && !string.IsNullOrWhiteSpace(SessionMode);
+
+        internal TarkovTrackerOrgKey Clone()
+        {
+            return new TarkovTrackerOrgKey
+            {
+                Id = Id,
+                Token = Token,
+                Prefix = Prefix,
+                AccountId = AccountId,
+                ProfileId = ProfileId,
+                SessionMode = SessionMode,
+                VerifiedTokenHash = VerifiedTokenHash,
+                ProfileNickname = ProfileNickname,
+                LegacyNickname = LegacyNickname,
+            };
+        }
+    }
+
+    internal sealed class TarkovTrackerOrgStore
+    {
+        private readonly List<TarkovTrackerOrgKey> keys;
+        private readonly List<TarkovTrackerOrgAccount> accounts;
+        private readonly List<TarkovTrackerOrgProfile> profiles;
+
+        private TarkovTrackerOrgStore(
+            IEnumerable<TarkovTrackerOrgKey>? keys = null,
+            IEnumerable<TarkovTrackerOrgAccount>? accounts = null,
+            IEnumerable<TarkovTrackerOrgProfile>? profiles = null)
+        {
+            this.keys = keys?.Select(key => key.Clone()).ToList() ?? new();
+            this.accounts = accounts?.Select(account => account.Clone()).ToList() ?? new();
+            this.profiles = profiles?.Select(profile => profile.Clone()).ToList() ?? new();
+        }
+
+        public static TarkovTrackerOrgStore Empty() => new();
+
+        public static bool TryParse(string rawValue, out TarkovTrackerOrgStore store, out string error)
+        {
+            store = Empty();
+            error = "";
+            try
+            {
+                if (string.IsNullOrWhiteSpace(rawValue))
+                {
+                    throw new JsonException("The stored value is empty.");
+                }
+
+                var document = JsonSerializer.Deserialize<TarkovTrackerOrgStoreDocument>(rawValue)
+                    ?? throw new JsonException("The stored value is null.");
+                if (document.Version is not (1 or 2 or 3 or TarkovTrackerOrgStoreDocument.CurrentVersion))
+                {
+                    throw new JsonException($"Unsupported store version {document.Version}.");
+                }
+                if (document.Keys == null)
+                {
+                    throw new JsonException("The key list is null.");
+                }
+
+                if (document.Keys.Any(key => key == null))
+                {
+                    throw new JsonException("The key list contains a null record.");
+                }
+
+                var normalizedKeys = document.Keys.Select(Normalize).ToList();
+                if (document.Version < 4)
+                {
+                    normalizedKeys.ForEach(key => key.ProfileNickname = "");
+                }
+                if (normalizedKeys.Any(key => string.IsNullOrWhiteSpace(key.Id)))
+                {
+                    throw new JsonException("A stored key record has no identifier.");
+                }
+                if (normalizedKeys.GroupBy(key => key.Id, StringComparer.Ordinal).Any(group => group.Count() > 1))
+                {
+                    throw new JsonException("The stored key list contains duplicate identifiers.");
+                }
+                if (normalizedKeys.Any(key => !IsValidProfileNickname(key)))
+                {
+                    throw new JsonException("A stored profile nickname record is invalid.");
+                }
+
+                List<TarkovTrackerOrgAccount> normalizedAccounts;
+                if (document.Version == 1)
+                {
+                    normalizedAccounts = normalizedKeys
+                        .Where(key => key.IsBound && !string.IsNullOrWhiteSpace(key.LegacyNickname))
+                        .GroupBy(key => key.AccountId, StringComparer.Ordinal)
+                        .Select(group =>
+                        {
+                            var nicknames = group
+                                .Select(key => NormalizeNickname(key.LegacyNickname))
+                                .Distinct(StringComparer.Ordinal)
+                                .ToList();
+                            if (nicknames.Count != 1)
+                            {
+                                throw new JsonException($"Account ID {group.Key} has conflicting saved nicknames.");
+                            }
+                            return new TarkovTrackerOrgAccount
+                            {
+                                AccountId = group.Key,
+                                Nickname = nicknames[0],
+                            };
+                        })
+                        .ToList();
+                }
+                else
+                {
+                    if (document.Accounts == null)
+                    {
+                        throw new JsonException("The account list is null.");
+                    }
+                    if (document.Accounts.Any(account => account == null))
+                    {
+                        throw new JsonException("The account list contains a null record.");
+                    }
+                    normalizedAccounts = document.Accounts.Select(Normalize).ToList();
+                }
+
+                if (normalizedAccounts.GroupBy(account => account.AccountId, StringComparer.Ordinal).Any(group => group.Count() > 1))
+                {
+                    throw new JsonException("The stored account list contains duplicate Account IDs.");
+                }
+                if (normalizedAccounts.Any(account => !IsValidAccountNickname(account.AccountId, account.Nickname)))
+                {
+                    throw new JsonException("A stored account nickname record is invalid.");
+                }
+
+                List<TarkovTrackerOrgProfile> normalizedProfiles;
+                if (document.Version < 3)
+                {
+                    normalizedProfiles = normalizedKeys
+                        .Where(key => key.IsBound)
+                        .Select(key => new TarkovTrackerOrgProfile
+                        {
+                            AccountId = key.AccountId,
+                            ProfileId = key.ProfileId,
+                            SessionMode = key.SessionMode,
+                        })
+                        .GroupBy(ProfileIdentity, StringComparer.Ordinal)
+                        .Select(group => group.First())
+                        .ToList();
+                }
+                else
+                {
+                    if (document.Profiles == null)
+                    {
+                        throw new JsonException("The profile list is null.");
+                    }
+                    if (document.Profiles.Any(profile => profile == null))
+                    {
+                        throw new JsonException("The profile list contains a null record.");
+                    }
+                    normalizedProfiles = document.Profiles
+                        .Select(Normalize)
+                        .ToList();
+                }
+
+                normalizedProfiles = normalizedProfiles
+                    .Where(IsValidProfile)
+                    .GroupBy(ProfileIdentity, StringComparer.Ordinal)
+                    .Select(MergeProfileObservations)
+                    .ToList();
+
+                foreach (var key in normalizedKeys)
+                {
+                    key.LegacyNickname = null;
+                }
+                store = new TarkovTrackerOrgStore(normalizedKeys, normalizedAccounts, normalizedProfiles);
+                return true;
+            }
+            catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        public TarkovTrackerOrgStore Clone() => new(keys, accounts, profiles);
+
+        public string Serialize()
+        {
+            return JsonSerializer.Serialize(new TarkovTrackerOrgStoreDocument
+            {
+                Keys = keys.Select(key => key.Clone()).ToList(),
+                Accounts = accounts.Select(account => account.Clone()).ToList(),
+                Profiles = profiles.Select(profile => profile.Clone()).ToList(),
+            });
+        }
+
+        public IReadOnlyList<TarkovTrackerOrgKey> GetKeys()
+        {
+            return keys.Select(key => key.Clone()).ToList();
+        }
+
+        public TarkovTrackerOrgKey? GetKey(string id)
+        {
+            return keys.FirstOrDefault(key => string.Equals(key.Id, id, StringComparison.Ordinal))?.Clone();
+        }
+
+        public IReadOnlyList<TarkovTrackerOrgProfile> GetProfiles()
+        {
+            return profiles.Select(profile => profile.Clone()).ToList();
+        }
+
+        public string GetAccountNickname(string accountId)
+        {
+            return accounts.FirstOrDefault(account => string.Equals(
+                account.AccountId,
+                accountId,
+                StringComparison.Ordinal))?.Nickname ?? "";
+        }
+
+        public TarkovTrackerOrgKey? GetForProfile(Profile profile)
+        {
+            var prefix = TarkovTracker.GetPrefixForSessionMode(profile.SessionMode);
+            var sessionMode = TarkovTracker.NormalizeSessionMode(profile.SessionMode);
+            return keys.FirstOrDefault(key => key.IsBound
+                && string.IsNullOrEmpty(GetStoreIssue(key))
+                && string.Equals(key.Prefix, prefix, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(key.AccountId, profile.AccountId, StringComparison.Ordinal)
+                && string.Equals(key.ProfileId, profile.Id, StringComparison.Ordinal)
+                && string.Equals(key.SessionMode, sessionMode, StringComparison.OrdinalIgnoreCase))?.Clone();
+        }
+
+        public bool HasPendingKey()
+        {
+            return keys.Any(key => !key.IsBound);
+        }
+
+        public bool HasPendingKey(string prefix)
+        {
+            return keys.Any(key => !key.IsBound
+                && string.Equals(key.Prefix, prefix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public bool ContainsToken(string token)
+        {
+            return keys.Any(key => TokenIdentityMatches(key.Token, token));
+        }
+
+        public TarkovTrackerOrgKey AddVerifiedToken(string token, string prefix, Profile? bindingProfile)
+        {
+            var normalizedToken = token.Trim();
+            var normalizedPrefix = prefix.Trim().ToUpperInvariant();
+            if (!TarkovTracker.IsImportableToken(normalizedToken)
+                || !string.Equals(
+                    normalizedPrefix,
+                    TarkovTracker.GetTokenPrefix(normalizedToken),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("The verified API key and mode prefix do not match.", nameof(token));
+            }
+            if (keys.Any(key => TokenIdentityMatches(key.Token, normalizedToken)))
+            {
+                throw new TarkovTracker.DuplicateImportedTokenException(
+                    $"This {TarkovTracker.GetPrefixDisplayName(normalizedPrefix)} API key is already saved locally.");
+            }
+            if (bindingProfile == null && HasPendingKey(normalizedPrefix))
+            {
+                throw new InvalidOperationException(
+                    $"Assign or remove the unassigned {TarkovTracker.GetPrefixDisplayName(normalizedPrefix)} API key before importing another one.");
+            }
+
+            var key = new TarkovTrackerOrgKey
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Token = normalizedToken,
+                Prefix = normalizedPrefix,
+                VerifiedTokenHash = ComputeTokenFingerprint(normalizedToken),
+            };
+
+            if (bindingProfile != null && CanBindToProfile(key, bindingProfile))
+            {
+                ApplyBinding(key, bindingProfile);
+                EnsureBindingAvailable(key);
+            }
+
+            keys.Add(key);
+            return key.Clone();
+        }
+
+        public TarkovTrackerOrgKey AddVerifiedBoundToken(string token, string prefix, Profile bindingProfile)
+        {
+            var key = AddVerifiedToken(token, prefix, bindingProfile);
+            if (!key.IsBound)
+            {
+                keys.RemoveAll(candidate => string.Equals(candidate.Id, key.Id, StringComparison.Ordinal));
+                throw new InvalidOperationException(
+                    $"The {TarkovTracker.GetPrefixDisplayName(prefix)} API key does not match the selected {bindingProfile.DisplayName} profile.");
+            }
+            return key;
+        }
+
+        public TarkovTrackerOrgKey Bind(string id, Profile profile)
+        {
+            var key = GetMutableKey(id);
+            if (key.IsBound)
+            {
+                throw new InvalidOperationException("This API key is already assigned.");
+            }
+            if (!IsVerified(key))
+            {
+                throw new InvalidOperationException("This API key must be verified before it can be assigned.");
+            }
+            if (!string.IsNullOrEmpty(GetStoreIssue(key)))
+            {
+                throw new InvalidOperationException("This API key record must be repaired before it can be assigned.");
+            }
+            if (!CanBindToProfile(key, profile))
+            {
+                throw new InvalidOperationException(
+                    $"This {TarkovTracker.GetPrefixDisplayName(key.Prefix)} API key cannot be assigned to the selected {profile.DisplayName} profile.");
+            }
+
+            ApplyBinding(key, profile);
+            EnsureBindingAvailable(key);
+            return key.Clone();
+        }
+
+        public TarkovTrackerOrgKey BindKnownProfile(string id, string accountId, string profileId, EftSessionMode sessionMode)
+        {
+            var profile = GetKnownProfile(accountId, profileId, sessionMode);
+            return Bind(id, profile);
+        }
+
+        public TarkovTrackerOrgKey? RememberAndAutoBind(
+            Profile profile,
+            DateTimeOffset seenAt,
+            bool allowAutoBind = true)
+        {
+            RememberProfile(profile, seenAt, seenAt);
+            var existing = GetForProfile(profile);
+            if (existing != null || !profile.SupportsTarkovTrackerWrites || !allowAutoBind)
+            {
+                return existing;
+            }
+
+            var prefix = TarkovTracker.GetPrefixForSessionMode(profile.SessionMode);
+            var pending = keys
+                .Where(key => !key.IsBound
+                    && string.IsNullOrEmpty(GetStoreIssue(key))
+                    && string.Equals(key.Prefix, prefix, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            return pending.Count == 1 ? Bind(pending[0].Id, profile) : null;
+        }
+
+        public int RememberProfiles(IEnumerable<TarkovTrackerOrgProfile> discoveredProfiles)
+        {
+            var changed = 0;
+            foreach (var discoveredProfile in discoveredProfiles)
+            {
+                var normalized = Normalize(discoveredProfile.Clone());
+                if (!IsValidProfile(normalized))
+                {
+                    continue;
+                }
+                if (RememberProfile(
+                    normalized.ToProfile(),
+                    normalized.FirstSeenUtc,
+                    normalized.LastSeenUtc))
+                {
+                    changed++;
+                }
+            }
+            return changed;
+        }
+
+        public (TarkovTrackerOrgKey Key, TarkovTrackerOrgKey? SwappedKey) ReassignKnownProfile(
+            string id,
+            string accountId,
+            string profileId,
+            EftSessionMode sessionMode)
+        {
+            var key = GetMutableKey(id);
+            if (!key.IsBound)
+            {
+                throw new InvalidOperationException("This API key is not assigned.");
+            }
+
+            var target = GetKnownProfile(accountId, profileId, sessionMode);
+            if (!CanBindToProfile(key, target))
+            {
+                throw new InvalidOperationException(
+                    $"This {TarkovTracker.GetPrefixDisplayName(key.Prefix)} API key cannot be assigned to the selected {target.DisplayName} profile.");
+            }
+            if (BindingMatches(key, target))
+            {
+                throw new InvalidOperationException("This API key is already assigned to that profile.");
+            }
+
+            var previous = new Profile
+            {
+                AccountId = key.AccountId,
+                Id = key.ProfileId,
+                SessionMode = GameWatcher.ResolveSessionMode(key.SessionMode),
+                Type = GameWatcher.ResolveProfileType(GameWatcher.ResolveSessionMode(key.SessionMode)),
+            };
+            var occupant = keys.FirstOrDefault(candidate => candidate.IsBound
+                && !string.Equals(candidate.Id, key.Id, StringComparison.Ordinal)
+                && BindingMatches(candidate, target));
+
+            ApplyBinding(key, target);
+            if (occupant != null)
+            {
+                if (!CanBindToProfile(occupant, previous))
+                {
+                    throw new InvalidOperationException("The selected profile already has an incompatible API key.");
+                }
+                ApplyBinding(occupant, previous);
+            }
+
+            EnsureBindingAvailable(key);
+            if (occupant != null)
+            {
+                EnsureBindingAvailable(occupant);
+            }
+            return (key.Clone(), occupant?.Clone());
+        }
+
+        public TarkovTrackerOrgKey Unbind(string id)
+        {
+            var key = GetMutableKey(id);
+            if (!key.IsBound)
+            {
+                throw new InvalidOperationException("This API key is already unassigned.");
+            }
+            if (keys.Any(candidate => !candidate.IsBound
+                && !string.Equals(candidate.Id, key.Id, StringComparison.Ordinal)
+                && string.Equals(candidate.Prefix, key.Prefix, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException(
+                    $"Assign or remove the unassigned {TarkovTracker.GetPrefixDisplayName(key.Prefix)} API key before unbinding another one.");
+            }
+
+            key.AccountId = "";
+            key.ProfileId = "";
+            key.SessionMode = "";
+            key.ProfileNickname = "";
+            return key.Clone();
+        }
+
+        public string SetProfileNickname(string id, string nickname)
+        {
+            var key = GetMutableKey(id);
+            if (!key.IsBound || !string.IsNullOrEmpty(GetStoreIssue(key)))
+            {
+                throw new InvalidOperationException("Assign this API key before setting its profile nickname.");
+            }
+
+            var normalizedNickname = NormalizeNickname(nickname);
+            if (!IsValidNickname(normalizedNickname))
+            {
+                throw new ArgumentException("Enter a nickname between 1 and 32 characters.", nameof(nickname));
+            }
+
+            key.ProfileNickname = normalizedNickname;
+            return normalizedNickname;
+        }
+
+        public string SetAccountNickname(string accountId, string nickname)
+        {
+            if (!keys.Any(key => key.IsBound
+                && string.IsNullOrEmpty(GetStoreIssue(key))
+                && string.Equals(key.AccountId, accountId, StringComparison.Ordinal)))
+            {
+                throw new InvalidOperationException("Assign an API key to this account before setting its nickname.");
+            }
+
+            var normalizedAccountId = accountId.Trim();
+            var normalizedNickname = NormalizeNickname(nickname);
+            if (!IsValidAccountNickname(normalizedAccountId, normalizedNickname))
+            {
+                throw new ArgumentException("Enter a nickname between 1 and 32 characters.", nameof(nickname));
+            }
+
+            var account = accounts.FirstOrDefault(candidate => string.Equals(
+                candidate.AccountId,
+                normalizedAccountId,
+                StringComparison.Ordinal));
+            if (account == null)
+            {
+                accounts.Add(new TarkovTrackerOrgAccount
+                {
+                    AccountId = normalizedAccountId,
+                    Nickname = normalizedNickname,
+                });
+            }
+            else
+            {
+                account.Nickname = normalizedNickname;
+            }
+            return normalizedNickname;
+        }
+
+        public bool Remove(string id)
+        {
+            return keys.RemoveAll(key => string.Equals(key.Id, id, StringComparison.Ordinal)) > 0;
+        }
+
+        public static bool IsVerified(TarkovTrackerOrgKey key)
+        {
+            return !string.IsNullOrWhiteSpace(key.Token)
+                && IsRecognizedStoredToken(key.Token)
+                && string.Equals(key.Prefix, TarkovTracker.GetTokenPrefix(key.Token), StringComparison.OrdinalIgnoreCase)
+                && string.Equals(
+                    key.VerifiedTokenHash,
+                    ComputeTokenFingerprint(key.Token),
+                    StringComparison.Ordinal);
+        }
+
+        public static string ComputeTokenFingerprint(string token)
+        {
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(token.Trim())));
+        }
+
+        private static bool IsRecognizedStoredToken(string token)
+        {
+            if (string.IsNullOrEmpty(token) || token != token.Trim())
+            {
+                return false;
+            }
+            var pieces = token.Split('_');
+            return pieces.Length == 2
+                && pieces[0] is "PVE" or "PVP" or "SZN"
+                && pieces[1].Length == 18
+                && pieces[1].All(Uri.IsHexDigit);
+        }
+
+        private static TarkovTrackerOrgKey Normalize(TarkovTrackerOrgKey key)
+        {
+            key.Id = key.Id?.Trim() ?? "";
+            // Never silently normalize a saved secret. Import performs its own
+            // strict validation; persisted whitespace must remain visible to the
+            // record validator so the key is quarantined instead of activated.
+            key.Token ??= "";
+            key.Prefix = key.Prefix?.Trim().ToUpperInvariant() ?? "";
+            key.AccountId = key.AccountId?.Trim() ?? "";
+            key.ProfileId = key.ProfileId?.Trim() ?? "";
+            key.SessionMode = key.SessionMode?.Trim() ?? "";
+            key.VerifiedTokenHash = key.VerifiedTokenHash?.Trim().ToUpperInvariant() ?? "";
+            key.ProfileNickname = NormalizeNickname(key.ProfileNickname);
+            key.LegacyNickname = key.LegacyNickname?.Trim();
+            return key;
+        }
+
+        private static TarkovTrackerOrgAccount Normalize(TarkovTrackerOrgAccount account)
+        {
+            account.AccountId = account.AccountId?.Trim() ?? "";
+            account.Nickname = NormalizeNickname(account.Nickname);
+            return account;
+        }
+
+        private static TarkovTrackerOrgProfile Normalize(TarkovTrackerOrgProfile profile)
+        {
+            profile.AccountId = profile.AccountId?.Trim() ?? "";
+            profile.ProfileId = profile.ProfileId?.Trim() ?? "";
+            profile.SessionMode = TarkovTracker.NormalizeSessionMode(
+                GameWatcher.ResolveSessionMode(profile.SessionMode));
+            return profile;
+        }
+
+        private static string NormalizeNickname(string? nickname) => nickname?.Trim() ?? "";
+
+        private static bool IsValidAccountNickname(string accountId, string nickname)
+        {
+            return !string.IsNullOrWhiteSpace(accountId)
+                && accountId.All(char.IsDigit)
+                && IsValidNickname(nickname);
+        }
+
+        private static bool IsValidProfileNickname(TarkovTrackerOrgKey key)
+        {
+            return string.IsNullOrEmpty(key.ProfileNickname)
+                || (key.IsBound && IsValidNickname(key.ProfileNickname));
+        }
+
+        private static bool IsValidNickname(string nickname)
+        {
+            return nickname.Length is >= 1 and <= 32
+                && !nickname.Any(char.IsControl);
+        }
+
+        private static bool IsValidProfile(TarkovTrackerOrgProfile profile)
+        {
+            var resolvedMode = GameWatcher.ResolveSessionMode(profile.SessionMode);
+            return !string.IsNullOrWhiteSpace(profile.AccountId)
+                && profile.AccountId.All(char.IsDigit)
+                && !string.IsNullOrWhiteSpace(profile.ProfileId)
+                && resolvedMode is EftSessionMode.PVE or EftSessionMode.Regular or EftSessionMode.Seasonal
+                && string.Equals(
+                    profile.SessionMode,
+                    TarkovTracker.NormalizeSessionMode(resolvedMode),
+                    StringComparison.OrdinalIgnoreCase)
+                && (profile.FirstSeenUtc == null
+                    || profile.LastSeenUtc == null
+                    || profile.FirstSeenUtc <= profile.LastSeenUtc);
+        }
+
+        private static TarkovTrackerOrgProfile MergeProfileObservations(
+            IEnumerable<TarkovTrackerOrgProfile> observations)
+        {
+            var records = observations.ToList();
+            var merged = records[0].Clone();
+            merged.FirstSeenUtc = records
+                .Where(record => record.FirstSeenUtc != null)
+                .Select(record => record.FirstSeenUtc)
+                .Min();
+            merged.LastSeenUtc = records
+                .Where(record => record.LastSeenUtc != null)
+                .Select(record => record.LastSeenUtc)
+                .Max();
+            return merged;
+        }
+
+        private bool RememberProfile(
+            Profile profile,
+            DateTimeOffset? firstSeenUtc,
+            DateTimeOffset? lastSeenUtc)
+        {
+            var candidate = Normalize(new TarkovTrackerOrgProfile
+            {
+                AccountId = profile.AccountId,
+                ProfileId = profile.Id,
+                SessionMode = TarkovTracker.NormalizeSessionMode(profile.SessionMode),
+                FirstSeenUtc = firstSeenUtc,
+                LastSeenUtc = lastSeenUtc,
+            });
+            if (!IsValidProfile(candidate))
+            {
+                return false;
+            }
+
+            var existing = profiles.FirstOrDefault(saved => string.Equals(
+                ProfileIdentity(saved),
+                ProfileIdentity(candidate),
+                StringComparison.Ordinal));
+            if (existing == null)
+            {
+                profiles.Add(candidate);
+                return true;
+            }
+
+            var previousFirstSeen = existing.FirstSeenUtc;
+            var previousLastSeen = existing.LastSeenUtc;
+            if (candidate.FirstSeenUtc != null
+                && (existing.FirstSeenUtc == null || candidate.FirstSeenUtc < existing.FirstSeenUtc))
+            {
+                existing.FirstSeenUtc = candidate.FirstSeenUtc;
+            }
+            if (candidate.LastSeenUtc != null
+                && (existing.LastSeenUtc == null || candidate.LastSeenUtc > existing.LastSeenUtc))
+            {
+                existing.LastSeenUtc = candidate.LastSeenUtc;
+            }
+            return previousFirstSeen != existing.FirstSeenUtc || previousLastSeen != existing.LastSeenUtc;
+        }
+
+        public Profile GetKnownProfile(string accountId, string profileId, EftSessionMode sessionMode)
+        {
+            var identity = ProfileIdentity(accountId, profileId, sessionMode);
+            return profiles.FirstOrDefault(profile => string.Equals(
+                    ProfileIdentity(profile),
+                    identity,
+                    StringComparison.Ordinal))?.ToProfile()
+                ?? throw new InvalidOperationException("The selected EFT profile is not in the saved profile list. Scan profiles and try again.");
+        }
+
+        private static string ProfileIdentity(TarkovTrackerOrgProfile profile)
+        {
+            return ProfileIdentity(
+                profile.AccountId,
+                profile.ProfileId,
+                GameWatcher.ResolveSessionMode(profile.SessionMode));
+        }
+
+        private static string ProfileIdentity(string accountId, string profileId, EftSessionMode sessionMode)
+        {
+            return $"{accountId.Trim()}\u001f{profileId.Trim()}\u001f{TarkovTracker.NormalizeSessionMode(sessionMode).ToUpperInvariant()}";
+        }
+
+        private static bool BindingMatches(TarkovTrackerOrgKey key, Profile profile)
+        {
+            return string.Equals(key.AccountId, profile.AccountId, StringComparison.Ordinal)
+                && string.Equals(key.ProfileId, profile.Id, StringComparison.Ordinal)
+                && string.Equals(
+                    key.SessionMode,
+                    TarkovTracker.NormalizeSessionMode(profile.SessionMode),
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool CanBindToProfile(TarkovTrackerOrgKey key, Profile profile)
+        {
+            return profile.HasIdentity
+                && profile.AccountId.All(char.IsDigit)
+                && !string.IsNullOrWhiteSpace(profile.Id)
+                && profile.SupportsTarkovTrackerWrites
+                && string.Equals(
+                    key.Prefix,
+                    TarkovTracker.GetPrefixForSessionMode(profile.SessionMode),
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void ApplyBinding(TarkovTrackerOrgKey key, Profile profile)
+        {
+            key.AccountId = profile.AccountId;
+            key.ProfileId = profile.Id;
+            key.SessionMode = TarkovTracker.NormalizeSessionMode(profile.SessionMode);
+        }
+
+        private void EnsureBindingAvailable(TarkovTrackerOrgKey proposedKey)
+        {
+            if (keys.Any(key => key.IsBound
+                && !string.Equals(key.Id, proposedKey.Id, StringComparison.Ordinal)
+                && string.Equals(key.AccountId, proposedKey.AccountId, StringComparison.Ordinal)
+                && string.Equals(key.ProfileId, proposedKey.ProfileId, StringComparison.Ordinal)
+                && string.Equals(key.SessionMode, proposedKey.SessionMode, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException(
+                    "The selected EFT account, profile, and mode already have an assigned API key. Reassign, unbind, or remove it before assigning another key.");
+            }
+        }
+
+        private TarkovTrackerOrgKey GetMutableKey(string id)
+        {
+            return keys.FirstOrDefault(key => string.Equals(key.Id, id, StringComparison.Ordinal))
+                ?? throw new KeyNotFoundException("The saved API key was not found.");
+        }
+
+        private static bool TokenIdentityMatches(string first, string second)
+        {
+            return string.Equals(
+                ComputeTokenFingerprint(first),
+                ComputeTokenFingerprint(second),
+                StringComparison.Ordinal);
+        }
+
+        public static string GetRecordIssue(TarkovTrackerOrgKey key)
+        {
+            if (!IsVerified(key))
+            {
+                return "The token verification record is invalid.";
+            }
+
+            var hasAnyBindingField = !string.IsNullOrWhiteSpace(key.AccountId)
+                || !string.IsNullOrWhiteSpace(key.ProfileId)
+                || !string.IsNullOrWhiteSpace(key.SessionMode);
+            if (!key.IsBound && hasAnyBindingField)
+            {
+                return "The binding is incomplete.";
+            }
+            if (key.IsBound)
+            {
+                var resolvedMode = GameWatcher.ResolveSessionMode(key.SessionMode);
+                var expectedPrefix = TarkovTracker.GetPrefixForSessionMode(resolvedMode);
+                if (!key.AccountId.All(char.IsDigit)
+                    || resolvedMode is not (EftSessionMode.Regular or EftSessionMode.PVE or EftSessionMode.Seasonal)
+                    || !string.Equals(
+                        key.Prefix,
+                        expectedPrefix,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return "The account, profile, or mode binding is invalid.";
+                }
+            }
+            return "";
+        }
+
+        public string GetStoreIssue(TarkovTrackerOrgKey key)
+        {
+            var recordIssue = GetRecordIssue(key);
+            if (!string.IsNullOrEmpty(recordIssue))
+            {
+                return recordIssue;
+            }
+            if (keys.Any(candidate => !string.Equals(candidate.Id, key.Id, StringComparison.Ordinal)
+                && TokenIdentityMatches(candidate.Token, key.Token)))
+            {
+                return "The store contains the same token more than once.";
+            }
+            if (key.IsBound && keys.Any(candidate => candidate.IsBound
+                && !string.Equals(candidate.Id, key.Id, StringComparison.Ordinal)
+                && string.Equals(candidate.AccountId, key.AccountId, StringComparison.Ordinal)
+                && string.Equals(candidate.ProfileId, key.ProfileId, StringComparison.Ordinal)
+                && string.Equals(candidate.SessionMode, key.SessionMode, StringComparison.OrdinalIgnoreCase)))
+            {
+                return "The store contains more than one key for the same binding.";
+            }
+            return "";
+        }
+    }
+}

--- a/TarkovMonitor/TokenStoreProtection.cs
+++ b/TarkovMonitor/TokenStoreProtection.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace TarkovMonitor
+{
+    internal static class TokenStoreProtection
+    {
+        private const string Prefix = "TM-PROTECTED-V1:";
+        private static readonly byte[] Entropy = SHA256.HashData(
+            Encoding.UTF8.GetBytes("TarkovMonitor:TarkovTracker:settings:v1"));
+
+        internal static string Protect(string value)
+        {
+            if (string.IsNullOrEmpty(value) || value.StartsWith(Prefix, StringComparison.Ordinal))
+            {
+                return value;
+            }
+
+            return Prefix + Convert.ToBase64String(ProtectedData.Protect(
+                Encoding.UTF8.GetBytes(value),
+                Entropy,
+                DataProtectionScope.CurrentUser));
+        }
+
+        internal static string Unprotect(string value, out bool wasProtected)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                wasProtected = true;
+                return value;
+            }
+
+            if (!value.StartsWith(Prefix, StringComparison.Ordinal))
+            {
+                wasProtected = false;
+                return value;
+            }
+
+            wasProtected = true;
+            try
+            {
+                var encrypted = Convert.FromBase64String(value[Prefix.Length..]);
+                return Encoding.UTF8.GetString(ProtectedData.Unprotect(
+                    encrypted,
+                    Entropy,
+                    DataProtectionScope.CurrentUser));
+            }
+            catch (Exception ex) when (ex is CryptographicException or FormatException)
+            {
+                throw new InvalidDataException("A protected TarkovTracker settings value could not be decrypted.", ex);
+            }
+        }
+    }
+}

--- a/TarkovMonitor/wwwroot/css/app.css
+++ b/TarkovMonitor/wwwroot/css/app.css
@@ -23,13 +23,422 @@ body {
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.24);
 }
 
+.app-surface .tm-card-heading-text {
+    color: #c2b27e;
+}
+
+/* Consistent dropdown surfaces and option states across settings, dialogs, and messages. */
+.tm-select {
+    width: min(100%, 20rem);
+    min-width: 0;
+    margin-top: 0.18rem;
+    margin-bottom: 0.18rem;
+}
+
+.tm-select .mud-input-control {
+    width: 100%;
+    min-width: 0;
+}
+
+.tm-select--compact,
+.tm-message-select {
+    width: min(100%, 12rem);
+}
+
+.tm-select--dialog {
+    width: 100%;
+    max-width: none;
+}
+
+.tm-input {
+    width: min(100%, 20rem);
+    min-width: 0;
+    margin-top: 0.18rem;
+    margin-bottom: 0.18rem;
+}
+
+.tm-input--full {
+    width: 100%;
+    max-width: none;
+}
+
+.tm-input .mud-input-label,
+.tm-input .mud-input-label-inputcontrol,
+.tm-input .mud-input-label-outlined {
+    color: rgba(255, 255, 255, 0.68) !important;
+}
+
+.tm-input:focus-within .mud-input-label,
+.tm-input:focus-within .mud-input-label-inputcontrol,
+.tm-input:focus-within .mud-input-label-outlined {
+    color: #d7c996 !important;
+}
+
+/* MudTextField renders its label as a sibling of the input surface. Keep the
+   focused label in the same neutral/warm palette as the surrounding fields. */
+.tm-input .mud-input:focus-within ~ .mud-input-label,
+.tm-input .mud-input:focus-within ~ .mud-input-label-inputcontrol,
+.tm-input .mud-input:focus-within ~ .mud-input-label-outlined {
+    color: #d7c996 !important;
+}
+
+.tm-input .mud-input.mud-input-underline:before {
+    background-color: transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.28);
+}
+
+.tm-input .mud-input.mud-input-underline:hover:not(.mud-disabled):before {
+    background-color: transparent;
+    border-bottom-color: rgba(152, 138, 102, 0.78);
+}
+
+.tm-input .mud-input.mud-input-underline:after {
+    background-color: transparent;
+    border-bottom-color: #988a66;
+}
+
+.tm-input:focus-within .mud-input.mud-input-underline:after {
+    background-color: transparent;
+    border-bottom-color: #c2b27e !important;
+}
+
+.tm-input .mud-input.mud-input-underline:focus-within:after {
+    background-color: transparent !important;
+    border-bottom-color: #c2b27e !important;
+}
+
+.tm-action-link {
+    color: rgba(255, 255, 255, 0.75) !important;
+}
+
+.tm-action-link .mud-button-label {
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.16em;
+}
+
+.mud-link.tm-profile-link {
+    color: #d7c996 !important;
+}
+
+.tm-action-link:hover,
+.mud-link.tm-profile-link:hover {
+    color: #f8f2df !important;
+}
+
+.tm-section-link {
+    color: inherit !important;
+    text-decoration-line: underline !important;
+    text-decoration-color: currentColor !important;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.16em;
+}
+
+.tm-section-link:hover {
+    color: inherit !important;
+}
+
+.tm-section-suffix {
+    margin-left: 0.25rem;
+}
+
+.tm-select .mud-input-outlined-border {
+    border-color: rgba(255, 255, 255, 0.28);
+    border-radius: 8px;
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.tm-select .mud-select-input {
+    color: rgba(255, 255, 255, 0.88);
+}
+
+.tm-select .mud-select-input-icon,
+.tm-select .mud-select-icon {
+    color: #988a66 !important;
+}
+
+/* Keep underline-variant selects in the same warm Tarkov palette as outlined selects. */
+.tm-select .mud-input.mud-input-underline:before {
+    background-color: transparent;
+    border-bottom-color: rgba(255, 255, 255, 0.28);
+}
+
+.tm-select .mud-input.mud-input-underline:hover:not(.mud-disabled):before {
+    background-color: transparent;
+    border-bottom-color: rgba(152, 138, 102, 0.78);
+}
+
+.tm-select .mud-input.mud-input-underline:after {
+    background-color: transparent;
+    border-bottom-color: #988a66;
+}
+
+.tm-select:focus-within .mud-input.mud-input-underline:after {
+    background-color: transparent;
+    border-bottom-color: #c2b27e;
+}
+
+.tm-select .mud-input.mud-input-underline:focus-within:after {
+    background-color: transparent !important;
+    border-bottom-color: #c2b27e !important;
+}
+
+.tm-select .mud-input-label,
+.tm-select .mud-input-label-inputcontrol,
+.tm-select .mud-input-label-outlined {
+    color: rgba(255, 255, 255, 0.68) !important;
+}
+
+.tm-select:focus-within .mud-input-label,
+.tm-select:focus-within .mud-input-label-inputcontrol,
+.tm-select:focus-within .mud-input-label-outlined {
+    color: #d7c996 !important;
+}
+
+.tm-select .mud-input:focus-within ~ .mud-input-label,
+.tm-select .mud-input:focus-within ~ .mud-input-label-inputcontrol,
+.tm-select .mud-input:focus-within ~ .mud-input-label-outlined {
+    color: #d7c996 !important;
+}
+
+.tm-select .mud-input-adornment {
+    color: #988a66;
+}
+
+.tm-select:hover .mud-input-outlined-border {
+    border-color: rgba(152, 138, 102, 0.78);
+}
+
+.tm-select:focus-within .mud-input-outlined-border {
+    border-color: #988a66;
+    box-shadow: 0 0 0 2px rgba(194, 178, 126, 0.2);
+}
+
+.tm-select .mud-disabled .mud-input-outlined-border,
+.tm-select .mud-input-control.mud-disabled .mud-input-outlined-border {
+    border-color: rgba(255, 255, 255, 0.14);
+    background-color: rgba(255, 255, 255, 0.035);
+}
+
+.tm-select .mud-input-error .mud-input-outlined-border {
+    border-color: rgba(240, 93, 93, 0.82);
+}
+
+.tm-select-popover,
+.tm-menu-popover {
+    z-index: 1400;
+    max-width: min(34rem, calc(100vw - 1.5rem)) !important;
+    border: 1px solid rgba(132, 122, 94, 0.52);
+    border-radius: 10px;
+    background: linear-gradient(145deg, #232428, #16171a);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38), 0 3px 10px rgba(0, 0, 0, 0.24);
+    overflow: hidden;
+}
+
+.tm-select-popover {
+    /* MudBlazor owns height and viewport flipping; this keeps long labels readable. */
+    width: max-content !important;
+    min-width: min(18rem, calc(100vw - 1.5rem));
+    max-width: min(34rem, calc(100vw - 1.5rem)) !important;
+}
+
+.tm-select-list,
+.tm-menu-list {
+    padding: 0.3rem;
+    background: transparent;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    scrollbar-color: rgba(143, 132, 99, 0.78) rgba(255, 255, 255, 0.04);
+    scrollbar-width: thin;
+}
+
+.tm-select-list .mud-list-item,
+.tm-menu-list .mud-menu-item {
+    min-height: 2.15rem;
+    margin: 0.12rem 0;
+    padding: 0.42rem 0.68rem;
+    border-radius: 7px;
+    color: rgba(255, 255, 255, 0.82);
+    line-height: 1.25;
+    overflow: visible;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    transition: background-color 140ms ease, box-shadow 140ms ease, color 140ms ease;
+}
+
+.tm-select-list .mud-list-item:hover,
+.tm-select-list .mud-list-item:focus-visible,
+.tm-menu-list .mud-menu-item:hover,
+.tm-menu-list .mud-menu-item:focus-visible {
+    color: #f8f2df;
+    background-color: rgba(152, 138, 102, 0.18);
+}
+
+.tm-menu-activator {
+    border: 1px solid rgba(143, 130, 95, 0.58);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+    transition: border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
+}
+
+.tm-menu-activator:hover,
+.tm-menu-activator:focus-visible {
+    border-color: rgba(152, 138, 102, 0.82);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.38), 0 0 0 2px rgba(194, 178, 126, 0.16);
+    transform: translateY(-1px);
+}
+
+.tm-select-list .mud-list-item.mud-list-item-selected,
+.tm-select-list .mud-list-item.mud-selected,
+.tm-select-list .mud-list-item[aria-selected="true"],
+.tm-select-list .mud-list-item[data-selected="true"] {
+    color: rgba(255, 255, 255, 0.88) !important;
+    background: linear-gradient(90deg, rgba(74, 67, 48, 0.72), rgba(52, 48, 38, 0.56));
+    box-shadow: inset 3px 0 0 #c2b27e;
+    font-weight: 600;
+}
+
+.tm-select-list .mud-list-item.mud-list-item-selected .mud-list-item-text,
+.tm-select-list .mud-list-item.mud-selected .mud-list-item-text,
+.tm-select-list .mud-list-item[aria-selected="true"] .mud-list-item-text,
+.tm-select-list .mud-list-item[data-selected="true"] .mud-list-item-text,
+.tm-select-list .mud-list-item[aria-selected="true"] * {
+    color: rgba(255, 255, 255, 0.88) !important;
+    font-weight: 600;
+}
+
+.tm-select-list .mud-list-item.mud-list-item-selected:hover,
+.tm-select-list .mud-list-item.mud-selected:hover,
+.tm-select-list .mud-list-item[aria-selected="true"]:hover,
+.tm-select-list .mud-list-item[data-selected="true"]:hover {
+    background: linear-gradient(90deg, rgba(80, 72, 51, 0.74), rgba(57, 52, 40, 0.59));
+}
+
+html.tm-keyboard-input .tm-select-list .mud-list-item.mud-selected-item[tabindex="0"][aria-selected="false"] {
+    outline: 1px solid rgba(194, 178, 126, 0.62);
+    outline-offset: -2px;
+}
+
+html.tm-keyboard-input .tm-select-list .mud-list-item.mud-selected-item[tabindex="0"][aria-selected="false"] {
+    color: #f8f2df !important;
+    background-color: rgba(152, 138, 102, 0.18) !important;
+    background-image: none;
+    box-shadow: none;
+}
+
+.tm-select-list .mud-list-item .mud-list-item-text,
+.tm-menu-list .mud-menu-item .mud-menu-item-text {
+    display: block;
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: 100%;
+    padding-right: 0.25rem;
+    overflow: visible !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    text-overflow: clip !important;
+    white-space: normal !important;
+}
+
+.tm-message-actions {
+    display: flex;
+    width: 100%;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.tm-menu-host {
+    position: fixed;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 1250;
+}
+
+@media (max-width: 520px) {
+    .tm-select,
+    .tm-select .mud-input-control {
+        width: 100%;
+    }
+
+    .tm-select--compact,
+    .tm-message-select {
+        width: 100%;
+    }
+
+    .tm-menu-host {
+        right: 0.75rem;
+        bottom: 0.75rem;
+    }
+}
+
 .settings-grid {
+    display: block !important;
+    column-count: 1;
+    column-gap: 0.5rem;
+    column-fill: balance;
     align-content: flex-start;
 }
 
+/* Dialogs opt in surface-by-surface so each can be reviewed without changing
+   unrelated MudBlazor dialogs. */
+.mud-dialog.tm-dialog-shell--read-past {
+    border: 1px solid rgba(132, 122, 94, 0.52);
+    border-radius: 12px;
+    background: linear-gradient(145deg, #232428, #16171a);
+    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.48), 0 3px 10px rgba(0, 0, 0, 0.28);
+}
+
+.tm-dialog-shell--read-past .tm-dialog-title {
+    padding: 0.75rem 1.125rem 0.6rem;
+    border-bottom: 1px solid rgba(143, 130, 95, 0.22);
+    color: #c2b27e;
+    font-weight: 600;
+}
+
+.tm-dialog-shell--read-past .tm-dialog-content {
+    padding: 0.5rem 1.125rem 0.625rem;
+}
+
+.tm-dialog-shell--read-past .tm-dialog-content--read-past > p {
+    margin: 0.25rem 0;
+}
+
+.tm-dialog-shell--read-past .tm-dialog-actions {
+    padding: 0.5rem 0.75rem 0.625rem;
+    border-top: 1px solid rgba(143, 130, 95, 0.22);
+    background: rgba(0, 0, 0, 0.1);
+}
+
+/* Keep cards in a masonry-like flow on wider Settings windows. The regular
+   MudGrid flex rows reserve the height of the tallest card, which leaves large
+   blank shelves beside short cards such as Language and Initial setup. */
+.settings-grid > .mud-grid-item {
+    display: inline-block !important;
+    width: 100% !important;
+    max-width: none !important;
+    vertical-align: top;
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+
+@media (min-width: 60rem) {
+    .settings-grid {
+        column-count: 2;
+    }
+}
+
+@media (min-width: 100rem) {
+    .settings-grid {
+        column-count: 3;
+    }
+}
+
 .dashboard-notification-surface {
-    min-height: calc(100% - 16px);
-    margin: 8px 16px;
+    min-height: calc(100% - 8px);
+    margin: 0 16px 8px;
 }
 
 .dashboard-page-grid,

--- a/TarkovMonitor/wwwroot/css/app.css
+++ b/TarkovMonitor/wwwroot/css/app.css
@@ -94,3 +94,276 @@ body {
 .floating-timer-panel__timer .mud-typography-h5 {
     font-size: 1.1rem;
 }
+
+/* TarkovTracker.org key-management dialogs */
+.mud-dialog.tracker-assignment-dialog,
+.mud-dialog.tracker-settings-dialog {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(194, 178, 126, 0.72);
+    border-radius: 14px;
+    background: #1b1c1f;
+    box-shadow: 0 20px 56px rgba(0, 0, 0, 0.62), 0 0 0 1px rgba(0, 0, 0, 0.42);
+}
+
+.mud-dialog.tracker-assignment-dialog {
+    max-height: calc(100vh - 72px);
+}
+
+.mud-dialog.tracker-assignment-dialog::before,
+.mud-dialog.tracker-settings-dialog::before {
+    position: absolute;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: 2px;
+    background: linear-gradient(90deg, #68a4ff, #7ed7ad 58%, #c2b27e);
+    content: "";
+    pointer-events: none;
+}
+
+.mud-dialog.tracker-assignment-dialog .mud-dialog-title,
+.mud-dialog.tracker-settings-dialog .mud-dialog-title {
+    padding: 13px 18px 11px;
+    border-bottom: 1px solid rgba(194, 178, 126, 0.28);
+    background: linear-gradient(180deg, rgba(194, 178, 126, 0.09), rgba(255, 255, 255, 0.015));
+    color: #c2b27e;
+}
+
+.mud-dialog.tracker-assignment-dialog .mud-dialog-content {
+    min-height: 0;
+    overflow: hidden;
+    padding: 13px 18px 10px;
+}
+
+.mud-dialog.tracker-settings-dialog .mud-dialog-content {
+    min-height: 0;
+    padding: 16px 18px;
+}
+
+.mud-dialog.tracker-assignment-dialog .mud-dialog-actions,
+.mud-dialog.tracker-settings-dialog .mud-dialog-actions {
+    min-height: 52px;
+    padding: 8px 12px;
+    border-top: 1px solid rgba(255, 255, 255, 0.09);
+    background: rgba(0, 0, 0, 0.16);
+}
+
+.mud-dialog.tracker-edit-key-dialog .mud-dialog-content {
+    padding: 8px 18px 7px;
+}
+
+.mud-dialog.tracker-edit-key-dialog .mud-dialog-actions {
+    min-height: 46px;
+    padding: 4px 10px;
+}
+
+.tracker-dialog-note {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.62rem;
+    align-items: flex-start;
+    margin-bottom: 0.85rem;
+    padding: 0.66rem 0.72rem;
+    border: 1px solid rgba(111, 166, 255, 0.3);
+    border-radius: 10px;
+    color: rgba(255, 255, 255, 0.76);
+    background: linear-gradient(135deg, rgba(61, 112, 194, 0.12), rgba(255, 255, 255, 0.018));
+    font-size: 0.76rem;
+    line-height: 1.38;
+}
+
+.tracker-dialog-note--assigned {
+    border-color: rgba(87, 194, 142, 0.32);
+    background: linear-gradient(135deg, rgba(48, 146, 99, 0.12), rgba(255, 255, 255, 0.018));
+}
+
+.tracker-dialog-note--warning {
+    border-color: rgba(242, 188, 87, 0.36);
+    background: linear-gradient(135deg, rgba(181, 123, 37, 0.14), rgba(255, 255, 255, 0.018));
+}
+
+.tracker-dialog-note--danger {
+    border-color: rgba(242, 105, 105, 0.38);
+    background: linear-gradient(135deg, rgba(181, 57, 57, 0.15), rgba(255, 255, 255, 0.018));
+}
+
+.tracker-dialog-note__icon { color: #9fc5ff; }
+.tracker-dialog-note--assigned .tracker-dialog-note__icon { color: #8ce0b8; }
+.tracker-dialog-note--warning .tracker-dialog-note__icon { color: #f2ca7f; }
+.tracker-dialog-note--danger .tracker-dialog-note__icon { color: #ff9b9b; }
+
+.tracker-dialog-note__copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.tracker-dialog-note__copy strong {
+    color: rgba(255, 255, 255, 0.94);
+    font-size: 0.79rem;
+}
+
+.tracker-dialog-section-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.38rem;
+    margin: 0 0 0.42rem;
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 0.73rem;
+    font-weight: 750;
+    letter-spacing: 0.035em;
+    text-transform: uppercase;
+}
+
+.tracker-dialog-detail-card {
+    display: flex;
+    overflow: hidden;
+    flex-direction: column;
+    margin: 0;
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 11px;
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.038), rgba(0, 0, 0, 0.11));
+}
+
+.tracker-dialog-detail-row {
+    display: grid;
+    grid-template-columns: 7.25rem minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: center;
+    min-height: 1.95rem;
+    padding: 0.26rem 0.62rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.065);
+}
+
+.tracker-dialog-detail-row:last-child { border-bottom: 0; }
+.tracker-dialog-detail-row dt { color: rgba(255, 255, 255, 0.55); font-size: 0.72rem; font-weight: 650; }
+.tracker-dialog-detail-row dd { min-width: 0; margin: 0; overflow-wrap: anywhere; color: rgba(255, 255, 255, 0.92); font-size: 0.8rem; font-weight: 600; }
+
+.tracker-dialog-mode-badge {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.2rem;
+    padding: 0.02rem 0.4rem;
+    border: 1px solid rgba(111, 166, 255, 0.42);
+    border-radius: 999px;
+    color: #a9cbff;
+    background: rgba(61, 112, 194, 0.14);
+    font-size: 0.67rem;
+    font-weight: 750;
+}
+
+.tracker-dialog-mode-badge--pve { border-color: rgba(87, 194, 142, 0.42); color: #8ce0b8; background: rgba(48, 146, 99, 0.14); }
+.tracker-dialog-mode-badge--seasonal { border-color: rgba(212, 148, 255, 0.42); color: #deb0ff; background: rgba(139, 74, 180, 0.14); }
+
+.tracker-dialog-form-card {
+    padding: 0.7rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 11px;
+    background: rgba(255, 255, 255, 0.022);
+}
+
+.tracker-dialog-field-help {
+    display: block;
+    margin-top: 0.42rem;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.7rem;
+    line-height: 1.35;
+}
+
+.tracker-key-action-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+}
+
+.tracker-key-action {
+    display: flex;
+    min-width: 0;
+    min-height: 4.45rem;
+    align-items: flex-start;
+    gap: 0.52rem;
+    padding: 0.54rem;
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 10px;
+    color: rgba(255, 255, 255, 0.88);
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.038), rgba(0, 0, 0, 0.1));
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.tracker-key-action:hover,
+.tracker-key-action:focus-visible { border-color: rgba(111, 166, 255, 0.55); background-color: rgba(61, 112, 194, 0.12); outline: none; }
+.tracker-key-action:disabled { cursor: not-allowed; opacity: 0.48; }
+.tracker-key-action--warning:hover,
+.tracker-key-action--warning:focus-visible { border-color: rgba(242, 188, 87, 0.5); background-color: rgba(181, 123, 37, 0.11); }
+.tracker-key-action--danger:hover,
+.tracker-key-action--danger:focus-visible { border-color: rgba(242, 105, 105, 0.52); background-color: rgba(181, 57, 57, 0.12); }
+.tracker-key-action__icon { color: #9fc5ff; }
+.tracker-key-action--warning .tracker-key-action__icon { color: #f2ca7f; }
+.tracker-key-action--danger .tracker-key-action__icon { color: #ff9b9b; }
+.tracker-key-action__copy { display: flex; min-width: 0; flex-direction: column; gap: 0.16rem; }
+.tracker-key-action__title { font-size: 0.76rem; font-weight: 750; }
+.tracker-key-action__description { color: rgba(255, 255, 255, 0.56); font-size: 0.67rem; line-height: 1.28; }
+.mud-dialog .tracker-dialog-footer-button { min-width: 5.6rem; border-radius: 8px; }
+
+/* Message IDs stay masked unless the user deliberately hovers or focuses them. */
+.dashboard-message__protected-values {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.55rem;
+    margin-top: 0.4rem;
+}
+
+.dashboard-message__protected-detail {
+    display: inline-flex;
+    max-width: 100%;
+    align-items: center;
+    gap: 0.35rem;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 0.72rem;
+}
+
+.dashboard-message__protected-label { font-weight: 650; }
+
+.dashboard-message__protected-value {
+    display: inline-grid;
+    max-width: 100%;
+    min-height: 1.45rem;
+    align-items: center;
+    padding: 0.08rem 0.42rem;
+    overflow: hidden;
+    border: 1px solid rgba(194, 178, 126, 0.38);
+    border-radius: 999px;
+    color: #d7c996;
+    background: rgba(0, 0, 0, 0.2);
+    cursor: help;
+    outline: none;
+}
+
+.dashboard-message__protected-mask,
+.dashboard-message__protected-reveal { grid-area: 1 / 1; }
+
+.dashboard-message__protected-reveal {
+    visibility: hidden;
+    overflow-wrap: anywhere;
+    color: rgba(255, 255, 255, 0.9);
+    font-family: Consolas, monospace;
+    font-size: 0.7rem;
+    user-select: text;
+}
+
+.dashboard-message__protected-value:hover .dashboard-message__protected-mask,
+.dashboard-message__protected-value:focus .dashboard-message__protected-mask { visibility: hidden; }
+
+.dashboard-message__protected-value:hover .dashboard-message__protected-reveal,
+.dashboard-message__protected-value:focus .dashboard-message__protected-reveal { visibility: visible; }
+
+@media (max-width: 520px) {
+    .tracker-dialog-detail-row { grid-template-columns: 1fr; gap: 0.08rem; align-items: flex-start; }
+    .tracker-key-action-grid { grid-template-columns: 1fr; }
+    .tracker-key-action { min-height: auto; }
+}

--- a/TarkovMonitor/wwwroot/index.html
+++ b/TarkovMonitor/wwwroot/index.html
@@ -3,20 +3,74 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WinFormsBlazor</title>
+    <title>Tarkov Monitor</title>
     <base href="/" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-    <link href="css/app.css" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="css/app.css?v=dropdown-resize-4" rel="stylesheet" />
     <link href="TarkovMonitor.styles.css" rel="stylesheet">
+    <style>
+        html, body, #app {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            overflow: hidden;
+            background: #1e1e1e;
+            color: rgba(255, 255, 255, 0.9);
+            font-family: "Segoe UI", Roboto, sans-serif;
+        }
+
+        .tm-startup-shell {
+            box-sizing: border-box;
+            width: 100%;
+            height: 100%;
+            display: grid;
+            place-content: center;
+            gap: 0.75rem;
+            background: #1e1e1e;
+            color: rgba(255, 255, 255, 0.9);
+            text-align: center;
+        }
+
+        .tm-startup-shell__spinner {
+            width: 1.5rem;
+            height: 1.5rem;
+            margin: 0 auto;
+            border: 0.2rem solid rgba(255, 255, 255, 0.22);
+            border-top-color: #5f9df7;
+            border-radius: 50%;
+            animation: tm-startup-spin 0.8s linear infinite;
+        }
+
+        .tm-startup-shell__title {
+            font-size: 1.05rem;
+            font-weight: 600;
+            letter-spacing: 0.01em;
+        }
+
+        .tm-startup-shell__status {
+            color: rgba(255, 255, 255, 0.62);
+            font-size: 0.82rem;
+        }
+
+        @keyframes tm-startup-spin {
+            to { transform: rotate(360deg); }
+        }
+    </style>
 </head>
 
 <body>
 
-    <div id="app">Loading...</div>
+    <div id="app">
+        <div class="tm-startup-shell" role="status" aria-live="polite">
+            <div class="tm-startup-shell__spinner" aria-hidden="true"></div>
+            <div class="tm-startup-shell__title">Tarkov Monitor</div>
+            <div class="tm-startup-shell__status">Starting the interface&hellip;</div>
+        </div>
+    </div>
 
     <div id="blazor-error-ui">
-        An unhandled error has occurred.
+        Tarkov Monitor encountered an error.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
@@ -24,6 +78,870 @@
     <script src="_framework/blazor.webview.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="js/floating-timer-panel.js"></script>
+    <script>
+        (() => {
+            const viewportMargin = 8;
+            const activatorGap = 4;
+            let frame = 0;
+            let constraintCleanupTimer = 0;
+            const constrainedDropdowns = new Map();
+            const dropdownConstraintDefaultsById = new Map();
+
+            const hasOpenDropdown = () => document.querySelector(
+                '.mud-popover-open .tm-select-list, .mud-popover-open .tm-menu-list') !== null;
+
+            const findDropdownActivator = owner => {
+                if (!(owner instanceof Element)) return null;
+                return [...owner.querySelectorAll(
+                    '.mud-input.mud-select-input,'
+                    + ' .mud-input-slot[role="combobox"]:not([type="hidden"]),'
+                    + ' .mud-input-root[role="combobox"]:not([type="hidden"]),'
+                    + ' .mud-menu button, .mud-menu [role="button"], .tm-menu-activator')]
+                    .find(element => element.getClientRects().length) ?? null;
+            };
+
+            const findDropdownPopover = owner => {
+                if (!(owner instanceof Element)) return null;
+                const anchor = [...owner.querySelectorAll('[id^="popover-"]')]
+                    .find(element => element.id.length > 'popover-'.length);
+                if (!anchor) return null;
+                const suffix = anchor.id.substring('popover-'.length);
+                const popover = document.getElementById(`popovercontent-${suffix}`);
+                return popover?.matches('.tm-select-popover, .tm-menu-popover')
+                    ? popover
+                    : null;
+            };
+
+            const restoreDropdownConstraint = (popover, record) => {
+                if (!(popover instanceof HTMLElement)) return;
+                if (record.originalMaxHeight) {
+                    popover.style.setProperty(
+                        'max-height',
+                        record.originalMaxHeight,
+                        record.originalMaxHeightPriority);
+                } else {
+                    popover.style.removeProperty('max-height');
+                }
+            };
+
+            const restoreClosedDropdownConstraints = () => {
+                const now = performance.now();
+                for (const [popover, record] of constrainedDropdowns) {
+                    if (popover.isConnected && popover.classList.contains('mud-popover-open')) {
+                        record.opened = true;
+                        continue;
+                    }
+                    // MudBlazor opens asynchronously after the activator event.
+                    // Keep a newly prepared cap long enough for that first render;
+                    // otherwise the observer can restore 280px before the menu opens.
+                    if (!record.opened && now - record.preparedAt < 250) continue;
+                    restoreDropdownConstraint(popover, record);
+                    constrainedDropdowns.delete(popover);
+                }
+                if (constrainedDropdowns.size === 0 && constraintCleanupTimer) {
+                    window.clearTimeout(constraintCleanupTimer);
+                    constraintCleanupTimer = 0;
+                }
+            };
+
+            const constrainDropdown = owner => {
+                const activator = findDropdownActivator(owner);
+                const popover = findDropdownPopover(owner);
+                if (!(activator instanceof HTMLElement) || !(popover instanceof HTMLElement)) return;
+
+                let record = constrainedDropdowns.get(popover);
+                if (!record) {
+                    let originalConstraint = dropdownConstraintDefaultsById.get(popover.id);
+                    if (!originalConstraint) {
+                        originalConstraint = {
+                            maxHeight: popover.style.maxHeight,
+                            maxHeightPriority: popover.style.getPropertyPriority('max-height')
+                        };
+                        dropdownConstraintDefaultsById.set(popover.id, originalConstraint);
+                    }
+                    record = {
+                        activator,
+                        originalMaxHeight: originalConstraint.maxHeight,
+                        originalMaxHeightPriority: originalConstraint.maxHeightPriority,
+                        preparedAt: performance.now(),
+                        opened: false
+                    };
+                    constrainedDropdowns.set(popover, record);
+                } else {
+                    record.activator = activator;
+                    if (!record.opened) record.preparedAt = performance.now();
+                }
+
+                const popoverIsOpen = popover.classList.contains('mud-popover-open');
+                if (popoverIsOpen) record.opened = true;
+
+                const activatorBounds = activator.getBoundingClientRect();
+                const ownerBounds = owner.getBoundingClientRect();
+                const visualTop = window.visualViewport?.offsetTop ?? 0;
+                const visualBottom = visualTop
+                    + (window.visualViewport?.height ?? window.innerHeight);
+                const visualLeft = window.visualViewport?.offsetLeft ?? 0;
+                const visualRight = visualLeft
+                    + (window.visualViewport?.width ?? window.innerWidth);
+                const appBarBottom = document.querySelector('.window-app-bar')
+                    ?.getBoundingClientRect().bottom ?? visualTop;
+                const safeTop = Math.max(visualTop + viewportMargin, appBarBottom + viewportMargin);
+                const safeBottom = visualBottom - viewportMargin;
+                const activatorOutsideViewport = activatorBounds.bottom <= safeTop
+                    || activatorBounds.top >= safeBottom
+                    || activatorBounds.right <= visualLeft + viewportMargin
+                    || activatorBounds.left >= visualRight - viewportMargin;
+
+                if (popoverIsOpen && activatorOutsideViewport) {
+                    closeOpenDropdowns({
+                        preserveScroll: true,
+                        scrollPositions: captureScrollPositions(),
+                        releaseOwnerFocusAfterClose: true
+                    });
+                    return false;
+                }
+
+                const availableAbove = Math.max(
+                    0,
+                    ownerBounds.top - safeTop - activatorGap);
+                const availableBelow = Math.max(
+                    0,
+                    safeBottom - activatorBounds.bottom - activatorGap);
+                const availableHeight = Math.floor(Math.max(availableAbove, availableBelow));
+                const constrainedHeight = availableHeight;
+
+                if (constrainedHeight > 0) {
+                    const value = `${constrainedHeight}px`;
+                    if (popover.style.maxHeight !== value) {
+                        popover.style.setProperty(
+                            'max-height',
+                            value,
+                            record.originalMaxHeightPriority);
+                        if (popoverIsOpen) {
+                            const suffix = popover.id.substring('popovercontent-'.length);
+                            window.mudPopover?.schedulePopoverUpdate?.(suffix, true);
+                        }
+                    }
+                }
+
+                if (!record.opened) {
+                    if (constraintCleanupTimer) window.clearTimeout(constraintCleanupTimer);
+                    constraintCleanupTimer = window.setTimeout(() => {
+                        constraintCleanupTimer = 0;
+                        scheduleDropdownUpdate();
+                    }, 300);
+                }
+
+                return true;
+            };
+
+            const constrainOpenDropdowns = () => {
+                const visitedPopovers = new Set();
+                for (const owner of document.querySelectorAll('.tm-select, .mud-menu')) {
+                    const popover = findDropdownPopover(owner);
+                    if (popover?.classList.contains('mud-popover-open')
+                        && popover.querySelector('.tm-select-list, .tm-menu-list')) {
+                        if (visitedPopovers.has(popover)) continue;
+                        visitedPopovers.add(popover);
+                        if (constrainDropdown(owner) === false) return;
+                    }
+                }
+
+                for (const [popover, record] of constrainedDropdowns) {
+                    if (visitedPopovers.has(popover)) continue;
+                    if (!popover.isConnected || !popover.classList.contains('mud-popover-open')) {
+                        continue;
+                    }
+                    const owner = record.activator.closest('.mud-select, .mud-menu');
+                    if (owner && constrainDropdown(owner) === false) return;
+                }
+            };
+
+            const captureScrollPositions = () => [...document.querySelectorAll(
+                '.app-main-content, .mud-main-content, [data-tm-scroll-container]')]
+                .map((element, index) => ({
+                    selector: element.matches('.app-main-content')
+                        ? '.app-main-content'
+                        : element.matches('.mud-main-content')
+                            ? '.mud-main-content'
+                            : '[data-tm-scroll-container]',
+                    index,
+                    top: element.scrollTop,
+                    left: element.scrollLeft
+                }));
+
+            const restoreScrollPositions = positions => {
+                for (const position of positions) {
+                    const element = document.querySelectorAll(position.selector)[position.index];
+                    if (!element) continue;
+                    element.scrollTop = position.top;
+                    element.scrollLeft = position.left;
+                }
+            };
+
+            const closeOpenDropdowns = ({
+                preserveScroll = false,
+                scrollPositions = null,
+                releaseOwnerFocusAfterClose = false
+            } = {}) => {
+                if (!hasOpenDropdown() && !(preserveScroll && scrollPositions?.length)) {
+                    return;
+                }
+
+                const positions = scrollPositions ?? (preserveScroll ? captureScrollPositions() : []);
+                const focusReleaseTargets = releaseOwnerFocusAfterClose
+                    ? getOpenDropdownFocusReleaseTargets()
+                    : [];
+                if (focusReleaseTargets.length) {
+                    // Arm the existing owner-scoped observer before Escape can
+                    // synchronously close the popup and restore activator focus.
+                    schedulePointerDismissFocusRelease(focusReleaseTargets, {
+                        settleLateOwnerRefocus: true
+                    });
+                }
+
+                // A popover is rendered outside its component, but MudBlazor keeps a
+                // matching popover-{id} anchor next to the component. Resolve only the
+                // open dropdown's own activator; dispatching Escape to every select on
+                // the page makes an off-screen control reclaim focus and scroll the
+                // document unexpectedly.
+                document.querySelectorAll('.mud-popover-open').forEach(popover => {
+                    if (!popover.querySelector('.tm-select-list, .tm-menu-list')) return;
+
+                    const contentId = popover.id;
+                    const suffix = contentId.startsWith('popovercontent-')
+                        ? contentId.substring('popovercontent-'.length)
+                        : '';
+                    const anchor = suffix ? document.getElementById(`popover-${suffix}`) : null;
+                    const owner = anchor?.parentElement;
+                    const activator = owner?.querySelector(
+                        '.mud-select-input, .mud-input-slot, .mud-menu button, .mud-menu [role="button"], [role="button"]')
+                        ?? (contentId ? document.querySelector(
+                            `[aria-controls="${CSS.escape(contentId)}"], [aria-owns="${CSS.escape(contentId)}"]`) : null);
+
+                    const candidates = [];
+                    if (activator instanceof HTMLElement) candidates.push(activator);
+                    const focused = document.activeElement;
+                    if (focused instanceof HTMLElement && focused.closest('.mud-select, .mud-menu')) {
+                        candidates.push(focused);
+                    }
+
+                    for (const target of candidates) {
+                        if (!(target instanceof HTMLElement)) continue;
+                        target.dispatchEvent(new KeyboardEvent('keydown', {
+                            key: 'Escape',
+                            code: 'Escape',
+                            keyCode: 27,
+                            which: 27,
+                            bubbles: true,
+                            cancelable: true
+                        }));
+                        if (!hasOpenDropdown()) break;
+                    }
+                });
+
+                if (preserveScroll && positions.length) {
+                    // MudSelect may restore focus while handling Escape. That focus
+                    // restoration can call scrollIntoView on the off-screen input and
+                    // jump the settings page to the top. Restore the user's position
+                    // after MudBlazor completes its synchronous and queued work.
+                    restoreScrollPositions(positions);
+                    window.requestAnimationFrame(() => {
+                        restoreScrollPositions(positions);
+                        window.requestAnimationFrame(() => restoreScrollPositions(positions));
+                    });
+                }
+
+            };
+
+            let pendingWheelDismiss = null;
+            let pendingWheelDismissTimer = 0;
+
+            const clearPendingWheelDismiss = () => {
+                if (pendingWheelDismissTimer) {
+                    window.clearTimeout(pendingWheelDismissTimer);
+                    pendingWheelDismissTimer = 0;
+                }
+                pendingWheelDismiss = null;
+            };
+
+            const queueScrollDismiss = event => {
+                if (!hasOpenDropdown()) return;
+                const rawTarget = event.target;
+                const target = rawTarget instanceof Element
+                    ? rawTarget.closest('.app-main-content, .mud-main-content, [data-tm-scroll-container]')
+                    : null;
+                if (!(target instanceof HTMLElement)) return;
+
+                const selector = target.matches('.app-main-content')
+                    ? '.app-main-content'
+                    : target.matches('.mud-main-content')
+                        ? '.mud-main-content'
+                        : '[data-tm-scroll-container]';
+                const index = [...document.querySelectorAll(selector)].indexOf(target);
+                if (index < 0) return;
+
+                // Capture and arm owner-scoped focus release before the
+                // browser's native scroll (or MudBlazor) can close and remove
+                // the popup. The later close path may find no open node.
+                const focusReleaseTargets = getOpenDropdownFocusReleaseTargets();
+                if (focusReleaseTargets.length) {
+                    schedulePointerDismissFocusRelease(focusReleaseTargets, {
+                        settleLateOwnerRefocus: true
+                    });
+                }
+
+                // Do not predict or set the destination from deltaY here. The
+                // browser still has to apply the wheel's native scroll; writing
+                // a predicted position before that happens makes constrained
+                // popovers scroll twice. Close after the native scroll event and
+                // preserve the position that the browser actually reached.
+                pendingWheelDismiss = { target, selector, index };
+                if (pendingWheelDismissTimer) window.clearTimeout(pendingWheelDismissTimer);
+                pendingWheelDismissTimer = window.setTimeout(() => {
+                    pendingWheelDismissTimer = 0;
+                    if (!pendingWheelDismiss) return;
+                    const positions = captureScrollPositions();
+                    pendingWheelDismiss = null;
+                    if (hasOpenDropdown()) {
+                        closeOpenDropdowns({
+                            preserveScroll: true,
+                            scrollPositions: positions,
+                            releaseOwnerFocusAfterClose: true
+                        });
+                    }
+                }, 80);
+            };
+
+            const updateOpenDropdowns = () => {
+                frame = 0;
+                restoreClosedDropdownConstraints();
+                if (hasOpenDropdown()) {
+                    constrainOpenDropdowns();
+                }
+            };
+
+            const scheduleDropdownUpdate = () => {
+                if (!hasOpenDropdown()
+                    && constrainedDropdowns.size === 0) return;
+                if (frame) return;
+                frame = window.requestAnimationFrame(() => {
+                    frame = window.requestAnimationFrame(updateOpenDropdowns);
+                });
+            };
+
+            window.addEventListener('resize', scheduleDropdownUpdate, { passive: true });
+            document.addEventListener('wheel', event => {
+                const target = event.target instanceof Element
+                    ? event.target.closest('.mud-popover-open')
+                    : null;
+                if (target) return;
+                if (hasOpenDropdown()) event.stopPropagation();
+                queueScrollDismiss(event);
+            }, true);
+            document.addEventListener('scroll', event => {
+                const target = event.target;
+                if (target instanceof Element && target.closest('.mud-popover-open')) {
+                    scheduleDropdownUpdate();
+                    return;
+                }
+                if (pendingWheelDismiss) {
+                    const pendingTarget = pendingWheelDismiss.target;
+                    if (target === pendingTarget || !(target instanceof Element)) {
+                        const positions = captureScrollPositions();
+                        clearPendingWheelDismiss();
+                        closeOpenDropdowns({
+                            preserveScroll: true,
+                            scrollPositions: positions,
+                            releaseOwnerFocusAfterClose: true
+                        });
+                        return;
+                    }
+                }
+                closeOpenDropdowns({
+                    preserveScroll: true,
+                    releaseOwnerFocusAfterClose: true
+                });
+            }, true);
+
+            let neutralDismissTimer = 0;
+
+            const isDropdownActivator = target => target.closest(
+                '.mud-select-input, .mud-input-slot, .mud-select [role="combobox"], .mud-select input,'
+                + ' .mud-menu button, .mud-menu [role="button"], .tm-menu-activator');
+
+            const cancelNeutralDismiss = () => {
+                if (!neutralDismissTimer) return;
+                window.clearTimeout(neutralDismissTimer);
+                neutralDismissTimer = 0;
+            };
+
+            const pendingPointerFocusReleases = new WeakSet();
+
+            const getOpenDropdownFocusReleaseTargets = () =>
+                [...document.querySelectorAll('.mud-popover-open')]
+                    .map(popover => {
+                        if (!popover.querySelector('.tm-select-list, .tm-menu-list')) return null;
+                        const contentId = popover.id;
+                        const suffix = contentId.startsWith('popovercontent-')
+                            ? contentId.substring('popovercontent-'.length)
+                            : '';
+                        const anchor = suffix ? document.getElementById(`popover-${suffix}`) : null;
+                        const owner = anchor?.parentElement;
+                        return owner instanceof HTMLElement ? { popover, owner } : null;
+                    })
+                    .filter(Boolean);
+
+            const schedulePointerDismissFocusRelease = (
+                targets,
+                { settleLateOwnerRefocus = false } = {}) => {
+                targets.forEach(({ popover, owner }) => {
+                    if (pendingPointerFocusReleases.has(popover)) return;
+
+                    pendingPointerFocusReleases.add(popover);
+                    let observer = null;
+                    let cleanupTimer = 0;
+                    let releaseFrame = 0;
+                    let reconcileFrame = 0;
+                    let releaseQueued = false;
+                    let settlingLateOwnerFocus = false;
+                    let quietFrames = 0;
+                    let closeScrollPositions = null;
+                    let ownerFocusGeneration = 0;
+                    let pendingSettlementWheel = null;
+                    let pendingSettlementWheelTimer = 0;
+
+                    const ownerDropdownIsOpen = () =>
+                        findDropdownPopover(owner)?.classList.contains('mud-popover-open') ?? false;
+
+                    const cleanup = () => {
+                        observer?.disconnect();
+                        observer = null;
+                        if (cleanupTimer) window.clearTimeout(cleanupTimer);
+                        cleanupTimer = 0;
+                        if (releaseFrame) window.cancelAnimationFrame(releaseFrame);
+                        releaseFrame = 0;
+                        if (reconcileFrame) window.cancelAnimationFrame(reconcileFrame);
+                        reconcileFrame = 0;
+                        if (pendingSettlementWheelTimer) {
+                            window.clearTimeout(pendingSettlementWheelTimer);
+                        }
+                        pendingSettlementWheelTimer = 0;
+                        pendingSettlementWheel = null;
+                        document.removeEventListener('wheel', trackSettlementWheel, true);
+                        document.removeEventListener('scroll', trackSettlementScroll, true);
+                        document.removeEventListener('focusin', trackSettlementOwnerFocus, true);
+                        window.removeEventListener('pointerdown', cancelSettlementForNewIntent, true);
+                        window.removeEventListener('keydown', cancelSettlementForNewIntent, true);
+                        pendingPointerFocusReleases.delete(popover);
+                    };
+
+                    const scrollPositionsMatch = (left, right) =>
+                        left?.length === right?.length
+                        && left.every((position, index) => {
+                            const candidate = right[index];
+                            return position.selector === candidate?.selector
+                                && position.index === candidate.index
+                                && position.top === candidate.top
+                                && position.left === candidate.left;
+                        });
+
+                    function trackSettlementOwnerFocus(event) {
+                        if (!settlingLateOwnerFocus || ownerDropdownIsOpen()) return;
+                        const target = event.target;
+                        if (target instanceof HTMLElement && owner.contains(target)) {
+                            ownerFocusGeneration += 1;
+                            quietFrames = 0;
+                            target.blur();
+                            if (closeScrollPositions?.length) {
+                                restoreScrollPositions(closeScrollPositions);
+                            }
+                        }
+                    }
+
+                    function cancelSettlementForNewIntent() {
+                        if (settlingLateOwnerFocus) cleanup();
+                    }
+
+                    function trackSettlementWheel(event) {
+                        if (!settlingLateOwnerFocus || ownerDropdownIsOpen()) return;
+                        const rawTarget = event.target;
+                        if (!(rawTarget instanceof Element)
+                            || rawTarget.closest('.mud-popover-open')) return;
+                        const target = rawTarget.closest(
+                            '.app-main-content, .mud-main-content, [data-tm-scroll-container]');
+                        if (!(target instanceof HTMLElement)) return;
+
+                        const focused = document.activeElement;
+                        if (focused instanceof HTMLElement && owner.contains(focused)) {
+                            focused.blur();
+                            if (closeScrollPositions?.length) {
+                                restoreScrollPositions(closeScrollPositions);
+                            }
+                            quietFrames = 0;
+                        }
+                        const observedPositions = captureScrollPositions();
+
+                        if (!scrollPositionsMatch(observedPositions, closeScrollPositions)) {
+                            // Chromium may apply compositor scrolling before the
+                            // DOM wheel listener runs. Preserve that observed
+                            // user delta immediately when it is already visible.
+                            closeScrollPositions = observedPositions;
+                            pendingSettlementWheel = null;
+                        } else {
+                            pendingSettlementWheel = {
+                                target,
+                                ownerFocusGeneration
+                            };
+                        }
+
+                        if (pendingSettlementWheelTimer) {
+                            window.clearTimeout(pendingSettlementWheelTimer);
+                        }
+                        pendingSettlementWheelTimer = window.setTimeout(() => {
+                            pendingSettlementWheelTimer = 0;
+                            pendingSettlementWheel = null;
+                        }, 80);
+                    }
+
+                    function trackSettlementScroll(event) {
+                        const pending = pendingSettlementWheel;
+                        if (!pending || event.target !== pending.target) return;
+                        // A same-owner focus event identifies MudBlazor's
+                        // scrollIntoView side effect, not a second wheel delta.
+                        if (ownerFocusGeneration !== pending.ownerFocusGeneration) {
+                            pending.ownerFocusGeneration = ownerFocusGeneration;
+                            return;
+                        }
+                        const observedPositions = captureScrollPositions();
+                        if (scrollPositionsMatch(observedPositions, closeScrollPositions)) return;
+                        closeScrollPositions = observedPositions;
+                        pendingSettlementWheel = null;
+                        if (pendingSettlementWheelTimer) {
+                            window.clearTimeout(pendingSettlementWheelTimer);
+                            pendingSettlementWheelTimer = 0;
+                        }
+                    }
+
+                    const settleLateOwnerFocus = () => {
+                        releaseFrame = 0;
+                        if (ownerDropdownIsOpen()) {
+                            cleanup();
+                            return;
+                        }
+
+                        const focused = document.activeElement;
+                        if (focused instanceof HTMLElement && owner.contains(focused)) {
+                            focused.blur();
+                            if (closeScrollPositions?.length) {
+                                restoreScrollPositions(closeScrollPositions);
+                            }
+                            quietFrames = 0;
+                        } else {
+                            quietFrames += 1;
+                        }
+
+                        if (quietFrames >= 2) {
+                            cleanup();
+                            return;
+                        }
+
+                        releaseFrame = window.requestAnimationFrame(settleLateOwnerFocus);
+                    };
+
+                    const releaseAfterClose = () => {
+                        if (ownerDropdownIsOpen()) {
+                            if (settlingLateOwnerFocus) cleanup();
+                            return false;
+                        }
+                        if (releaseQueued) return true;
+
+                        releaseQueued = true;
+                        if (settleLateOwnerRefocus) {
+                            // External wheel dismissal can close the popup before
+                            // MudBlazor's queued .NET focus restoration reaches the
+                            // activator. Keep this owner-scoped session alive until
+                            // two quiet frames have passed, and only restore the
+                            // browser-applied scroll position when that late focus
+                            // actually has to be cleared.
+                            settlingLateOwnerFocus = true;
+                            closeScrollPositions = captureScrollPositions();
+                            document.addEventListener('wheel', trackSettlementWheel, true);
+                            document.addEventListener('scroll', trackSettlementScroll, true);
+                            document.addEventListener('focusin', trackSettlementOwnerFocus, true);
+                            window.addEventListener('pointerdown', cancelSettlementForNewIntent, true);
+                            window.addEventListener('keydown', cancelSettlementForNewIntent, true);
+                            releaseFrame = window.requestAnimationFrame(settleLateOwnerFocus);
+                            return true;
+                        }
+                        releaseFrame = window.requestAnimationFrame(() => {
+                            releaseFrame = 0;
+                            const focused = document.activeElement;
+                            if (!ownerDropdownIsOpen()
+                                && focused instanceof HTMLElement
+                                && owner.contains(focused)) {
+                                focused.blur();
+                            }
+                            cleanup();
+                        });
+                        return true;
+                    };
+
+                    const reconcileCloseState = () => {
+                        reconcileFrame = 0;
+                        if (releaseQueued || releaseAfterClose()) return;
+                        reconcileFrame = window.requestAnimationFrame(reconcileCloseState);
+                    };
+
+                    observer = new MutationObserver(releaseAfterClose);
+                    observer.observe(popover, { attributes: true, attributeFilter: ['class'] });
+                    // MudBlazor may replace or detach the popup node without
+                    // first mutating that node's class. Watch only while this
+                    // owner-scoped release is pending so removal is reconciled
+                    // in the close microtask instead of the fallback timeout.
+                    observer.observe(document.body, { childList: true, subtree: true });
+                    cleanupTimer = window.setTimeout(cleanup, 500);
+                    if (!releaseAfterClose()) {
+                        reconcileFrame = window.requestAnimationFrame(reconcileCloseState);
+                    }
+                });
+            };
+
+            const isDropdownLabelClick = (target, event) => {
+                if (target.closest('.mud-select .mud-input-label')) return true;
+
+                // The label has pointer-events disabled by MudBlazor, so a
+                // real mouse hit on its text lands on the input container.
+                // Use the label's bounds to distinguish that title area from
+                // the actual value/arrow activator below it.
+                const select = target.closest('.mud-select');
+                const label = select?.querySelector('.mud-input-label');
+                if (!(label instanceof HTMLElement)
+                    || !Number.isFinite(event.clientX)
+                    || !Number.isFinite(event.clientY)) return false;
+                const bounds = label.getBoundingClientRect();
+                return event.clientX >= bounds.left
+                    && event.clientX <= bounds.right
+                    && event.clientY >= bounds.top
+                    && event.clientY <= bounds.bottom;
+            };
+
+            let pendingPointerDismissFocusRelease = null;
+
+            const clearPendingPointerDismissFocusRelease = () => {
+                if (!pendingPointerDismissFocusRelease) return;
+                if (pendingPointerDismissFocusRelease.cleanupTimer) {
+                    window.clearTimeout(pendingPointerDismissFocusRelease.cleanupTimer);
+                }
+                pendingPointerDismissFocusRelease = null;
+            };
+
+            // Capture the exact open popup before MudBlazor's document-level
+            // outside-click handler can close it. Focus is not released until
+            // the same pointer sequence produces a click, so a held or
+            // cancelled press cannot change keyboard/scroll focus semantics.
+            const capturePointerDismissFocusRelease = event => {
+                if (event.button !== 0) return;
+                const rawTarget = event.target;
+                const target = rawTarget instanceof Element
+                    ? rawTarget
+                    : rawTarget?.parentElement instanceof Element ? rawTarget.parentElement : null;
+
+                clearPendingPointerDismissFocusRelease();
+                if (!target
+                    || target.closest('.mud-popover-open, .resize-zone')) return;
+
+                const activator = isDropdownActivator(target);
+                const activatorOwner = activator
+                    ? target.closest('.mud-select, .mud-menu')
+                    : null;
+                const activatorPopover = activatorOwner
+                    ? findDropdownPopover(activatorOwner)
+                    : null;
+                const isActivatorToggleClose = !!activator
+                    && activatorPopover?.classList.contains('mud-popover-open');
+                if (activator && !isActivatorToggleClose) return;
+
+                let targets = getOpenDropdownFocusReleaseTargets();
+                if (isActivatorToggleClose) {
+                    targets = targets.filter(target => target.popover === activatorPopover);
+                }
+                if (!targets.length) return;
+
+                const pending = {
+                    targets,
+                    pointerId: event.pointerId,
+                    kind: isActivatorToggleClose ? 'activator-toggle' : 'neutral',
+                    cleanupTimer: 0
+                };
+                pending.cleanupTimer = window.setTimeout(() => {
+                    if (pendingPointerDismissFocusRelease === pending) {
+                        clearPendingPointerDismissFocusRelease();
+                    }
+                }, 5000);
+                pendingPointerDismissFocusRelease = pending;
+            };
+
+            const confirmPointerDismissFocusRelease = event => {
+                const pending = pendingPointerDismissFocusRelease;
+                if (!pending) return;
+                if (event.pointerId !== pending.pointerId
+                    || event.button !== 0
+                    || event.detail <= 0) return;
+
+                const rawTarget = event.target;
+                const target = rawTarget instanceof Element
+                    ? rawTarget
+                    : rawTarget?.parentElement instanceof Element ? rawTarget.parentElement : null;
+                const activator = target ? isDropdownActivator(target) : null;
+                const confirmsDismiss = pending.kind === 'activator-toggle'
+                    ? !!activator && pending.targets.some(entry => entry.owner.contains(target))
+                    : target
+                        && !target.closest('.mud-popover-open, .resize-zone')
+                        && !activator;
+
+                const targets = pending.targets;
+                clearPendingPointerDismissFocusRelease();
+                if (confirmsDismiss) {
+                    schedulePointerDismissFocusRelease(targets, {
+                        settleLateOwnerRefocus: true
+                    });
+                }
+            };
+
+            const clearPointerDismissFocusReleaseForPointer = event => {
+                const pending = pendingPointerDismissFocusRelease;
+                if (pending && event.pointerId === pending.pointerId) {
+                    clearPendingPointerDismissFocusRelease();
+                }
+            };
+
+            const clearPointerDismissFocusReleaseAfterPointerUp = event => {
+                const pending = pendingPointerDismissFocusRelease;
+                if (!pending || event.pointerId !== pending.pointerId) return;
+                window.setTimeout(() => {
+                    if (pendingPointerDismissFocusRelease === pending) {
+                        clearPendingPointerDismissFocusRelease();
+                    }
+                }, 250);
+            };
+
+            const closeOnNeutralClick = event => {
+                const rawTarget = event.target;
+                const target = rawTarget instanceof Element
+                    ? rawTarget
+                    : rawTarget?.parentElement instanceof Element ? rawTarget.parentElement : null;
+                if (!target) return;
+
+                // Reconcile the per-popup cap after MudBlazor finishes the
+                // click's open, selection, or close work.
+                if (event.type === 'click') {
+                    window.setTimeout(scheduleDropdownUpdate, 0);
+                }
+
+                // The animated field label is associated with MudSelect's
+                // hidden input. Letting the browser activate that association
+                // makes a title click open the menu even though the user did
+                // not click the select control. Treat the label as neutral;
+                // prevent its default activation and let an already-open menu
+                // close only after the click completes.
+                if (isDropdownLabelClick(target, event)) {
+                    cancelNeutralDismiss();
+                    event.preventDefault();
+                    event.stopPropagation();
+                    if (event.type === 'click' && hasOpenDropdown()) {
+                        closeOpenDropdowns();
+                    }
+                    return;
+                }
+
+                const select = target.closest('.mud-select');
+                if (select) {
+                    const activator = findDropdownActivator(select);
+                    const bounds = activator?.getBoundingClientRect();
+                    const insideControl = bounds
+                        && Number.isFinite(event.clientX)
+                        && Number.isFinite(event.clientY)
+                        && event.clientX >= bounds.left
+                        && event.clientX <= bounds.right
+                        && event.clientY >= bounds.top
+                        && event.clientY <= bounds.bottom;
+                    if (!insideControl) {
+                        cancelNeutralDismiss();
+                        event.preventDefault();
+                        event.stopPropagation();
+                        if (event.type === 'click' && hasOpenDropdown()) {
+                            closeOpenDropdowns();
+                        }
+                        return;
+                    }
+                }
+
+                const activatorClicked = isDropdownActivator(target);
+                if (activatorClicked) {
+                    const owner = target.closest('.mud-select, .mud-menu');
+                    const popover = findDropdownPopover(owner);
+                    if (owner && !popover?.classList.contains('mud-popover-open')) {
+                        constrainDropdown(owner);
+                    }
+                }
+                if (!hasOpenDropdown()) return;
+                if (target.closest('.mud-popover-open, .resize-zone') || activatorClicked) {
+                    cancelNeutralDismiss();
+                    return;
+                }
+
+                // MudSelect can handle the same pointer sequence after this
+                // capture listener. Defer the neutral dismissal until that
+                // sequence has finished so a label/card click cannot reopen
+                // the menu after we close it.
+                cancelNeutralDismiss();
+                neutralDismissTimer = window.setTimeout(() => {
+                    neutralDismissTimer = 0;
+                    closeOpenDropdowns();
+                }, 0);
+            };
+
+            // There is intentionally no modal backdrop. Capture normal
+            // activation so a neutral area closes the open menu.
+            window.addEventListener('pointerdown', () => {
+                document.documentElement.classList.remove('tm-keyboard-input');
+            }, true);
+            window.addEventListener('pointerdown', capturePointerDismissFocusRelease, true);
+            window.addEventListener('click', confirmPointerDismissFocusRelease, true);
+            window.addEventListener('pointercancel', clearPointerDismissFocusReleaseForPointer, true);
+            window.addEventListener('pointerup', clearPointerDismissFocusReleaseAfterPointerUp, true);
+            document.addEventListener('pointerdown', closeOnNeutralClick, true);
+            document.addEventListener('mousedown', closeOnNeutralClick, true);
+            document.addEventListener('click', closeOnNeutralClick, true);
+            document.addEventListener('keydown', event => {
+                if (!['Enter', ' ', 'ArrowDown', 'ArrowUp'].includes(event.key)) return;
+                const target = event.target instanceof Element ? event.target : null;
+                if (!target || !isDropdownActivator(target)) return;
+                document.documentElement.classList.add('tm-keyboard-input');
+                const owner = target.closest('.mud-select, .mud-menu');
+                const popover = findDropdownPopover(owner);
+                if (owner && !popover?.classList.contains('mud-popover-open')) {
+                    constrainDropdown(owner);
+                }
+            }, true);
+
+            if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', scheduleDropdownUpdate, { passive: true });
+                // A native window resize can emit a visual-viewport scroll as
+                // the WebView is re-laid out. Reposition the open popover here;
+                // the document scroll handler above still dismisses it when
+                // the user actually scrolls a page/card.
+                window.visualViewport.addEventListener('scroll', scheduleDropdownUpdate, { passive: true });
+            }
+            new MutationObserver(scheduleDropdownUpdate).observe(document.body, {
+                subtree: true,
+                childList: true,
+                attributes: true,
+                attributeFilter: ['class', 'style', 'data-mudpopover-flip']
+            });
+        })();
+    </script>
 </body>
 
 </html>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
﻿## Summary

This PR replaces the ambiguous TarkovTracker.org API token workflow with a verified, profile-bound API key system and a complete management interface.

Tarkov Monitor can now visibly and reliably store multiple PVE, PVP, and Seasonal keys, bind each key to an exact EFT account, profile, and game mode, and automatically select the correct key for the active session. It also introduces a responsive Settings overhaul, consistent dropdown and dialog styling, safer historical log replay, and several startup and profile-state fixes.

Startup also feels substantially faster because the interface now renders before watcher and update services finish initializing.

The branch also hardens profile activation and diagnostic reporting, supports clean startup when EFT is not installed, and keeps Tarkov.dev data isolated to the currently active session mode. Repeated profile notifications now share in-flight work, superseded requests are handled as expected state changes, and diagnostics retain endpoint, duration, and privacy-safe failure context.

TarkovTracker.io remains visible as a retired service with guidance directing users to TarkovTracker.org.

Fixes #191
### Legacy profile-keyed `.org` upgrade behavior

Existing TarkovTracker.org records from the legacy profile-keyed store are intentionally recovered as **Unassigned** during upgrade. Tarkov Monitor does not infer ownership from a legacy record or silently bind it to the active session. Users must review the recovered key in Settings and explicitly assign it to the verified EFT account, profile, and game mode before tracker writes resume.

## Commit-by-commit summary

### `e002f15` - `feat(tracker): store and switch verified org keys by EFT profile`

Author: Giribaldi_TTV

- Adds a versioned local TarkovTracker.org key store with guarded migration and corruption-aware persistence.
- Supports verified PVE, regular PVP, and Seasonal API keys.
- Verifies keys against the TarkovTracker.org endpoint before accepting or activating them.
- Binds each key to an exact EFT account ID, profile ID, and game mode.
- Automatically selects the matching key when Tarkov Monitor detects an active EFT profile.
- Prevents a key from another account, profile, or game mode from being used as a fallback.
- Treats unknown or future EFT modes as unsupported and revokes writable tracker state.
- Adds backend operations for assignment, reassignment, swapping, unbinding, removal, account nicknames, and profile-key nicknames.
- Preserves protected account and profile identifiers in Dashboard messages without displaying raw API keys.
- Keeps TarkovTracker.io state isolated and inactive.

### `f659649` - `feat(settings): add guided TarkovTracker key management`

Author: Giribaldi_TTV

- Replaces the single-token interface with assigned and unassigned key drawers.
- Adds guided API key import, endpoint verification, and saved-profile scanning.
- Adds dialogs for assignment, reassignment, swapping, unbinding, removal, account naming, profile-key naming, and key details.
- Filters assignment choices by the key's verified game mode.
- Clearly distinguishes available and unavailable profiles.
- Keeps API keys and protected identifiers masked until intentionally revealed.
- Displays storage recovery warnings when saved data cannot be safely modified.
- Disables only the affected write operations while keeping safe details and recovery information available.
- Opens Settings with key-management drawers collapsed while preserving normal in-session navigation state.
- Improves guidance for users with no saved matching profile and provides a visible Scan profiles action.
- Retains the retired TarkovTracker.io selector and migration guidance.

### `7407d56` - `bugfix(raw-logs): replay task history chronologically and in profile scope`

Author: Giribaldi_TTV

- Processes historical log folders and notifications from oldest to newest.
- Uses an isolated watcher so historical replay does not interfere with the active live watcher.
- Resolves the exact account, profile, and game mode represented by the selected log breakpoint.
- Requires a verified key assigned to that exact profile before sending task updates.
- Acquires a profile-scoped TarkovTracker lease instead of relying on ambient active-session state.
- Prevents historical replay while EFT is running.
- Stops before parsing or displaying task changes when no matching key is available.
- Restores watcher state and event subscriptions through guarded cleanup paths.
- Batches replay results so large histories remain bounded and readable.
- Keeps the resulting Dashboard messages in chronological order.

### `1664912` - `bugfix(settings): handle missing EFT profile identity`

Author: Giribaldi_TTV

- Replaces the false default PVP profile display with a neutral "No EFT profile detected" state.
- Prevents empty startup state from generating a broken Tarkov.dev player link.
- Avoids unnecessary player-name requests when no complete profile identity exists.
- Applies asynchronous profile-name results only when the same account, profile, and session mode remain active.
- Prevents stale names from appearing after a profile change.
- Applies the same guarded profile presentation to Settings and Read Past Logs.

### `ea9f3a3` - `bugfix(startup): stabilize first paint and window restoration`

Author: Giribaldi_TTV

- Upgrades persisted user settings before startup options are read.
- Allows the WebView and Blazor interface to render before watcher and update services begin.
- Coordinates the optional splash screen with the first completed UI paint.
- Preserves immediate startup when the splash screen is disabled.
- Prevents historical offline profile data from being announced as a newly confirmed live EFT session.
- Deduplicates session messages using the exact account, profile, and game mode identity.
- Prevents tracker-management refreshes from generating false session-confirmation messages.
- Improves minimize, restore, maximize, title-bar double-click, and drag-to-restore behavior.
- Recalculates the native frame after restore to remove the stale upper window inset.
- Preserves the previous restored bounds and responsive layout.

### `57a46fb` - `feat(ui): overhaul responsive settings and dropdown interactions`

Author: Giribaldi_TTV

- Reflows Settings into one, two, or three columns based on available width.
- Uses a denser masonry-style layout to reduce unused fullscreen space.
- Moves Language and Window behavior to predictable leading positions.
- Tightens card, row, banner, drawer, dialog, and control spacing without blurring section boundaries.
- Normalizes user-facing text throughout Settings, Sounds, Stats, Timers, and tracker dialogs.
- Adds a shared mid-dark dropdown design across all application dropdowns and menus.
- Constrains dropdowns to small windows while allowing long menus to expand on larger and fullscreen displays.
- Keeps dropdown positioning under MudBlazor while applying viewport-aware height limits.
- Supports reliable neutral-click, activator-toggle, and page-scroll dismissal.
- Preserves the exact native page-scroll delta when an open dropdown closes.
- Prevents dropdowns from detaching from their activators or jumping during responsive resizing.
- Removes persistent focus glow after pointer or scroll dismissal.
- Adds distinct keyboard navigation cues without changing committed selection styling.
- Standardizes selected-row fill, text contrast, borders, scrollbars, shadows, and child-dialog title colors.
- Improves Read Past Logs dialog structure and responsive behavior.
- Makes the Active profile label spacing explicit.
- Preserves minimum-window behavior and fullscreen dropdown expansion.

### `e9b70ee` - `merge(master): reconcile PR 212 with 2.0.5.0`

Author: Giribaldi_TTV

- Reconciles the UI and API-key work with the 2.0.5.0 base.
- Incorporates the diagnostics, watcher resilience, Steam-log recovery, future-mode parsing, missing-profile handling, Tarkov.dev response handling, player-lookup safeguards, and version changes from the current base.
- Resolves overlap across startup, watcher, tracker, Tarkov.dev, logging, socket, and diagnostics code.

### `7446f45` - `fix(tracker): harden profile activation and diagnostic reporting`

Author: Giribaldi_TTV

- Coalesces concurrent Tarkov.dev player-name lookups and guards cache insertion, preventing duplicate-key failures.
- Makes tracker activation latest-wins and shares repeated activation requests for the same account, profile, and mode.
- Classifies superseded activation cancellations as expected state changes instead of user-facing errors.
- Preserves inner exceptions and adds endpoint and duration metadata to diagnostics.
- Improves diagnostic redaction for numeric identifiers and separates player-lookup failures from background refresh failures.

### `216e90b` - `fix(ui): make session messages and assets deterministic`

Author: Giribaldi_TTV

- Makes tracker progress and Tarkov.dev messages identify the active EFT player, level/class, and session mode.
- Keeps the full tracker API key protected behind the existing hidden/reveal interaction.
- Changes localized guidance from ?set? to ?assign.?
- Reloads Tarkov.dev assets when the session mode changes.
- Cancels stale asset requests, clears superseded snapshots, and publishes complete asset sets atomically so Seasonal and Non-Seasonal PVP data cannot mix.
- Completes the follow-up for `TM-API-TARKOVDEV-002` and `TM-API-TRACKER-001`.

### `cc748f3` - `bump needed sdk version`

Author: Razzmatazz

- Updates the required .NET SDK from 10.0.302 to 10.0.400.
- Retains latest-patch roll-forward behavior for reproducible branch builds.

### `5d961e5` - `identify self on connect`

Author: Razzmatazz

- Adds the application identity and version as the WebSocket `Origin` header during connection.
- Allows the socket service to identify the connecting Tarkov Monitor client in addition to the existing `User-Agent`.

### `bf0a282` - `fix(watcher): treat missing EFT install as idle state`

Author: Giribaldi_TTV

- Treats a missing Escape from Tarkov installation or logs folder as a valid first-run state.
- Keeps the watcher dormant instead of throwing a startup exception.
- Allows Tarkov Monitor to remain usable when EFT is installed after Tarkov Monitor.

### `63d58f0` - `merge(master): apply current base fixes to PR 212`

Author: Giribaldi_TTV

- Reconciles PR #212 with the then-current `master`.
- Brings the current SDK and socket-identification base commits into the PR history.
- Adds no further product-tree changes beyond its first parent; it is a branch-reconciliation commit.

## Changelog

### User-visible changes

- Multiple verified TarkovTracker.org API keys can now be stored and managed.
- Keys are automatically selected using the active EFT account, profile, and game mode.
- PVE, PVP, and Seasonal keys are supported.
- Assigned and unassigned keys have dedicated management drawers.
- Account names and profile-key nicknames can be managed separately.
- Historical task progress is replayed chronologically and only for the selected profile.
- Settings now adapts across compact, normal, and fullscreen window sizes.
- Dropdowns and child dialogs share consistent styling and interaction behavior.
- Startup, splash, minimize, restore, maximize, and drag-to-restore behavior is smoother.
- Empty profile state and session messages are more accurate.
- Tarkov Monitor remains usable when EFT is not installed.
- Expected superseded tracker requests no longer surface as user-facing failures.
- Tarkov.dev assets reload when switching between PVE, Seasonal PVP, and Non-Seasonal PVP.
- Session and tracker messages identify the active player and session mode deterministically.
- Tracker API keys remain hidden unless intentionally revealed.

### Internal and technical changes

- Stores TarkovTracker.org keys, assignments, saved profiles, and nicknames together in a structured local settings record that can be safely upgraded when its format changes.
- Adds exact account/profile/mode request isolation.
- Adds guarded legacy recovery and malformed-store preservation.
- Adds profile-scoped historical update leases.
- Adds bounded and ordered Dashboard message batching.
- Adds viewport-aware dropdown constraints and owner-scoped dismissal handling.
- Adds latest-wins tracker activation with shared in-flight activation for duplicate profile notifications.
- Adds concurrent player-name lookup coalescing and guarded cache writes.
- Adds endpoint- and duration-aware diagnostics with expanded identifier redaction.
- Adds explicit handling for missing EFT installations and unavailable log folders.
- Adds WebSocket client identification through the `Origin` header.
- Requires the .NET 10.0.400 SDK for branch builds.

## Validation conducted

- Built the final branch using the bundled .NET 10.0.400 SDK with zero build errors.
- Restored the final `win-x64` runtime target successfully.
- Produced a fresh self-contained, single-file Windows publication with zero publish errors.
- Confirmed the published executable and required native dependencies were present.
- Confirmed the published `index.html` and `app.css` exactly matched the committed source.
- Confirmed the branch remained clean after build and publication.
- Reviewed the committed branch for accidental credentials and non-product artifacts.
- Exercised live and historical PVE, PVP, Seasonal, and unsupported future-mode parsing.
- Verified unsupported modes fail closed without retaining another mode's writable state.
- Exercised API key prefix handling, verified-mode matching, store migration, malformed-store rejection, and populated-store round trips.
- Exercised chronological log breakpoint discovery, exact-profile replay, ordered task batching, and bounded Dashboard messages.
- Exercised fresh-user storage with no imported keys or profiles.
- Exercised populated-user migration while preserving existing keys, bindings, accounts, profiles, and nicknames.
- Tested Settings at minimum, default, medium, maximized, and fullscreen dimensions.
- Confirmed one-, two-, and three-column layouts with no card overlap or horizontal overflow.
- Tested all Settings dropdowns for opening, internal scrolling, selection, keyboard navigation, neutral dismissal, activator dismissal, external page scrolling, focus release, responsive resizing, flipping, and fullscreen expansion.
- Tested key-management and Read Past Logs dialogs at compact and normal window sizes.
- Tested minimize, restore, maximize, title-bar restore, and previous-bounds restoration.
- Observed no Blazor error interface, unhandled runtime exception, repeated render failure, or dropdown interaction regression during the completed local validation matrix.

## Follow-up validation required for the reconciled head

The post-reconciliation fixes in `7446f45`, `216e90b`, and `bf0a282` should be revalidated at `63d58f0` before release:

- Duplicate player-name lookup protection and concurrent cache access.
- Superseded tracker activation and cancellation handling.
- Diagnostic redaction of numeric identifiers and endpoint/duration reporting.
- Startup with no EFT installation or logs folder.
- Session-mode asset reload, stale-request cancellation, and atomic snapshot publication.
- WebSocket connection identity headers.

## Author-reported live EFT client testing

The author tested the current branch runtime while actively using Escape from Tarkov over several weeks.

The reported live-use checks included:

- Starting Tarkov Monitor before EFT and allowing the active profile to be detected after EFT launched.
- Starting Tarkov Monitor after an EFT profile had already loaded.
- Detecting profile and session changes without requiring an application restart.
- Confirming the active account, profile, and game mode were represented correctly.
- Exercising PVE, PVP, and Seasonal profile recognition.
- Confirming the matching TarkovTracker.org key was selected for the active identity.
- Importing and verifying TarkovTracker.org keys.
- Exercising assignment, reassignment, swapping, unbinding, removal, account naming, and profile-key nickname workflows.
- Restarting Tarkov Monitor and confirming saved key-management state remained available.
- Confirming Settings drawers returned to their intended closed startup state.
- Confirming Tarkov.dev received the current map and session context.
- Reviewing Dashboard session, tracker, task, and protected-identifier messages.
- Confirming duplicate session messages and offline previous-session announcements no longer appeared during the tested workflow.
- Exercising Read Past Logs with a matching assigned key and reviewing chronological task results.
- Exercising compact, resized, maximized, minimized, restored, and fullscreen window states.
- Reviewing dropdowns, child dialogs, warnings, links, focus states, scrolling, and responsive card placement during normal use.
- Testing both splash-enabled and splash-disabled startup behavior.

A later beta-runtime test did report TM-API-TARKOVDEV-002 and TM-API-TRACKER-001 diagnostics during profile activation. The follow-up commits above address the duplicate player-lookup, superseded-activation, deterministic-message, and session-specific asset-reload paths.

The author reported no errors, unhandled exceptions, or functional issues during the earlier completed live-use period; that statement predates the later beta-runtime report and should not be read as coverage of the post-report fixes.

## Validation scope note

The live-client section records author-reported manual usage. It is separate from independently captured local validation. Exhaustive release validation across every possible EFT profile transition, production first-launch migration, network failure, and Seasonal endpoint-write condition remains part of the release process rather than this PR's automated evidence.

## Merge-order note

PR #211 and the 2.0.5.0 base changes were reconciled through `e9b70ee`. The final branch reconciliation at `63d58f0` also incorporates the current master commits `c9f7b4e` and `0cc5107`. No outstanding PR #211 merge-order action remains; the branch should only be rechecked if `master` advances again.





## Update for pushed head `5c541ce`

This section supersedes the earlier follow-up list for the reconciled head. Six focused commits were added to PR212 and pushed together as the reviewed correction set.

### `7756b28` ? `fix(security): protect profile-bound tracker tokens with DPAPI`

- Keeps the existing JSON settings container and migrates legacy plaintext tracker tokens during load.
- Stores new token values as user-scoped DPAPI-protected data with versioned recovery handling.
- Fails closed when the current Windows user cannot decrypt protected settings.
- Preserves exact account, profile, and session binding for verified TarkovTracker.org keys.
- Prevents prefix-only automatic binding and preserves manual-unbind suppression across reloads.

### `7664b14` ? `fix(settings): make tracker key assignment state explicit`

- Changes guidance from setting a token to assigning a token.
- Adds the clear `MANUAL ASSIGNMENT ONLY` state for keys intentionally unbound from their previous EFT account.
- Keeps assignment, reassignment, conflict, and removal flows explicit to the user.

### `2884169` ? `fix(tarkov.dev): make session data lifecycle identity-safe`

- Preloads read-only Tarkov.dev assets from the most recent complete profile recovered from EFT log history when a prior profile exists.
- Keeps tracker writes inactive until live EFT identity is available.
- Cancels stale asset requests, clears invalid or superseded snapshots, and publishes only the exact account/profile/session context.
- Refreshes replacement application logs through the profile-ready transition, stops updates on EFT exit, and keeps timer registration idempotent.

### `a2a524a` ? `fix(replay): isolate historical task catalogs and renderer work`

- Resolves historical task IDs through the selected session?s catalog.
- Moves large replay parsing and event processing away from the Blazor renderer.
- Preserves chronological, profile-scoped, immutable replay results.

### `8fbfa11` ? `fix(ui): reject expired message actions at execution time`

- Adds one-shot expiry notifications for Dashboard messages.
- Rechecks expiration when an action is clicked, including after confirmation dialogs.
- Prevents expired actions from remaining executable during the redraw interval.

### `5c541ce` ? `fix(startup): validate WebView2 before constructing UI`

- Runs WebView2 prerequisite repair before constructing the main WebView host.
- Covers normal, skip-splash, and minimized startup paths.
- Establishes the executable working directory before startup services begin.

## Regression and compatibility review

- Existing PR212 behavior for profile-bound keys, assignment persistence, responsive Settings, historical replay, deterministic session messaging, missing-EFT startup, and current-base diagnostics remains in the branch.
- Previously merged tracker endpoint, Seasonal verification, `.io` retirement, .NET 10, media-state, logs-folder, overlay, diagnostics, and timestamp-prefixed log handling were checked against the current base and remain present.
- Socket resilience remains outside this PR; no socket-resilience implementation was folded into these commits.
- Legacy profile-keyed `.org` upgrade behavior remains intentional: recovered records are unassigned until the user explicitly assigns them.

## Validation for pushed head

- `dotnet build TarkovMonitor.sln -c Release --no-restore`: passed with 0 errors and 186 existing project warnings.
- The same final source tree restored and published successfully as a self-contained `win-x64` single-file runtime with 0 publish errors.
- Profile/key smoke validation passed, including automatic first-account binding, persistence, cross-account separation, ambiguous-key manual fallback, unbind suppression, explicit reassignment, and protected JSON serialization.
- Protected-store probe passed, including binding persistence, unbind suppression, and same-profile non-rebinding.
- `git diff --check` passed before publication.
- No source token-shaped literals or non-product artifacts were included in the pushed commits.
- The author confirmed the live startup workflow now preloads Tarkov.dev assets from the previous session log without requiring EFT to be launched first.

## Remaining release boundary

The pushed branch is build- and focused-validation green. The remaining release gate is the organic live EFT matrix: PVE, Seasonal PVP, Non-Seasonal PVP, account switching, EFT shutdown, tracker writes, first-launch migration, and network failure behavior. These require normal user workflows rather than injected triggers.
