### PR TITLE
UI Overhaul Part 2

### DIFF
--- a/TarkovMonitor/Blazor/AppLayout.razor
+++ b/TarkovMonitor/Blazor/AppLayout.razor
@@ -15,7 +15,7 @@
 	<MudLayout>
 		<MudAppBar Class="window-app-bar" Elevation="1" Bottom="false" Dense="true">
 			<MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer"/>
-			<span class="window-page-title">@CurrentPageTitle</span>
+			<span class="window-page-title" @onmousedown="BeginWindowDrag" @onmousedown:preventDefault="true">@CurrentPageTitle</span>
 			<div class="window-drag-region" @onmousedown="BeginWindowDrag">
 				<span class="window-product-title">@LocalizationService.GetString("TarkovMonitor")</span>
 			</div>

--- a/TarkovMonitor/Blazor/AppLayout.razor.css
+++ b/TarkovMonitor/Blazor/AppLayout.razor.css
@@ -8,9 +8,6 @@
     padding-top: 8px !important;
     overflow-x: hidden;
     overflow-y: auto;
-    scrollbar-color: auto;
-    scrollbar-gutter: stable;
-    scrollbar-width: auto;
 }
 
 ::deep .app-main-content--restored {
@@ -66,24 +63,26 @@
     min-width: 0;
     margin-left: 4px;
     overflow: hidden;
-    pointer-events: none;
+    pointer-events: auto;
     text-overflow: ellipsis;
     transform: translateY(1px);
     white-space: nowrap;
 }
 
 .window-product-title {
-    position: absolute;
+	align-items: center;
+	display: inline-flex;
+	position: absolute;
     left: 50%;
     overflow: hidden;
     color: #ffffff;
     font-size: 1rem;
     font-weight: 600;
     letter-spacing: 0.025em;
-    pointer-events: none;
+    pointer-events: auto;
     text-overflow: ellipsis;
     transform: translateX(-50%);
-    white-space: nowrap;
+	white-space: nowrap;
 }
 
 .window-controls {
@@ -101,12 +100,13 @@
 ::deep .navigation-drawer {
     top: 0 !important;
     height: 100vh !important;
+    width: 175px !important;
     z-index: 1300;
     border-right: 1px solid rgba(169, 154, 107, 0.32);
 }
 
 ::deep .navigation-drawer-header {
-    min-height: 96px;
+    min-height: 48px;
     padding: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
@@ -114,10 +114,10 @@
 .navigation-brand {
     display: flex;
     align-items: center;
-    gap: 8px;
+    position: relative;
     width: 100%;
-    min-height: 96px;
-    padding: 14px 10px 14px 18px;
+    min-height: 48px;
+    padding: 4px 0 4px 10px;
     border: 0;
     color: inherit;
     background: transparent;
@@ -133,12 +133,13 @@
 .navigation-brand-logo {
     display: block;
     width: 100%;
-    max-width: 198px;
+    max-width: 140px;
     height: auto;
 }
 
 ::deep .drawer-collapse-cue {
-    flex: 0 0 auto;
+    position: absolute;
+    right: 0;
     color: rgba(255, 255, 255, 0.60);
 }
 

--- a/TarkovMonitor/Blazor/Components/MessageBoard.razor
+++ b/TarkovMonitor/Blazor/Components/MessageBoard.razor
@@ -9,7 +9,7 @@
 @inject ISnackbar Snackbar
 @inject NavigationManager NavManager
 <MudPaper Class="app-surface dashboard-notification-surface" Elevation="3">
-<MudStack Reverse="true" Justify="Justify.FlexStart" AlignItems="AlignItems.Center" Class="pa-3">
+<MudStack Reverse="true" Justify="Justify.FlexEnd" AlignItems="AlignItems.Center" Class="pa-3 dashboard-message-stack">
     @if (messages.Count == 0)
     {
         <MudAlert Severity="Severity.Info">@LocalizationService.GetString("ThereArentAnyMessagesYet")</MudAlert>
@@ -18,8 +18,8 @@
         {
             <div class="dashboard-message">
                 <div class="d-block dashboard-message__paper">
-                    <MudPaper Class="align-center py-2 px-3 mud-theme-secondary dashboard-message__paper" Elevation="3">
-                        <div class="d-flex align-start dashboard-message__row">
+                    <MudPaper Class="@GetMessagePaperClass(message)" Elevation="3">
+                        <div class="d-flex align-center dashboard-message__row">
                             <MudIcon Icon="@GetTypeIcon(message.Type)" Title="@GetTypeTitle(message.Type)" Class="mr-2"/>
                             <div class="dashboard-message__content">
                                 @if (string.IsNullOrWhiteSpace(message.LinkText))
@@ -213,6 +213,15 @@
     {
         if (url.Length == 0) return ""; 
         return "cursor: pointer; text-decoration: underline;";
+    }
+
+    private static string GetMessagePaperClass(MonitorMessage message)
+    {
+        var actionClass = message.Buttons.Count > 0 || message.Selects.Count > 0
+            ? "dashboard-message__paper--with-actions"
+            : "dashboard-message__paper--text-only";
+
+        return $"align-center py-2 px-3 mud-theme-secondary dashboard-message__paper {actionClass}";
     }
 
     private void OpenURL(string url)

--- a/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
+++ b/TarkovMonitor/Blazor/Pages/RawLogs/ForceReadDialog.razor
@@ -8,14 +8,14 @@
 <MudDialog Class="tm-dialog-shell tm-dialog-shell--read-past" TitleClass="tm-dialog-title" ContentClass="tm-dialog-content tm-dialog-content--read-past" ActionsClass="tm-dialog-actions">
     <DialogContent>
         <MudText>
-            @LocalizationService.GetString("CurrentProfile"):
-            @if (HasCurrentProfileRoute)
+            @LocalizationService.GetString("LastProfileLoaded"):
+            @if (HasLastLoadedProfileRoute)
             {
-                <MudLink Class="tm-profile-link" Href="@CurrentProfileUrl">@CurrentProfileName (@GetProfileTypeDisplayName(GameWatcher.CurrentProfile.Type))</MudLink>
+                <MudLink Class="tm-profile-link" Href="@LastLoadedProfileUrl">@LastProfileName (@GetProfileTypeDisplayName(LastLoadedProfileType))</MudLink>
             }
             else
             {
-                <span>No EFT profile detected.</span>
+                <span>No EFT profile loaded.</span>
             }
         </MudText>
         <MudText>
@@ -84,37 +84,39 @@
     bool SubmitDisabled { get; set; } = true;
     bool IsProcessing { get; set; }
 
-    private string currentProfileName = GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
-        ? GameWatcher.CurrentProfile.AccountId
+    private string lastProfileName = TarkovDev.LastLoadedProfile?.AccountId
+        ?? "";
+    private Profile? LastLoadedProfile => TarkovDev.LastLoadedProfile;
+    private ProfileType LastLoadedProfileType => LastLoadedProfile?.Type ?? ProfileType.Unknown;
+    private string LastProfileName => lastProfileName;
+    private bool HasLastLoadedProfileRoute => LastLoadedProfile?.HasTarkovDevPlayerRoute == true;
+    private string LastLoadedProfileUrl => HasLastLoadedProfileRoute
+        ? $"https://tarkov.dev/players/{LastLoadedProfile!.TarkovDevPlayerMode}/{LastLoadedProfile.AccountId}"
         : "";
-    private bool HasCurrentProfileRoute => GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute;
-    private string CurrentProfileUrl => HasCurrentProfileRoute
-        ? $"https://tarkov.dev/players/{GameWatcher.CurrentProfile.TarkovDevPlayerMode}/{GameWatcher.CurrentProfile.AccountId}"
-        : "";
-    private string CurrentProfileName
+
+    private static bool ProfilesMatch(Profile left, Profile right)
     {
-        get
-        {
-            return currentProfileName;
-        }
+        return left.Type == right.Type
+            && left.SessionMode == right.SessionMode
+            && string.Equals(left.AccountId, right.AccountId, StringComparison.Ordinal)
+            && string.Equals(left.Id, right.Id, StringComparison.Ordinal);
     }
+
     private async Task UpdateProfileName()
     {
-        var profile = GameWatcher.CurrentProfile.Snapshot();
-        if (!profile.HasTarkovDevPlayerRoute)
+        var profile = TarkovDev.LastLoadedProfile;
+        if (profile == null || !profile.HasTarkovDevPlayerRoute)
         {
-            currentProfileName = "";
+            lastProfileName = "";
             return;
         }
 
-        currentProfileName = profile.AccountId;
+        lastProfileName = profile.AccountId;
         var profileName = await TarkovDev.GetPlayerName(profile);
-        if (GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
-            && string.Equals(GameWatcher.CurrentProfile.AccountId, profile.AccountId, StringComparison.Ordinal)
-            && string.Equals(GameWatcher.CurrentProfile.Id, profile.Id, StringComparison.Ordinal)
-            && GameWatcher.CurrentProfile.SessionMode == profile.SessionMode)
+        var latestProfile = TarkovDev.LastLoadedProfile;
+        if (latestProfile != null && ProfilesMatch(latestProfile, profile))
         {
-            currentProfileName = profileName;
+            lastProfileName = profileName;
         }
     }
 
@@ -124,12 +126,22 @@
         Task.Run(GetBreakPoints);
         _ = UpdateProfileName();
 
+        TarkovDev.ApiDataLoaded += OnTarkovDevDataLoaded;
         Properties.Settings.Default.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    private void OnTarkovDevDataLoaded(object? sender, EventArgs e)
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await UpdateProfileName();
+            StateHasChanged();
+        });
     }
 
     private void GetBreakPoints()
     {
-        breakpoints = customWatcher.GetLogBreakpoints(GameWatcher.CurrentProfile.Id);
+        breakpoints = customWatcher.GetLogBreakpoints();
         InvokeAsync(() => StateHasChanged());
     }
 
@@ -341,6 +353,7 @@
 
     public void Dispose()
     {
+        TarkovDev.ApiDataLoaded -= OnTarkovDevDataLoaded;
         Properties.Settings.Default.PropertyChanged -= Settings_PropertyChanged;
     }
 }

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -144,7 +144,6 @@
                 {
                     <span>No EFT profile detected.</span>
                 }
-                <MudText Typo="Typo.body2" Class="tracker-key-intro">Add a TarkovTracker.org API key. Tarkov Monitor verifies the key and its game mode before it can be assigned to an EFT profile.</MudText>
                 @foreach (var warning in TrackerStorageWarnings)
                 {
                     <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">@warning</MudAlert>
@@ -346,7 +345,7 @@
     <MudItem xs="12" lg="6" xl="4">
         <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
             <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.SettingsRemote" Class="mr-2" /><span class="tm-card-heading-text">@TarkovDevWebsiteRemoteTitle</span></MudText>
-            <MudTextField @bind-Value="@RemoteID" MaxLength="4" Label="@LocalizationService.GetString("RemoteID")" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.ContentPaste" OnAdornmentClick="PasteRemoteClick"></MudTextField>
+            <MudTextField @bind-Value="@RemoteID" MaxLength="4" Label="@LocalizationService.GetString("RemoteID")" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.ContentPaste" OnAdornmentClick="PasteRemoteClick" Class="tm-input tm-input--full"></MudTextField>
             <div>
                 <MudSwitch @bind-Value="@NavigateMapSwitch" Label="@LocalizationService.GetString("SwitchToTarkovDevMapOnRaidLoad")" Color="Color.Info" />
             </div>
@@ -421,6 +420,12 @@
     private string currentProfileName = GameWatcher.CurrentProfile.HasTarkovDevPlayerRoute
         ? GameWatcher.CurrentProfile.AccountId
         : "";
+    private string CurrentProfileName {
+        get
+        {
+            return currentProfileName;
+        }
+    }
 
     private RenderFragment TarkovDevWebsiteRemoteTitle => builder =>
     {
@@ -447,13 +452,6 @@
         builder.AddContent(sequence++, title[(linkStart + linkText.Length)..].TrimStart());
         builder.CloseElement();
     };
-    private string CurrentProfileName {
-        get
-        {
-            return currentProfileName;
-        }
-    }
-
     private static string GetProfileTypeDisplayName(ProfileType profileType) => profileType switch
     {
         ProfileType.PVE => "PVE",

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor.css
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor.css
@@ -225,7 +225,7 @@
     bottom: 0;
     left: 0;
     width: 2px;
-    background: linear-gradient(180deg, #78aefb, rgba(139, 92, 246, 0.55));
+    background: linear-gradient(180deg, #78aefb, rgba(194, 178, 126, 0.55));
     content: "";
     opacity: 0.58;
     pointer-events: none;
@@ -377,9 +377,9 @@
 }
 
 .tracker-mode-badge--seasonal {
-    border-color: rgba(212, 148, 255, 0.46);
-    color: #deb0ff;
-    background: rgba(139, 74, 180, 0.16);
+    border-color: rgba(194, 178, 126, 0.46);
+    color: #d7c996;
+    background: rgba(152, 138, 102, 0.16);
 }
 
 .tracker-mode-badge--unknown {

--- a/TarkovMonitor/GameWatcher.cs
+++ b/TarkovMonitor/GameWatcher.cs
@@ -1202,22 +1202,14 @@ namespace TarkovMonitor
                 .ToList();
         }
 
-        public List<LogDetails> GetLogBreakpoints(string profileId)
+        public List<LogDetails> GetLogBreakpoints()
         {
             List<LogDetails> breakpoints = new();
-            if (profileId == "")
-            {
-                return breakpoints;
-            }
             foreach (var kvp in GetLogFolders().OrderBy(key => key.Key).ToDictionary(x => x.Key, x => x.Value))
             {
                 List<LogDetails> folderBreakpoints = GetLogDetails(kvp.Value);
                 foreach(var breakpoint in folderBreakpoints)
                 {
-                    if (breakpoint.Profile.Id != profileId)
-                    {
-                        continue;
-                    }
                     var matchingBreakpoint = breakpoints.Where((bp) => bp.Version == breakpoint.Version
                         && bp.Profile.Id == breakpoint.Profile.Id
                         && bp.Profile.SessionMode == breakpoint.Profile.SessionMode).FirstOrDefault();

--- a/TarkovMonitor/MainBlazorUI.Designer.cs
+++ b/TarkovMonitor/MainBlazorUI.Designer.cs
@@ -79,7 +79,7 @@
             FormBorderStyle = FormBorderStyle.None;
             Icon = (Icon)resources.GetObject("$this.Icon");
             Margin = new Padding(3, 4, 3, 4);
-            MinimumSize = new Size(720, 480);
+            MinimumSize = new Size(450, 250);
             Name = "MainBlazorUI";
             Padding = new Padding(1);
             Text = "Tarkov Monitor";

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -17,10 +17,14 @@ namespace TarkovMonitor
     {
         private const int WmNcHitTest = 0x0084;
         private const int WmNcCalcSize = 0x0083;
+        private const int WmNcPaint = 0x0085;
+        private const int WmNcActivate = 0x0086;
         private const int WmNcLButtonDown = 0x00A1;
         private const int HtCaption = 0x0002;
         private const int HtClient = 0x0001;
         private const int ResizeBorderWidth = 4;
+        private const int MinimumWindowWidth = 450;
+        private const int MinimumWindowHeight = 250;
         private const int WsThickFrame = 0x00040000;
         private const int WsMinimizeBox = 0x00020000;
         private const int WsMaximizeBox = 0x00010000;
@@ -33,6 +37,7 @@ namespace TarkovMonitor
         private const int DwmBorderColor = 34;
         private const int DwmCaptionColor = 35;
         private const int DwmRound = 2;
+        private const int DwmColorNone = unchecked((int)0xFFFFFFFE);
         private const int TarkovBorderColor = 0x003B555F;
         private const int TarkovHeaderColor = 0x002D2F2F;
 
@@ -82,6 +87,7 @@ namespace TarkovMonitor
         private readonly object trackerSessionNoticeLock = new();
         private long trackerSessionNoticeGeneration;
         private TrackerSessionNoticeIdentity? lastAnnouncedTrackerSession;
+        private int noActiveEftSessionNoticePublished;
         private readonly object tarkovDevDataRefreshLock = new();
         private CancellationTokenSource? tarkovDevDataRefreshCancellation;
         private long tarkovDevDataRefreshGeneration;
@@ -188,14 +194,18 @@ namespace TarkovMonitor
             {
                 if (!e.Profile.HasTarkovDevPlayerRoute)
                 {
+                    PublishNoActiveEftSessionNotice();
                     TarkovTracker.ResetActiveState();
                     TarkovDev.StopAutoUpdates();
-                    InvalidateTarkovDevData();
+                    // EFT can be running at "Select Profile and Mode" while the
+                    // watcher has not recovered a player route yet. Preserve the
+                    // read-only Tarkov.dev preload until a real profile is selected.
                     return;
                 }
 
                 if (!eft.IsGameRunning)
                 {
+                    PublishNoActiveEftSessionNotice();
                     // The startup scan is historical, not a live EFT session.
                     // It may still establish the read-only Tarkov.dev context so
                     // the user does not need to launch EFT just to verify the
@@ -206,6 +216,7 @@ namespace TarkovMonitor
                     return;
                 }
 
+                MarkEftSessionRecognized();
                 // Load the data set for the exact EFT session mode detected by
                 // the watcher. A later mode switch starts a new generation and
                 // invalidates this load before it can publish stale assets.
@@ -264,6 +275,12 @@ namespace TarkovMonitor
         }
 
         public bool IsMaximized => WindowState == FormWindowState.Maximized;
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            MinimumSize = new System.Drawing.Size(MinimumWindowWidth, MinimumWindowHeight);
+        }
 
         public void MinimizeWindow() => WindowState = FormWindowState.Minimized;
 
@@ -356,6 +373,11 @@ namespace TarkovMonitor
             {
                 Activate();
             }
+
+            // DWM can recreate the native frame when the hidden host is
+            // revealed. Reapply the state-aware color after that transition
+            // so the temporary white frame is not left behind.
+            BeginInvoke(new Action(ApplyWindowFrameAttributes));
         }
 
         public void BeginWindowDrag()
@@ -376,6 +398,29 @@ namespace TarkovMonitor
                 SwpNoSize | SwpNoMove | SwpNoZOrder | SwpNoActivate | SwpFrameChanged);
         }
 
+        private void ApplyWindowFrameAttributes()
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            var cornerPreference = DwmRound;
+            DwmSetWindowAttribute(Handle, DwmWindowCornerPreference, ref cornerPreference, sizeof(int));
+
+            // Keep the accepted gold frame around restored windows while
+            // suppressing the native frame only for maximized windows.
+            // WS_THICKFRAME remains enabled for Windows snap/resize behavior;
+            // WM_NCACTIVATE below prevents it from being repainted white.
+            var borderColor = WindowState == FormWindowState.Maximized
+                ? DwmColorNone
+                : TarkovBorderColor;
+            DwmSetWindowAttribute(Handle, DwmBorderColor, ref borderColor, sizeof(int));
+
+            var captionColor = TarkovHeaderColor;
+            DwmSetWindowAttribute(Handle, DwmCaptionColor, ref captionColor, sizeof(int));
+        }
+
         public void BeginWindowResize(int hitTest)
         {
             if (WindowState != FormWindowState.Normal || !IsResizeHit(hitTest))
@@ -390,20 +435,34 @@ namespace TarkovMonitor
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-
-            var cornerPreference = DwmRound;
-            DwmSetWindowAttribute(Handle, DwmWindowCornerPreference, ref cornerPreference, sizeof(int));
-
-            var borderColor = TarkovBorderColor;
-            DwmSetWindowAttribute(Handle, DwmBorderColor, ref borderColor, sizeof(int));
-
-            var captionColor = TarkovHeaderColor;
-            DwmSetWindowAttribute(Handle, DwmCaptionColor, ref captionColor, sizeof(int));
+            // Apply the borderless client frame immediately. Without an
+            // initial SWP_FRAMECHANGED, DWM can keep the standard resize
+            // frame until the first mouse hit-test or window-state change.
+            RefreshNormalWindowFrame();
+            ApplyWindowFrameAttributes();
         }
 
         protected override void WndProc(ref Message message)
         {
-            if (message.Msg == WmNcCalcSize && message.WParam != IntPtr.Zero && WindowState == FormWindowState.Normal)
+            if (message.Msg == WmNcPaint)
+            {
+                // The client area is the complete custom frame. Do not let
+                // DefWindowProc paint the native resize border over it.
+                message.Result = IntPtr.Zero;
+                return;
+            }
+
+            if (message.Msg == WmNcActivate)
+            {
+                // DefWindowProc repaints the native non-client frame during
+                // activation. Keep activation state while preventing that
+                // repaint from restoring the white resize border.
+                ApplyWindowFrameAttributes();
+                message.Result = (IntPtr)1;
+                return;
+            }
+
+            if (message.Msg == WmNcCalcSize && message.WParam != IntPtr.Zero)
             {
                 message.Result = IntPtr.Zero;
                 return;
@@ -483,35 +542,66 @@ namespace TarkovMonitor
         private void Eft_ProfileChanged(object? sender, ProfileEventArgs e)
         {
             var profileSnapshot = e.Profile.Snapshot();
-            _ = RefreshTarkovDevApiData(profileSnapshot);
+            if (profileSnapshot.HasTarkovDevPlayerRoute && eft.IsGameRunning)
+            {
+                MarkEftSessionRecognized();
+            }
+            else
+            {
+                PublishNoActiveEftSessionNotice();
+            }
+            if (profileSnapshot.HasTarkovDevPlayerRoute)
+            {
+                _ = RefreshTarkovDevApiData(profileSnapshot, allowPersistedProfile: !eft.IsGameRunning);
+            }
             if (profileSnapshot.HasTarkovDevPlayerRoute && eft.IsGameRunning)
             {
                 TarkovDev.StartAutoUpdates();
+                _ = InitializeProgress(profileSnapshot, announceSession: true);
             }
             else
             {
                 TarkovDev.StopAutoUpdates();
+                if (!eft.IsGameRunning)
+                {
+                    TarkovTracker.DeactivateProfile();
+                }
             }
-            _ = InitializeProgress(profileSnapshot, announceSession: true);
         }
 
         private void Eft_ProfileReady(object? sender, ProfileEventArgs e)
         {
             var profileSnapshot = e.Profile.Snapshot();
-            _ = RefreshTarkovDevApiData(profileSnapshot);
+            if (profileSnapshot.HasTarkovDevPlayerRoute && eft.IsGameRunning)
+            {
+                MarkEftSessionRecognized();
+            }
+            else
+            {
+                PublishNoActiveEftSessionNotice();
+            }
+            if (profileSnapshot.HasTarkovDevPlayerRoute)
+            {
+                _ = RefreshTarkovDevApiData(profileSnapshot, allowPersistedProfile: !eft.IsGameRunning);
+            }
             if (profileSnapshot.HasTarkovDevPlayerRoute && eft.IsGameRunning)
             {
                 TarkovDev.StartAutoUpdates();
+                _ = InitializeProgress(profileSnapshot, announceSession: true);
             }
             else
             {
                 TarkovDev.StopAutoUpdates();
+                if (!eft.IsGameRunning)
+                {
+                    TarkovTracker.DeactivateProfile();
+                }
             }
-            _ = InitializeProgress(profileSnapshot, announceSession: true);
         }
 
         private void Eft_GameStopped(object? sender, EventArgs e)
         {
+            PublishNoActiveEftSessionNotice();
             TarkovTracker.DeactivateProfile();
             TarkovDev.StopAutoUpdates();
             InvalidateTarkovDevData();
@@ -656,6 +746,11 @@ namespace TarkovMonitor
         {
             base.OnShown(e);
 
+            // DWM can recreate the native frame while the hidden host is
+            // being shown. Reapply the state-aware color after that transition
+            // so the temporary white frame is not left behind.
+            BeginInvoke(new Action(ApplyWindowFrameAttributes));
+
             var startedUtc = DateTime.UtcNow;
             try
             {
@@ -696,6 +791,10 @@ namespace TarkovMonitor
                     _ = RefreshTarkovDevApiData(lastKnownProfile, allowPersistedProfile: true);
                 }
                 gameWatcherStarted = eft.Start();
+                if (!eft.IsGameRunning)
+                {
+                    PublishNoActiveEftSessionNotice();
+                }
             }
             catch (Exception ex)
             {
@@ -953,7 +1052,6 @@ namespace TarkovMonitor
 
             CancellationTokenSource refreshCancellation;
             long refreshGeneration;
-            Profile? previousProfile;
             lock (tarkovDevDataRefreshLock)
             {
                 if (tarkovDevDataProfile != null
@@ -968,15 +1066,8 @@ namespace TarkovMonitor
                 tarkovDevDataRefreshCancellation?.Cancel();
                 refreshCancellation = new CancellationTokenSource();
                 tarkovDevDataRefreshCancellation = refreshCancellation;
-                previousProfile = tarkovDevDataProfile;
                 tarkovDevDataProfile = profileSnapshot;
 
-                if (previousProfile == null
-                    || !ProfilesMatch(previousProfile, profileSnapshot)
-                    || TarkovDev.LoadedProfileType != profileSnapshot.Type)
-                {
-                    TarkovDev.ClearApiData();
-                }
             }
 
             var published = false;
@@ -992,8 +1083,16 @@ namespace TarkovMonitor
                         return;
                     }
 
-                    TarkovDev.PublishApiData(data);
+                    TarkovDev.PublishApiData(data, profileSnapshot);
                     published = true;
+                }
+
+                if (eft.IsGameRunning && !allowPersistedProfile)
+                {
+                    // Delay only the current-session Tarkov.dev notification so
+                    // the session/progress messages can appear first. Do not
+                    // delay startup preload or change callback sequencing.
+                    await Task.Delay(TimeSpan.FromMilliseconds(1000), refreshCancellation.Token);
                 }
 
                 messageLog.AddMessage(
@@ -1061,7 +1160,23 @@ namespace TarkovMonitor
         {
             if (eft.IsGameRunning)
             {
-                return IsCurrentProfile(expectedProfile);
+                if (IsCurrentProfile(expectedProfile))
+                {
+                    return true;
+                }
+
+                // While EFT is waiting at profile selection, there is no live
+                // player route to own the refresh. Permit only the persisted
+                // read-only preload; a selected live profile must supersede it.
+                if (!allowPersistedProfile
+                    || GameWatcher.CurrentProfile.Snapshot().HasTarkovDevPlayerRoute)
+                {
+                    return false;
+                }
+
+                var waitingProfile = TarkovTracker.GetLastKnownOrgProfile();
+                return waitingProfile != null
+                    && ProfilesMatch(waitingProfile, expectedProfile);
             }
 
             if (!allowPersistedProfile)
@@ -1089,8 +1204,22 @@ namespace TarkovMonitor
                 tarkovDevDataRefreshCancellation?.Cancel();
                 tarkovDevDataRefreshCancellation = null;
                 tarkovDevDataProfile = null;
-                TarkovDev.ClearApiData();
             }
+        }
+
+        private void PublishNoActiveEftSessionNotice()
+        {
+            if (Interlocked.Exchange(ref noActiveEftSessionNoticePublished, 1) == 0)
+            {
+                messageLog.AddMessage(
+                    localizationService.GetString("NoActiveEftSessionRecognized"),
+                    "info");
+            }
+        }
+
+        private void MarkEftSessionRecognized()
+        {
+            Volatile.Write(ref noActiveEftSessionNoticePublished, 0);
         }
 
         private async Task InitializeProgress(Profile? profile = null, bool announceSession = true)
@@ -1150,7 +1279,7 @@ namespace TarkovMonitor
             }
 
             messageLog.AddProtectedMessage(
-                $"EFT session confirmed - Session: {TarkovTracker.GetSessionDisplayName(profileSnapshot.SessionMode)}.",
+                $"EFT session confirmed: {TarkovTracker.GetSessionDisplayName(profileSnapshot.SessionMode)}.",
                 "info",
                 new[]
                 {
@@ -1602,9 +1731,10 @@ namespace TarkovMonitor
                     var nextWindowState = WindowState;
                     lastPublishedWindowState = nextWindowState;
 
-                    if (previousWindowState == FormWindowState.Maximized && nextWindowState == FormWindowState.Normal)
+                    if (previousWindowState != nextWindowState)
                     {
                         RefreshNormalWindowFrame();
+                        ApplyWindowFrameAttributes();
                     }
 
                     WindowStateChanged?.Invoke(this, EventArgs.Empty);

--- a/TarkovMonitor/Program.cs
+++ b/TarkovMonitor/Program.cs
@@ -6,7 +6,7 @@ namespace TarkovMonitor
         ///  The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+		static void Main()
         {
             var diagnostics = new DiagnosticsService();
             Application.ThreadException += (_, args) => diagnostics.Capture(
@@ -58,7 +58,9 @@ namespace TarkovMonitor
 			// both modes. Skip mode has no branding window, but it should still
 			// reveal the finished UI instead of exposing the temporary WebView
 			// startup shell.
-			var mainWindow = new MainBlazorUI(holdUntilSplashCompletes: true, diagnosticsService: diagnostics)
+			var mainWindow = new MainBlazorUI(
+				holdUntilSplashCompletes: true,
+				diagnosticsService: diagnostics)
 			{
 				ShowInTaskbar = false
 			};
@@ -107,5 +109,6 @@ namespace TarkovMonitor
 
 			Application.Run(mainWindow);
         }
+
     }
 }

--- a/TarkovMonitor/Properties/Strings.resx
+++ b/TarkovMonitor/Properties/Strings.resx
@@ -315,6 +315,12 @@
   <data name="CurrentProfile" xml:space="preserve">
     <value>Active profile</value>
   </data>
+    <data name="LastProfileLoaded" xml:space="preserve">
+      <value>Last/Current Profile</value>
+    </data>
+  <data name="NoActiveEftSessionRecognized" xml:space="preserve">
+    <value>No active session recognized, please launch Escape From Tarkov.</value>
+  </data>
   <data name="IfYouWantToUpdateProgressForDifferentProfile" xml:space="preserve">
     <value>If you want to update progress for a different profile, activate that profile in the game.</value>
   </data>
@@ -394,7 +400,7 @@
     <value>Retrieved {0} items, {1} maps, {2} traders, {3} tasks, and {4} hideout stations from Tarkov.dev for {5}.</value>
   </data>
   <data name="ToAutomaticallyTrackTaskProgress" xml:space="preserve">
-    <value>To track task progress automatically, assign your Tarkov Tracker token in Settings.</value>
+    <value>API key not assigned. To track task progress automatically, please import or assign an API key in Settings.</value>
   </data>
   <data name="UsingProfile" xml:space="preserve">
     <value>Using the {0} profile.</value>

--- a/TarkovMonitor/Sound.cs
+++ b/TarkovMonitor/Sound.cs
@@ -77,10 +77,62 @@ namespace TarkovMonitor
             {
                 { -1, "Default Device" }
             };
+
+            // WaveOutCapabilities.ProductName is backed by the fixed-size
+            // WAVEOUTCAPS product-name field, so Windows truncates longer
+            // endpoint names before the UI ever receives them. Keep the
+            // WaveOut indexes for playback, but use the full Core Audio
+            // friendly names for display after matching each endpoint by
+            // its original (possibly truncated) WaveOut name.
+            List<string> endpointNames = new();
+            try
+            {
+                using var enumerator = new NAudio.CoreAudioApi.MMDeviceEnumerator();
+                var endpoints = enumerator.EnumerateAudioEndPoints(
+                    NAudio.CoreAudioApi.DataFlow.Render,
+                    NAudio.CoreAudioApi.DeviceState.Active);
+                foreach (var endpoint in endpoints)
+                {
+                    using (endpoint)
+                    {
+                        endpointNames.Add(endpoint.FriendlyName);
+                    }
+                }
+            }
+            catch
+            {
+                // The WaveOut names below remain a usable fallback if Core
+                // Audio enumeration is unavailable during startup.
+            }
+
+            HashSet<int> matchedEndpointIndexes = new();
             for (var deviceNum = 0; deviceNum < WaveOut.DeviceCount; deviceNum++)
             {
                 WaveOutCapabilities deviceInfo = WaveOut.GetCapabilities(deviceNum);
-                devices.Add(deviceNum, deviceInfo.ProductName);
+                var displayName = deviceInfo.ProductName;
+                for (var endpointIndex = 0; endpointIndex < endpointNames.Count; endpointIndex++)
+                {
+                    if (matchedEndpointIndexes.Contains(endpointIndex))
+                    {
+                        continue;
+                    }
+
+                    var endpointName = endpointNames[endpointIndex];
+                    if (!string.Equals(endpointName, deviceInfo.ProductName, StringComparison.OrdinalIgnoreCase)
+                        && !endpointName.StartsWith(deviceInfo.ProductName, StringComparison.OrdinalIgnoreCase)
+                        && !deviceInfo.ProductName.StartsWith(endpointName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    displayName = endpointName;
+                    matchedEndpointIndexes.Add(endpointIndex);
+                    break;
+                }
+
+                devices.Add(deviceNum, string.IsNullOrWhiteSpace(displayName)
+                    ? deviceInfo.ProductName
+                    : displayName);
             }
             return devices;
         }

--- a/TarkovMonitor/TarkovDev.cs
+++ b/TarkovMonitor/TarkovDev.cs
@@ -8,6 +8,7 @@ namespace TarkovMonitor
     public class TarkovDev
     {
         public static event EventHandler<ExceptionEventArgs>? ExceptionThrown;
+        public static event EventHandler? ApiDataLoaded;
         private static readonly object playerNameCacheLock = new();
         private static readonly ConcurrentDictionary<(ProfileType ProfileType, string AccountId), Lazy<Task<string>>> playerNameLookups = new();
         private static readonly HttpClient jsonClient = new(new HttpClientHandler
@@ -131,6 +132,7 @@ namespace TarkovMonitor
         }
 
         private static ApiDataSnapshot apiData = ApiDataSnapshot.Empty;
+        private static Profile? lastLoadedProfile;
         private static ApiDataSnapshot CurrentApiData => Volatile.Read(ref apiData);
 
         public static List<Task> Tasks => CurrentApiData.Tasks;
@@ -140,6 +142,7 @@ namespace TarkovMonitor
         public static List<HideoutStation> Stations => CurrentApiData.Stations;
         public static List<PlayerLevel> PlayerLevels => CurrentApiData.PlayerLevels;
         public static ProfileType LoadedProfileType => CurrentApiData.ProfileType;
+        public static Profile? LastLoadedProfile => Volatile.Read(ref lastLoadedProfile)?.Snapshot();
         public static DateTime ScavAvailableTime { get; set; } = DateTime.Now;
         public static DateTime LastActivity { get; set; } = DateTime.MinValue;
         public static Dictionary<ProfileType, Dictionary<string, string>> PlayerNames { get; private set; } = new();
@@ -344,9 +347,14 @@ namespace TarkovMonitor
                 items.ScavCooldownSeconds);
         }
 
-        internal static void PublishApiData(ApiDataSnapshot snapshot)
+        internal static void PublishApiData(ApiDataSnapshot snapshot, Profile? loadedProfile = null)
         {
             Volatile.Write(ref apiData, snapshot);
+            if (loadedProfile != null)
+            {
+                Volatile.Write(ref lastLoadedProfile, loadedProfile.Snapshot());
+            }
+            ApiDataLoaded?.Invoke(null, EventArgs.Empty);
         }
 
         internal static void ClearApiData()
@@ -369,7 +377,7 @@ namespace TarkovMonitor
                 return false;
             }
 
-            PublishApiData(snapshot);
+            PublishApiData(snapshot, currentProfile);
             return true;
         }
 
@@ -392,7 +400,7 @@ namespace TarkovMonitor
                 return false;
             }
 
-            PublishApiData(snapshot);
+            PublishApiData(snapshot, expectedProfile);
             return true;
         }
 

--- a/TarkovMonitor/TarkovMonitor.csproj
+++ b/TarkovMonitor/TarkovMonitor.csproj
@@ -11,15 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Blazor\AppLayout.razor.css" />
-    <None Remove="Blazor\MainLayout.razor.css" />
-    <None Remove="Blazor\Pages\Dashboard\Dashboard.razor.css" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Blazor\AppLayout.razor.css" />
-    <Content Include="Blazor\MainLayout.razor.css" />
-    <Content Include="Blazor\Pages\Dashboard\Dashboard.razor.css" />
     <Content Include="Resources\TarkovDev.ico" />
   </ItemGroup>
 

--- a/TarkovMonitor/wwwroot/css/app.css
+++ b/TarkovMonitor/wwwroot/css/app.css
@@ -82,6 +82,24 @@ body {
     color: #d7c996 !important;
 }
 
+.tm-input .mud-input-outlined-border {
+    border-color: rgba(255, 255, 255, 0.28);
+    border-radius: 8px;
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.tm-input:hover .mud-input-outlined-border {
+    border-color: rgba(152, 138, 102, 0.78) !important;
+}
+
+.tm-input:focus-within .mud-input-outlined-border {
+    border-color: #988a66 !important;
+}
+
+.tm-input .mud-input-adornment {
+    color: #988a66;
+}
+
 .tm-input .mud-input.mud-input-underline:before {
     background-color: transparent;
     border-bottom-color: rgba(255, 255, 255, 0.28);
@@ -233,6 +251,8 @@ body {
     border-radius: 10px;
     background: linear-gradient(145deg, #232428, #16171a);
     box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38), 0 3px 10px rgba(0, 0, 0, 0.24);
+    /* MudBlazor's list owns dropdown scrolling. The popover only clips its
+       rounded surface so it cannot create a second scrollbar. */
     overflow: hidden;
 }
 
@@ -250,6 +270,8 @@ body {
     width: 100%;
     min-width: 0;
     max-width: 100%;
+    overflow-x: auto;
+    overflow-y: auto;
     scrollbar-color: rgba(143, 132, 99, 0.78) rgba(255, 255, 255, 0.04);
     scrollbar-width: thin;
 }
@@ -262,9 +284,12 @@ body {
     border-radius: 7px;
     color: rgba(255, 255, 255, 0.82);
     line-height: 1.25;
+    width: max-content;
+    min-width: 100%;
+    max-width: none;
     overflow: visible;
-    white-space: normal;
-    overflow-wrap: anywhere;
+    white-space: nowrap;
+    overflow-wrap: normal;
     transition: background-color 140ms ease, box-shadow 140ms ease, color 140ms ease;
 }
 
@@ -331,14 +356,14 @@ html.tm-keyboard-input .tm-select-list .mud-list-item.mud-selected-item[tabindex
 .tm-menu-list .mud-menu-item .mud-menu-item-text {
     display: block;
     flex: 1 1 auto;
-    min-width: 0;
-    max-width: 100%;
+    min-width: max-content;
+    max-width: none;
     padding-right: 0.25rem;
     overflow: visible !important;
-    overflow-wrap: anywhere;
-    word-break: break-word;
+    overflow-wrap: normal;
+    word-break: normal;
     text-overflow: clip !important;
-    white-space: normal !important;
+    white-space: nowrap !important;
 }
 
 .tm-message-actions {
@@ -437,8 +462,22 @@ html.tm-keyboard-input .tm-select-list .mud-list-item.mud-selected-item[tabindex
 }
 
 .dashboard-notification-surface {
+    display: flex;
+    flex-direction: column;
     min-height: calc(100% - 8px);
-    margin: 0 16px 8px;
+    margin: 0 0 8px 16px;
+}
+
+.dashboard-message-stack {
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+    padding-right: 0.75rem !important;
+    justify-content: flex-end !important;
+}
+
+.dashboard-message__paper--text-only {
+    padding-bottom: 0 !important;
 }
 
 .dashboard-page-grid,


### PR DESCRIPTION
## Summary

This PR repairs the remaining UI-overhaul defects found during EFT session, Read Past Logs, small-window, and Settings testing.

Tarkov Monitor now preserves read-only Tarkov.dev data while EFT is waiting at Select Profile and Mode, keeps live tracker work gated until a real EFT profile exists, publishes clear session-state messages, and adds a 1000 ms delay only before publishing the current-session Tarkov.dev notification; startup/persisted preload and callback sequencing are unchanged. This resolves [#218](https://github.com/the-hideout/TarkovMonitor/issues/218).

Read Past Logs now uses the last/current profile and exposes every distinct PVE, PVP, and Seasonal session breakpoint found in the selected log history instead of presenting a misleading single-session list. This resolves [#219](https://github.com/the-hideout/TarkovMonitor/issues/219).

The remaining accepted UI corrections restore the gold custom window frame, 450x250 minimum size, Windows drag and snap behavior, message-board spacing, gold Remote ID and Logs Folder focus states, complete playback-device names, and one scroll owner for long dropdown content.

Fixes #218
Fixes #219

## Commit-by-commit summary

### `3a8bcfa` - `fix(session): preserve Tarkov.dev preload while EFT awaits profile (#218)`

Author: Giribaldi_TTV

- Preserves the last persisted read-only Tarkov.dev data set while EFT is at Select Profile and Mode.
- Separates historical/startup data from a live EFT session so tracker work remains profile-gated.
- Publishes explicit no-session and session-confirmed messages with the corrected wording.
- Adds a 1000 ms delay only before publishing the current-session Tarkov.dev notification; startup/persisted preload and callback sequencing are unchanged.
- Prevents stale profile state from being treated as a live EFT profile.

### `19907fb` - `fix(logs): expose complete Read Past Logs scope (#219)`

Author: Giribaldi_TTV

- Uses the last loaded profile as the Read Past Logs identity.
- Discovers and displays all deduplicated PVE, PVP, and Seasonal session breakpoints in the selected log history.
- Preserves account, profile, game-mode, timestamp, and source-folder context for each starting point.
- Keeps asynchronous profile-name refreshes identity-safe.
- Clarifies the historical replay labels and starting-point behavior.

### `dda6679` - `fix(ui): restore custom window chrome`

Author: Giribaldi_TTV

- Restores the accepted gold window frame and message-board shell.
- Restores the compact navigation drawer, logo spacing, and collapse gutter.
- Restores the 450x250 minimum window size.
- Preserves custom drag regions, Windows snap behavior, resize behavior, and title-bar interaction at the minimum size.
- Restores the accepted message-board padding and alignment treatment.

### `0faa708` - `fix(settings): restore gold controls and complete device labels`

Author: Giribaldi_TTV

- Restores the accepted gold focus and hover treatment for Remote ID and Logs Folder controls.
- Removes the obsolete TarkovTracker API-key introduction text.
- Keeps the Last/Current Profile presentation consistent with the stored profile state.
- Restores complete Core Audio endpoint names without changing WaveOut indexes or device order.
- Corrects Seasonal status-color styling and gives long dropdown content one scroll owner.

## Changelog

### User-visible changes

- Tarkov.dev data remains available while EFT is waiting at profile selection.
- Session state is visible through explicit no-session and session-confirmed messages.
- Current-session Tarkov.dev notifications use a 1000 ms publication delay; startup/persisted preload and callback sequencing are unchanged.
- Read Past Logs clearly shows PVE, PVP, and Seasonal history choices.
- Message cards retain consistent alignment and padding.
- The custom window frame, compact drawer, minimum size, drag behavior, and Windows snap behavior are restored.
- Remote ID and Logs Folder controls use the accepted gold interaction styling.
- Full playback-device names remain readable in long dropdowns without a duplicate scrollbar.

### Internal and technical changes

- Separates persisted read-only Tarkov.dev preload state from live EFT profile ownership.
- Gates tracker activation and writes on a complete live profile identity.
- Adds identity-safe session-generation and profile-name handling.
- Preserves complete log-breakpoint identity while replay options are built.
- Keeps native window chrome and WebView layout ownership coordinated at compact sizes.
- Normalizes dropdown overflow ownership and Core Audio endpoint display metadata.

## Before/after comparison

The following captures are the approved before and after evidence currently available for this branch. They are embedded directly as GitHub attachments; developer-only runtime channel markers are omitted.

### Message surface and session state

<img width="798" height="498" alt="before-message-baseline" src="https://github.com/user-attachments/assets/927a10b4-d5cb-4478-a2df-cf50d1ad70c7" />

<img width="1591" height="1440" alt="after-message-session-idle-clean" src="https://github.com/user-attachments/assets/4f177d02-f2c3-4fa8-84c4-bd473271d577" />

<img width="663" height="269" alt="after-message-session-order" src="https://github.com/user-attachments/assets/6efdcd39-0b99-4907-9d32-e754c2a75f6c" />

### Settings control focus colors

<img width="798" height="980" alt="before-settings-purple-control-redacted" src="https://github.com/user-attachments/assets/1d8c05f5-93e3-4801-bd3f-daaed7f01000" />

<img width="798" height="498" alt="after-settings-gold-control-clean" src="https://github.com/user-attachments/assets/4d10a3f7-1258-461e-b954-6a6eb8067e4a" />

### TarkovTracker card wording and profile identity

<img width="798" height="980" alt="before-tracker-card-wording-redacted" src="https://github.com/user-attachments/assets/aafd2f82-50cc-4ce9-8d9d-628b8091190f" />

<img width="769" height="375" alt="after-tracker-card-wording" src="https://github.com/user-attachments/assets/02f09444-9e43-4fbc-ba71-b233b56d7bc8" />

### Navigation drawer and Tarkov.dev splash sizing

<img width="277" height="536" alt="before-drawer-expanded" src="https://github.com/user-attachments/assets/7a189f58-6f38-49e4-a048-efa21ea5141b" />

<img width="175" height="499" alt="after-drawer-accepted" src="https://github.com/user-attachments/assets/75e7ae55-c6f8-47d1-8c25-8ab2aed5afa4" />

The rejected compact-drawer candidate is intentionally excluded; the accepted compact-drawer after state is shown above.

### Read Past Logs and dropdown states

<img width="1440" height="504" alt="before-read-past-log-scope" src="https://github.com/user-attachments/assets/abef9a7d-4778-4190-af7b-8d928dfaa9ab" />

<img width="592" height="1161" alt="before-dropdown-clipping" src="https://github.com/user-attachments/assets/124be3d9-a0ec-436a-8d68-a45d4adb8a51" />

<img width="800" height="450" alt="after-dropdown-full-labels" src="https://github.com/user-attachments/assets/05d71603-5161-4c2f-808d-571d3c8439dc" />

No final paired Read Past Logs capture is available because the launched client exposed no log breakpoints.

### Minimum-window behavior

<img width="450" height="201" alt="after-minimum-window" src="https://github.com/user-attachments/assets/6dab33dd-1ddc-4773-9230-c86717752871" />

The minimum-window after capture is included; no paired before capture was available.

## Testing notes

Manual EFT testing confirmed the #218 session/preload behavior and the #219 Read Past Logs scope, along with the accepted UI states.

These manual EFT checks are recorded separately from the repository and image checks above.
