### PR TITLE
Fix startup profile lookup and timestamp-prefixed EFT log detection

### DIFF
--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -136,7 +136,14 @@
                 <MudButton @onclick="OpenTrackerSettings" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("GetAToken")</MudButton>
                 <MudButton @onclick="TestToken" Disabled="@TestTokenButtonDisabled" Variant="Variant.Text" Color="Color.Info">@LocalizationService.GetString("TestToken")</MudButton>
                 <span>@LocalizationService.GetString("CurrentProfile"):</span>
-                <MudLink Href="@CurrentProfileUrl">@CurrentProfileName (@GameWatcher.CurrentProfile.Type)</MudLink>
+                @if (HasCurrentProfileRoute)
+                {
+                    <MudLink Href="@CurrentProfileUrl">@CurrentProfileName (@GameWatcher.CurrentProfile.Type)</MudLink>
+                }
+                else
+                {
+                    <span>No EFT profile detected.</span>
+                }
                 <MudTextField @bind-Value="@TarkovTrackerToken" Immediate="true" Label="@LocalizationService.GetString("APIToken")" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
             }
         </MudPaper>
@@ -205,7 +212,7 @@
         }
     }
 
-    private string currentProfileName = GameWatcher.CurrentProfile.AccountId;
+    private string currentProfileName = "";
     private string CurrentProfileName {
         get
         {
@@ -213,16 +220,42 @@
         }
     }
 
-    private Task UpdateProfileName()
+    private bool HasCurrentProfileRoute =>
+        !string.IsNullOrWhiteSpace(GameWatcher.CurrentProfile.Id)
+        && !string.IsNullOrWhiteSpace(GameWatcher.CurrentProfile.AccountId)
+        && GameWatcher.CurrentProfile.Type != ProfileType.Unknown;
+
+    private async Task UpdateProfileName()
     {
-        return TarkovDev.GetPlayerName(GameWatcher.CurrentProfile).ContinueWith(t =>
+        if (!HasCurrentProfileRoute)
         {
-            if (!t.IsCompletedSuccessfully)
-            {
-                return;
-            }
-            currentProfileName = t.Result;
-        });
+            currentProfileName = "";
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        var profile = new Profile
+        {
+            Id = GameWatcher.CurrentProfile.Id,
+            AccountId = GameWatcher.CurrentProfile.AccountId,
+            Type = GameWatcher.CurrentProfile.Type,
+        };
+        currentProfileName = profile.AccountId;
+        var profileName = await TarkovDev.GetPlayerName(profile);
+        if (HasCurrentProfileRoute
+            && string.Equals(GameWatcher.CurrentProfile.Id, profile.Id, StringComparison.Ordinal)
+            && string.Equals(GameWatcher.CurrentProfile.AccountId, profile.AccountId, StringComparison.Ordinal)
+            && GameWatcher.CurrentProfile.Type == profile.Type)
+        {
+            currentProfileName = profileName;
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async void OnProfileChanged(object? sender, ProfileEventArgs e)
+    {
+        await UpdateProfileName();
     }
 
     protected override void OnInitialized()
@@ -231,8 +264,9 @@
         PlaybackDevices = Sound.GetPlaybackDevices();
         AvailableLanguages = LocalizationService.GetAvailableLanguages();
         LocalizationService.LanguageChanged += OnLanguageChanged;
+        eft.ProfileChanged += OnProfileChanged;
         ResolveCustomLogsFolder();
-        UpdateProfileName();
+        _ = UpdateProfileName();
     }
 
     protected override void OnParametersSet()
@@ -252,6 +286,7 @@
     public void Dispose()
     {
         LocalizationService.LanguageChanged -= OnLanguageChanged;
+        eft.ProfileChanged -= OnProfileChanged;
     }
 
     private void OnLanguageChanged(object? sender, EventArgs e)
@@ -623,8 +658,9 @@
         "tarkovtracker.io",
         StringComparison.OrdinalIgnoreCase);
 
-    private string CurrentProfileUrl =>
-        $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}";
+    private string CurrentProfileUrl => HasCurrentProfileRoute
+        ? $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.Type.ToString().ToLower()}/{GameWatcher.CurrentProfile.AccountId}"
+        : "#";
 
     void TokenShowClick()
     {

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -1286,23 +1286,23 @@ namespace TarkovMonitor
         private static GameLogType? GetLogType(string path)
         {
             var filename = Path.GetFileName(path);
-            if (filename.Equals("application.log", StringComparison.OrdinalIgnoreCase)
-                || filename.Equals("application_000.log", StringComparison.OrdinalIgnoreCase))
+            if (filename.EndsWith("application.log", StringComparison.OrdinalIgnoreCase)
+                || filename.EndsWith("application_000.log", StringComparison.OrdinalIgnoreCase))
             {
                 return GameLogType.Application;
             }
-            if (filename.Equals("notifications.log", StringComparison.OrdinalIgnoreCase)
-                || filename.Equals("notifications_000.log", StringComparison.OrdinalIgnoreCase))
+            if (filename.EndsWith("notifications.log", StringComparison.OrdinalIgnoreCase)
+                || filename.EndsWith("notifications_000.log", StringComparison.OrdinalIgnoreCase))
             {
                 return GameLogType.Notifications;
             }
-            if (filename.Equals("output.log", StringComparison.OrdinalIgnoreCase)
-                || filename.Equals("output_000.log", StringComparison.OrdinalIgnoreCase))
+            if (filename.EndsWith("output.log", StringComparison.OrdinalIgnoreCase)
+                || filename.EndsWith("output_000.log", StringComparison.OrdinalIgnoreCase))
             {
                 return GameLogType.Output;
             }
-            if (filename.Equals("traces.log", StringComparison.OrdinalIgnoreCase)
-                || filename.Equals("traces_000.log", StringComparison.OrdinalIgnoreCase))
+            if (filename.EndsWith("traces.log", StringComparison.OrdinalIgnoreCase)
+                || filename.EndsWith("traces_000.log", StringComparison.OrdinalIgnoreCase))
             {
                 return GameLogType.Traces;
             }


### PR DESCRIPTION
## Summary

- Prevent player-profile lookups until a valid EFT profile identity is available.
- Avoid rendering broken tarkov.dev player links when no profile has been detected.
- Refresh the displayed player name when the active EFT profile changes.
- Restore detection of timestamp-prefixed EFT application, output, notification, and trace logs.
- Preserve the existing fail-closed behavior: tarkov.dev assets load for known profile modes, while `Unknown` modes remain blocked.

## Root cause

PR #211 changed EFT log classification to compare exact filenames. Current EFT logs include a timestamp prefix, for example:

`2026.08.11_7-37-02_1.1.0.1.46699 application_000.log`

Because that filename did not exactly equal `application_000.log`, the watcher ignored it. This prevented profile-mode detection, completion of the initial log read, and the subsequent tarkov.dev asset load.

Settings could also attempt a player-profile lookup before a valid profile ID and account ID were available, producing the “Player profile lookup failed” error.

## Validation

- Successfully published the Release build for `win-x64`.
- Verified matching against real timestamp-prefixed EFT logs.
- Confirmed unrelated backend and file-checker logs remain ignored.
- Manually launched and verified the combined runtime.
- Confirmed profile lookup, Settings responsiveness, and tarkov.dev asset loading.
