### PR TITLE
fix(watcher): find Steam EFT installs and recover from a missing logs path

### DIFF
--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -17,6 +17,10 @@ namespace TarkovMonitor
         private readonly FileSystemWatcher logFileCreateWatcher;
         private readonly FileSystemWatcher screenshotWatcher;
         private string _logsPath = "";
+        // Start() has run; log monitoring may still be waiting on a usable logs folder.
+        private bool watcherStarted = false;
+        // The log folder watcher is live and pointed at an existing folder.
+        private bool logWatcherStarted = false;
         public static Profile CurrentProfile { get; set; } = new();
         public static bool ReadingPastLogs = false;
         public bool InitialLogsRead { get; private set; } = false;
@@ -45,12 +49,32 @@ namespace TarkovMonitor
             set
             {
                 _logsPath = value;
-                if (logFileCreateWatcher.EnableRaisingEvents)
+                if (!watcherStarted)
                 {
-                    logFileCreateWatcher.Path = LogsPath;
-                    WatchLogsFolder(GetLatestLogFolder());
+                    return;
                 }
-
+                try
+                {
+                    if (!logWatcherStarted)
+                    {
+                        // Log monitoring was deferred because no usable folder was available at
+                        // startup; the new path may be the one we were waiting for.
+                        StartLogWatcher();
+                        return;
+                    }
+                    var logsPath = LogsPath;
+                    if (!Directory.Exists(logsPath))
+                    {
+                        ReportMissingLogsPath();
+                        return;
+                    }
+                    logFileCreateWatcher.Path = logsPath;
+                    WatchLatestLogFolder();
+                }
+                catch (Exception ex)
+                {
+                    ExceptionThrown?.Invoke(this, new ExceptionEventArgs(ex, "changing the logs folder"));
+                }
             }
         }
         public string CurrentLogsFolder {
@@ -116,35 +140,185 @@ namespace TarkovMonitor
         private static string logPatternPrefix = @"(?<date>^\d{4}-\d{2}-\d{2}) (?<time>\d{2}:\d{2}:\d{2}\.\d{3})(?<tzoffset> [+-]\d{2}:\d{2})?\|";
         private static string logPattern = @$"{logPatternPrefix}(?<message>.+$)\s*(?<json>^{{[\s\S]+?^}})?";
 
+        private const string SteamAppId = "3932890";
+        // Steam writes some of its keys through the 32-bit view (SOFTWARE\WOW6432Node\...), so every
+        // registry lookup below checks both views rather than assuming the process bitness.
+        private static readonly RegistryView[] RegistryViews = { RegistryView.Registry64, RegistryView.Registry32 };
+
+        /// <summary>
+        /// Locates the EFT logs folder, first from an uninstall registry entry and then by walking
+        /// the Steam libraries. Returns an empty string when no install can be found; callers treat
+        /// that as recoverable and let the user pick the folder manually in Settings.
+        /// </summary>
         public static string GetDefaultLogsFolder()
         {
-            string[] paths = {
-                @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov",
-                @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 3932890"
-            };
-            foreach (var path in paths)
+            var logsPath = GetRegistryLogsFolder();
+            if (logsPath != "")
             {
-                using RegistryKey? regKey = Registry.LocalMachine.OpenSubKey(path);
-                if (regKey == null)
+                return logsPath;
+            }
+            return GetSteamLogsFolder();
+        }
+
+        private static string GetRegistryLogsFolder()
+        {
+            string[] paths = {
+                @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\EscapeFromTarkov",
+                @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App " + SteamAppId
+            };
+            RegistryHive[] hives = { RegistryHive.LocalMachine, RegistryHive.CurrentUser };
+            foreach (var hive in hives)
+            {
+                foreach (var view in RegistryViews)
                 {
-                    continue;
-                }
-                var installPath = regKey.GetValue("InstallLocation")?.ToString();
-                if (installPath == null)
-                {
-                    continue;
-                }
-                var logsPath = Path.Combine(installPath, "Logs");
-                if (!Directory.Exists(logsPath))
-                {
-                    logsPath = Path.Combine(installPath, "build", "Logs");
-                }
-                if (Directory.Exists(logsPath))
-                {
-                    return logsPath;
+                    foreach (var path in paths)
+                    {
+                        // Steam often leaves InstallLocation blank or writes the key with no values
+                        // at all, so an entry that exists is not enough on its own.
+                        var installPath = ReadRegistryValue(hive, view, path, "InstallLocation");
+                        var logsPath = GetLogsFolderForInstall(installPath);
+                        if (logsPath != "")
+                        {
+                            return logsPath;
+                        }
+                    }
                 }
             }
-		    throw new Exception("No Tarkov install path found");
+            return "";
+        }
+
+        /// <summary>
+        /// Finds a Steam install of EFT by reading the app manifest in each Steam library, which
+        /// stays accurate for non-default libraries even when the uninstall entry has no path.
+        /// </summary>
+        private static string GetSteamLogsFolder()
+        {
+            foreach (var library in GetSteamLibraryFolders())
+            {
+                var steamApps = Path.Combine(library, "steamapps");
+                List<string> installDirs = new();
+                var manifestDir = GetSteamInstallDir(Path.Combine(steamApps, $"appmanifest_{SteamAppId}.acf"));
+                if (manifestDir != "")
+                {
+                    installDirs.Add(manifestDir);
+                }
+                // Fall back to the conventional folder name if the manifest is missing or unreadable.
+                installDirs.Add("Escape from Tarkov");
+                foreach (var installDir in installDirs)
+                {
+                    var logsPath = GetLogsFolderForInstall(Path.Combine(steamApps, "common", installDir));
+                    if (logsPath != "")
+                    {
+                        return logsPath;
+                    }
+                }
+            }
+            return "";
+        }
+
+        private static List<string> GetSteamLibraryFolders()
+        {
+            List<string> libraries = new();
+            var steamPath = GetSteamPath();
+            if (steamPath == "")
+            {
+                return libraries;
+            }
+            libraries.Add(steamPath);
+            var libraryFolders = Path.Combine(steamPath, "steamapps", "libraryfolders.vdf");
+            if (!File.Exists(libraryFolders))
+            {
+                return libraries;
+            }
+            try
+            {
+                foreach (Match match in Regex.Matches(File.ReadAllText(libraryFolders), @"""path""\s+""(?<path>[^""]+)"""))
+                {
+                    // Paths in a .vdf are backslash-escaped.
+                    var path = match.Groups["path"].Value.Replace(@"\\", @"\");
+                    if (path != "" && !libraries.Contains(path, StringComparer.OrdinalIgnoreCase))
+                    {
+                        libraries.Add(path);
+                    }
+                }
+            }
+            catch { }
+            return libraries;
+        }
+
+        private static string GetSteamInstallDir(string manifestPath)
+        {
+            if (!File.Exists(manifestPath))
+            {
+                return "";
+            }
+            try
+            {
+                var match = Regex.Match(File.ReadAllText(manifestPath), @"""installdir""\s+""(?<dir>[^""]+)""");
+                if (match.Success)
+                {
+                    return match.Groups["dir"].Value.Replace(@"\\", @"\");
+                }
+            }
+            catch { }
+            return "";
+        }
+
+        private static string GetSteamPath()
+        {
+            // HKCU stores SteamPath with forward slashes; HKLM\SOFTWARE\Valve is a 32-bit key.
+            (RegistryHive Hive, string Key, string Value)[] locations = {
+                (RegistryHive.CurrentUser, @"SOFTWARE\Valve\Steam", "SteamPath"),
+                (RegistryHive.LocalMachine, @"SOFTWARE\Valve\Steam", "InstallPath"),
+            };
+            foreach (var location in locations)
+            {
+                foreach (var view in RegistryViews)
+                {
+                    var path = ReadRegistryValue(location.Hive, view, location.Key, location.Value);
+                    if (path == "")
+                    {
+                        continue;
+                    }
+                    try
+                    {
+                        return Path.GetFullPath(path);
+                    }
+                    catch { }
+                }
+            }
+            return "";
+        }
+
+        private static string ReadRegistryValue(RegistryHive hive, RegistryView view, string key, string valueName)
+        {
+            try
+            {
+                using RegistryKey baseKey = RegistryKey.OpenBaseKey(hive, view);
+                using RegistryKey? regKey = baseKey.OpenSubKey(key);
+                return regKey?.GetValue(valueName)?.ToString() ?? "";
+            }
+            catch
+            {
+                return "";
+            }
+        }
+
+        private static string GetLogsFolderForInstall(string installPath)
+        {
+            if (string.IsNullOrEmpty(installPath))
+            {
+                return "";
+            }
+            string[] candidates = { Path.Combine(installPath, "Logs"), Path.Combine(installPath, "build", "Logs") };
+            foreach (var candidate in candidates)
+            {
+                if (Directory.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+            return "";
 		}
 
         public GameWatcher()
@@ -281,22 +455,58 @@ namespace TarkovMonitor
         {
 			try
 			{
-                logFileCreateWatcher.Path = LogsPath;
-                logFileCreateWatcher.Created += LogFileCreateWatcher_Created;
-				logFileCreateWatcher.EnableRaisingEvents = true;
+                watcherStarted = true;
 				processTimer.Elapsed += ProcessTimer_Elapsed;
 				UpdateProcess();
 				SetupScreenshotWatcher();
 				processTimer.Enabled = true;
-				if (Monitors.Count == 0)
-				{
-					WatchLogsFolder(GetLatestLogFolder());
-				}
+				StartLogWatcher();
 			}
 			catch (Exception ex)
 			{
                 ExceptionThrown?.Invoke(this, new(ex, "starting game watcher"));
 			}
+        }
+
+        /// <summary>
+        /// Brings up log monitoring for the current <see cref="LogsPath"/>. When no usable folder is
+        /// available this reports a single actionable message and leaves the process and screenshot
+        /// watchers running, so the user can recover by choosing a folder in Settings.
+        /// </summary>
+        private void StartLogWatcher()
+        {
+            var logsPath = LogsPath;
+            if (!Directory.Exists(logsPath))
+            {
+                ReportMissingLogsPath();
+                return;
+            }
+            logFileCreateWatcher.Path = logsPath;
+            logFileCreateWatcher.Created -= LogFileCreateWatcher_Created;
+            logFileCreateWatcher.Created += LogFileCreateWatcher_Created;
+            logFileCreateWatcher.EnableRaisingEvents = true;
+            logWatcherStarted = true;
+            if (Monitors.Count == 0)
+            {
+                WatchLatestLogFolder();
+            }
+        }
+
+        private void ReportMissingLogsPath()
+        {
+            ExceptionThrown?.Invoke(this, new(new Exception("Could not find the Escape from Tarkov logs folder. Choose it under Settings > Logs Folder to start monitoring."), "finding the logs folder"));
+        }
+
+        private void WatchLatestLogFolder()
+        {
+            var latestLogFolder = GetLatestLogFolder();
+            if (latestLogFolder == "")
+            {
+                // The logs folder exists but has no session folders yet; the create watcher picks
+                // up the next one EFT writes.
+                return;
+            }
+            WatchLogsFolder(latestLogFolder);
         }
 
         private void LogFileCreateWatcher_Created(object sender, FileSystemEventArgs e)
@@ -836,6 +1046,10 @@ namespace TarkovMonitor
         private string GetLatestLogFolder()
         {
             var logFolders = System.IO.Directory.GetDirectories(LogsPath);
+            if (logFolders.Length == 0)
+            {
+                return "";
+            }
             var latestDate = new DateTime(0);
             var latestLogFolder = logFolders.Last();
             foreach (var logFolder in logFolders)


### PR DESCRIPTION
Fixes #210.

## Root cause is not what the issue describes

The issue attributes the failure to the discovery code relying on "a single machine-wide Steam uninstall registry key". The key and the registry view are actually fine — the value inside it is not.

On a machine that reproduces the bug (EFT installed through Steam, no Battlestate launcher):

```
HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 3932890
  DisplayName     = [Escape from Tarkov]
  InstallLocation = []          <-- empty string, not absent
  UninstallString = ["C:\program files (x86)\steam\steam.exe" steam://uninstall/3932890]
```

`GetDefaultLogsFolder` guards with `if (installPath == null)`, which an empty string passes. Discovery then builds **relative** paths — `Path.Combine("", "Logs")` is `Logs`, and `Path.Combine("", "build", "Logs")` is `build\Logs` — which get probed against TarkovMonitor's working directory rather than against the install. Both miss, the loop exhausts, and it throws `No Tarkov install path found`.

This is not an edge case. On that same machine, 57 of 98 `Steam App *` uninstall entries have no usable `InstallLocation`: some are written with the value blank (Destiny 2 shows the identical pattern), others are empty keys with no values at all. The uninstall entry alone is not a reliable source for a Steam install, which is why this PR adds the Steam library walk the issue asks for.

Worth recording for anyone who reads the issue first: the registry **view** is not the problem. Steam writes these entries to the 64-bit view (98 entries under `Registry64`, 0 under `Registry32`), so the existing non-`WOW6432Node` path was correct. This PR still checks both views, because `HKLM\SOFTWARE\Valve\Steam` genuinely is a 32-bit key.

## The cascade after the throw

The reported second error is reproducible, and the ordering matters:

1. The `LogsPath` getter catches the throw, reports `getting logs path`, and returns `""`.
2. `logFileCreateWatcher.Path = ""` is a **silent no-op** — the setter short-circuits when the value equals the already-empty backing field, so nothing throws here.
3. `EnableRaisingEvents = true` then throws `FileNotFoundException: Error reading the  directory.`, which is the second message users see.

Because the throw lands on step 3 rather than step 1, the remainder of `Start()` never runs, so `processTimer` and `SetupScreenshotWatcher()` are silently skipped too — the process and screenshot watchers die alongside log monitoring.

It also leaves `EnableRaisingEvents` false, and the `LogsPath` setter only re-points the watcher `if (logFileCreateWatcher.EnableRaisingEvents)`. So after a failed startup, choosing a folder under Settings > Logs Folder writes the setting and does nothing else. Monitoring stays dead until the app is restarted, with no feedback that anything is still wrong.

## Changes

All in `GameWatcher.cs`.

**Discovery**

- `IsNullOrEmpty` guard on `InstallLocation`, so a blank value no longer produces relative path probes.
- New Steam fallback: resolve the Steam root from `Valve\Steam`, enumerate libraries from `libraryfolders.vdf`, and read `installdir` from `appmanifest_3932890.acf` in each. Falls back to the conventional `Escape from Tarkov` folder name when the manifest is missing. This is what makes non-default libraries work.
- Registry reads go through a helper that checks both the 32- and 64-bit views and swallows access errors.
- `GetDefaultLogsFolder` returns `""` instead of throwing. Both callers already handle an empty result; `Settings.razor` keeps its `try`/`catch` for genuine registry failures.

**Recoverable startup**

- `Start()` starts the process timer and screenshot watcher first, then calls `StartLogWatcher()`. A missing folder reports one actionable message (`Could not find the Escape from Tarkov logs folder. Choose it under Settings > Logs Folder to start monitoring.`) and leaves the rest of the app running. No empty path reaches `FileSystemWatcher`.

**Deferred startup completion**

- Explicit `watcherStarted` / `logWatcherStarted` flags replace the `EnableRaisingEvents` check. Setting `LogsPath` after a deferred start now completes startup, so the existing `customLogsPath` handler in `MainBlazorUI` recovers without a restart. `MainBlazorUI` itself is unchanged.
- `GetLatestLogFolder` called `logFolders.Last()` on a possibly-empty array; it now returns `""` for a logs folder with no session subfolders, and the caller lets the create-watcher pick up the next one EFT writes.

## Verification

Built against the pinned SDK (10.0.302): 0 errors, 230 warnings — identical to the master baseline.

Before/after on the reproducing machine, invoking the compiled `GetDefaultLogsFolder` and then replaying what `Start()` does with the result:

```
##### BEFORE (master) #####
THREW: Exception: No Tarkov install path found

##### AFTER (this branch) #####
RESULT: 'G:\SteamLibrary\steamapps\common\Escape from Tarkov\build\Logs'
WATCHER: started OK
```

That install is in a non-default Steam library with the `build\Logs` layout and no Battlestate registry key. Also exercised directly: library enumeration returns all four libraries from `libraryfolders.vdf`; manifest parsing returns the expected `installdir`; a missing manifest and a nonexistent install path both return empty without throwing; and both the `Logs` and `build\Logs` layouts resolve.

Existing Battlestate installs are unaffected — that registry branch is unchanged apart from the stricter empty-value guard, and it is still tried before any Steam lookup.

## Not addressed

- The `user.config` / missing `customLogsPath` node item from the issue. That concerns hand-editing and external scripts, not app behavior; the app reads the setting through the generated wrapper, which returns the default when the node is absent.
- Tests. There is no test project in the solution, and `GetDefaultLogsFolder` reaches the registry and filesystem through static calls, so making it testable needs seams that felt out of scope for a bugfix. Happy to do it as a follow-up if you want it.
- Deferring watcher startup until the shell is shown, which the issue also proposes. I could not reproduce the frozen-navigation symptom from this failure — the two messages involved are short, and `MessageLog` buffers into a list so constructor-time messages still render once the WebView loads. That symptom looks like #187 (an oversized message breaking the layout) rather than this bug, so I left `eft.Start()` where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
