### PR TITLE
feat(update): install updates from within the application

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -33,6 +33,7 @@ jobs:
             --runtime win-x64 `
             -p:PublishSingleFile=true `
             -p:Version=${{ github.ref_name }} `
+            -p:AssemblyVersion=${{ github.ref_name }} `
             --output "$Env:GITHUB_WORKSPACE\publish"
 
       - name: Verify published application

--- a/TarkovMonitor/Blazor/Components/MessageBoard.razor
+++ b/TarkovMonitor/Blazor/Components/MessageBoard.razor
@@ -122,8 +122,16 @@
             if (subscribedMessages.Add(message))
             {
                 message.Buttons.CollectionChanged += MessageActions_CollectionChanged;
+                message.Changed += Message_Changed;
             }
         }
+    }
+
+    private void Message_Changed(object? sender, EventArgs e)
+    {
+        // Progress updates rewrite the text of a message already in the list,
+        // so only a redraw is needed.
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void MessageActions_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -319,6 +327,7 @@
         foreach (var message in subscribedMessages)
         {
             message.Buttons.CollectionChanged -= MessageActions_CollectionChanged;
+            message.Changed -= Message_Changed;
         }
         subscribedMessages.Clear();
         timer?.Dispose();

--- a/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
+++ b/TarkovMonitor/Blazor/Pages/Settings/Settings.razor
@@ -387,6 +387,16 @@
         </MudPaper>
     </MudItem>
 
+    <MudItem xs="12" lg="6" xl="4">
+        <MudPaper Class="app-surface pa-2 ma-2 mx-4" Elevation="3">
+            <MudText Typo="Typo.h6" Class="d-flex align-center"><MudIcon Icon="@Icons.Material.Filled.Update" Class="mr-2" /><span class="tm-card-heading-text">Updates</span></MudText>
+            <MudText>Installed version @CurrentVersion</MudText>
+            <div>
+                <MudButton @onclick="CheckForUpdates" Variant="Variant.Text" Class="tm-action-link" Disabled="@checkingForUpdates">Check for updates</MudButton>
+            </div>
+        </MudPaper>
+    </MudItem>
+
 </MudGrid>
 
 @code {
@@ -403,7 +413,31 @@
     private static bool pendingDrawerExpanded;
     private static bool boundDrawerExpanded;
     private bool scanningOrgProfiles;
+    private bool checkingForUpdates;
     private static readonly HashSet<string> expandedAccountIds = new(StringComparer.Ordinal);
+
+    private static string CurrentVersion => System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "";
+
+    private async Task CheckForUpdates()
+    {
+        checkingForUpdates = true;
+        StateHasChanged();
+        try
+        {
+            // A newer release announces itself through the notification list,
+            // where it can be installed. Only the "nothing to do" answer has to
+            // be reported from here.
+            if (await WindowHost.CheckForUpdates() == UpdateCheckResult.UpToDate)
+            {
+                messageLog.AddMessage($"Tarkov Monitor {CurrentVersion} is the latest version.", "update");
+            }
+        }
+        finally
+        {
+            checkingForUpdates = false;
+            StateHasChanged();
+        }
+    }
 
     private sealed record OrgAccountGroup(
         string AccountId,

--- a/TarkovMonitor/MainBlazorUI.cs
+++ b/TarkovMonitor/MainBlazorUI.cs
@@ -71,6 +71,7 @@ namespace TarkovMonitor
         private readonly LogRepository logRepository;
         private readonly GroupManager groupManager;
         private readonly TimersManager timersManager;
+        private readonly Updating.UpdateCoordinator updateCoordinator;
         private readonly System.Timers.Timer runthroughTimer;
         private readonly System.Timers.Timer scavCooldownTimer;
         private LocalizationService localizationService;
@@ -118,6 +119,10 @@ namespace TarkovMonitor
             diagnostics = diagnosticsService ?? new DiagnosticsService();
             messageLog = new MessageLog(diagnostics);
             messageLog.AddMessage($"Tarkov Monitor v{System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
+
+            // Offers new releases as an in-place install rather than only a
+            // link to the download page.
+            updateCoordinator = new Updating.UpdateCoordinator(messageLog, () => BeginInvoke(new Action(Application.Exit)));
 
             // Singleton log repository to record, display, and analyze logs for TarkovMonitor
             logRepository = new LogRepository();
@@ -803,6 +808,9 @@ namespace TarkovMonitor
 
             try
             {
+                // A completed update leaves its download behind, and the
+                // launcher that applied it has exited by now.
+                updateCoordinator.CleanStaleStaging();
                 UpdateCheck.CheckForNewVersion();
             }
             catch (Exception ex)
@@ -869,7 +877,16 @@ namespace TarkovMonitor
 
         private void UpdateCheck_NewVersion(object? sender, NewVersionEventArgs e)
         {
-            messageLog.AddMessage($"A new Tarkov Monitor version is available ({e.Version}). Click to open the download page, and update before reporting a bug.", null, e.Uri.ToString());
+            updateCoordinator.Announce(e);
+        }
+
+        /// <summary>
+        /// Runs the update check on demand from the settings page. A new
+        /// version is reported through the usual notification.
+        /// </summary>
+        public async Task<UpdateCheckResult> CheckForUpdates()
+        {
+            return await UpdateCheck.CheckForNewVersionAsync();
         }
 
         private async void Eft_MapLoading(object? sender, EventArgs e)

--- a/TarkovMonitor/MonitorMessage.cs
+++ b/TarkovMonitor/MonitorMessage.cs
@@ -97,6 +97,19 @@ namespace TarkovMonitor
         public MonitorMessageCollection<MonitorMessageButton> Buttons { get; } = new();
         public MonitorMessageCollection<MonitorMessageSelect> Selects { get; } = new();
         public List<MonitorMessageProtectedValue> ProtectedValues { get; } = new();
+
+        /// <summary>
+        /// Raised when the text of an already displayed message changes, so a
+        /// long-running action can report progress in place instead of adding a
+        /// new message for every step.
+        /// </summary>
+        public event EventHandler? Changed;
+
+        public void NotifyChanged()
+        {
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+
         public MonitorMessage(string message)
         {
             Message = message;

--- a/TarkovMonitor/Program.cs
+++ b/TarkovMonitor/Program.cs
@@ -6,8 +6,16 @@ namespace TarkovMonitor
         ///  The main entry point for the application.
         /// </summary>
         [STAThread]
-		static void Main()
+		static void Main(string[] args)
         {
+            // A copy of this executable installs downloaded updates, because a
+            // running application cannot replace its own files. That copy never
+            // reaches the rest of startup.
+            if (Updating.UpdateApplier.TryHandle(args))
+            {
+                return;
+            }
+
             var diagnostics = new DiagnosticsService();
             Application.ThreadException += (_, args) => diagnostics.Capture(
                 new DiagnosticContext("TM-APP-001", "UnhandledUiException", "Application", "Thread", "The application encountered an unexpected UI failure."),

--- a/TarkovMonitor/UpdateCheck.cs
+++ b/TarkovMonitor/UpdateCheck.cs
@@ -1,7 +1,14 @@
-﻿using Refit;
+using Refit;
 
 namespace TarkovMonitor
 {
+    public enum UpdateCheckResult
+    {
+        UpToDate,
+        UpdateAvailable,
+        Failed,
+    }
+
     internal class UpdateCheck
     {
         internal interface IGitHubAPI
@@ -36,32 +43,82 @@ namespace TarkovMonitor
 
         public static async void CheckForNewVersion()
         {
+            await CheckForNewVersionAsync();
+        }
+
+        /// <summary>
+        /// Awaitable form of the check, so a manual "check for updates" action
+        /// can tell the user that the installed version is already current.
+        /// Errors are still reported through <see cref="Error"/>.
+        /// </summary>
+        public static async Task<UpdateCheckResult> CheckForNewVersionAsync()
+        {
             try
             {
                 var release = await api.GetLatestRelease();
-                Version remoteVersion = new Version(release.tag_name);
+                if (!Version.TryParse(release.tag_name, out var remoteVersion))
+                {
+                    throw new Exception($"Could not read a version number from the release tag \"{release.tag_name}\".");
+                }
                 Version localVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version ?? throw new Exception("Could not retrieve version from assembly");
                 //System.Diagnostics.Debug.WriteLine(localVersion.ToString());
 
-                if (localVersion.CompareTo(remoteVersion) == -1)
+                if (localVersion.CompareTo(remoteVersion) != -1)
                 {
-                    NewVersion?.Invoke(null, new() { Version = remoteVersion, Uri = new(release.html_url) });
+                    return UpdateCheckResult.UpToDate;
                 }
+
+                NewVersion?.Invoke(null, new()
+                {
+                    Version = remoteVersion,
+                    Uri = new(release.html_url),
+                    Asset = SelectArchiveAsset(release),
+                });
+                return UpdateCheckResult.UpdateAvailable;
             }
             catch (ApiException ex)
             {
                 Error?.Invoke(null, new(new Exception($"Invalid GitHub API response code: {ex.StatusCode}.", ex), "checking for new version"));
+                return UpdateCheckResult.Failed;
             }
             catch (Exception ex)
             {
                 Error?.Invoke(null, new(new Exception("GitHub API error.", ex), "checking for new version"));
+                return UpdateCheckResult.Failed;
             }
+        }
+
+        /// <summary>
+        /// Finds the release archive the in-app updater can install. Releases
+        /// built before the updater existed, or with an unexpected set of
+        /// attachments, simply return null and fall back to the download page.
+        /// </summary>
+        private static ReleaseAsset? SelectArchiveAsset(ReleaseData release)
+        {
+            var archives = release.assets
+                .Where(asset => !string.IsNullOrEmpty(asset.browser_download_url)
+                    && asset.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            return archives.FirstOrDefault(asset => string.Equals(
+                    asset.name,
+                    "TarkovMonitor.zip",
+                    StringComparison.OrdinalIgnoreCase))
+                ?? archives.FirstOrDefault();
         }
 
         public class ReleaseData
         {
-            public string tag_name { get; set; }
-            public string html_url { get; set; }
+            public string tag_name { get; set; } = "";
+            public string html_url { get; set; } = "";
+            public List<ReleaseAsset> assets { get; set; } = new();
+        }
+
+        public class ReleaseAsset
+        {
+            public string name { get; set; } = "";
+            public string browser_download_url { get; set; } = "";
+            public long size { get; set; }
         }
     }
 
@@ -69,10 +126,18 @@ namespace TarkovMonitor
     {
         public Version Version { get; set; }
         public Uri Uri { get; set; }
+
+        /// <summary>
+        /// The archive the update can be installed from, or null when the
+        /// release has none and the user has to download it themselves.
+        /// </summary>
+        internal UpdateCheck.ReleaseAsset? Asset { get; set; }
     }
 }
 
 // to release a new version:
 // Checkout main/master (assuming everything is merged already)
+// bump AssemblyVersion in TarkovMonitor.csproj to match the tag you are about to
+// create; the in-app update check compares the release tag against that value
 // tag the current commit (eg. git tag 1.0.1.2)
 // push the tag to GitHub (git push origin 1.0.1.2)

--- a/TarkovMonitor/Updating/UpdateApplier.cs
+++ b/TarkovMonitor/Updating/UpdateApplier.cs
@@ -1,0 +1,266 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace TarkovMonitor.Updating
+{
+    /// <summary>
+    /// The half of the updater that runs from a temporary copy of the
+    /// executable. Because it does not run from the installation directory it
+    /// can overwrite every file there, which the application itself cannot do
+    /// while it is running.
+    /// </summary>
+    internal static class UpdateApplier
+    {
+        private const int ExitWaitSeconds = 120;
+        private const int CopyAttempts = 30;
+        private static readonly TimeSpan CopyRetryDelay = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
+        /// Runs the copy-and-restart sequence when the command line asks for
+        /// it. Returns true when the process acted as an updater and should not
+        /// continue into normal startup.
+        /// </summary>
+        internal static bool TryHandle(string[] args)
+        {
+            if (args.Length == 0 || !args.Contains(UpdateInstaller.ApplyUpdateSwitch, StringComparer.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var options = ParseArguments(args);
+            var log = new StringBuilder();
+            try
+            {
+                Apply(options, log);
+            }
+            catch (Exception exception)
+            {
+                log.AppendLine(exception.ToString());
+                WriteLog(options, log);
+                MessageBox.Show(
+                    "Tarkov Monitor could not install the update, and the previous version was left in place."
+                        + Environment.NewLine + Environment.NewLine
+                        + exception.Message
+                        + Environment.NewLine + Environment.NewLine
+                        + "Download the new version manually from the releases page.",
+                    "Tarkov Monitor update failed",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+                TryRelaunch(options);
+                return true;
+            }
+
+            WriteLog(options, log);
+            return true;
+        }
+
+        private static void Apply(ApplyOptions options, StringBuilder log)
+        {
+            if (options.SourceDirectory == null || options.TargetDirectory == null)
+            {
+                throw new ArgumentException("The updater was started without a source and target directory.");
+            }
+            if (!Directory.Exists(options.SourceDirectory))
+            {
+                throw new DirectoryNotFoundException($"The staged update is missing: {options.SourceDirectory}");
+            }
+
+            WaitForApplicationExit(options.ProcessId, log);
+
+            var backupDirectory = Path.Combine(
+                Path.GetDirectoryName(options.SourceDirectory) ?? options.SourceDirectory,
+                "backup");
+            // Track what was replaced so a failure part way through can put the
+            // working installation back rather than leaving a mixed one.
+            var restored = new List<(string TargetPath, string BackupPath)>();
+
+            try
+            {
+                foreach (var sourcePath in Directory.EnumerateFiles(options.SourceDirectory, "*", SearchOption.AllDirectories))
+                {
+                    var relativePath = Path.GetRelativePath(options.SourceDirectory, sourcePath);
+                    var targetPath = Path.Combine(options.TargetDirectory, relativePath);
+                    Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+
+                    if (File.Exists(targetPath))
+                    {
+                        var backupPath = Path.Combine(backupDirectory, relativePath);
+                        Directory.CreateDirectory(Path.GetDirectoryName(backupPath)!);
+                        CopyWithRetries(targetPath, backupPath, log);
+                        restored.Add((targetPath, backupPath));
+                    }
+
+                    CopyWithRetries(sourcePath, targetPath, log);
+                }
+            }
+            catch
+            {
+                RollBack(restored, log);
+                throw;
+            }
+
+            log.AppendLine($"Installed update into {options.TargetDirectory}.");
+            TryRelaunch(options);
+
+            // The payload and backup are only useful up to this point, and they
+            // are the bulk of what staging holds.
+            TryDeleteDirectory(options.SourceDirectory);
+            TryDeleteDirectory(backupDirectory);
+        }
+
+        private static void WaitForApplicationExit(int? processId, StringBuilder log)
+        {
+            if (processId is not int pid)
+            {
+                return;
+            }
+
+            try
+            {
+                using var process = Process.GetProcessById(pid);
+                if (!process.WaitForExit(TimeSpan.FromSeconds(ExitWaitSeconds)))
+                {
+                    throw new TimeoutException("Tarkov Monitor did not close, so the update was not installed.");
+                }
+                log.AppendLine($"Process {pid} exited.");
+            }
+            catch (ArgumentException)
+            {
+                // The application had already exited before the updater looked
+                // for it, which is the common case.
+                log.AppendLine($"Process {pid} had already exited.");
+            }
+        }
+
+        private static void CopyWithRetries(string sourcePath, string destinationPath, StringBuilder log)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    File.Copy(sourcePath, destinationPath, overwrite: true);
+                    return;
+                }
+                catch (Exception exception) when (attempt < CopyAttempts
+                    && exception is IOException or UnauthorizedAccessException)
+                {
+                    // Anti-virus scanners and the just-closed process can hold
+                    // a handle open for a few seconds after exit.
+                    log.AppendLine($"Retrying {destinationPath} after: {exception.Message}");
+                    Thread.Sleep(CopyRetryDelay);
+                }
+            }
+        }
+
+        private static void RollBack(List<(string TargetPath, string BackupPath)> restored, StringBuilder log)
+        {
+            log.AppendLine("Rolling back to the previous version.");
+            foreach (var (targetPath, backupPath) in restored)
+            {
+                try
+                {
+                    File.Copy(backupPath, targetPath, overwrite: true);
+                }
+                catch (Exception exception)
+                {
+                    log.AppendLine($"Could not restore {targetPath}: {exception.Message}");
+                }
+            }
+        }
+
+        private static void TryRelaunch(ApplyOptions options)
+        {
+            if (options.LaunchPath == null || !File.Exists(options.LaunchPath))
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = options.LaunchPath,
+                    WorkingDirectory = Path.GetDirectoryName(options.LaunchPath)!,
+                    UseShellExecute = false,
+                });
+            }
+            catch
+            {
+                // Nothing useful can be done from here; the user can start the
+                // application from its shortcut.
+            }
+        }
+
+        private static ApplyOptions ParseArguments(string[] args)
+        {
+            var options = new ApplyOptions();
+            for (var index = 0; index < args.Length - 1; index++)
+            {
+                var value = args[index + 1];
+                switch (args[index].ToLowerInvariant())
+                {
+                    case "--pid":
+                        options.ProcessId = int.TryParse(value, out var pid) ? pid : null;
+                        break;
+                    case "--source":
+                        options.SourceDirectory = value;
+                        break;
+                    case "--target":
+                        options.TargetDirectory = value;
+                        break;
+                    case "--launch":
+                        options.LaunchPath = value;
+                        break;
+                }
+            }
+            return options;
+        }
+
+        private static void WriteLog(ApplyOptions options, StringBuilder log)
+        {
+            if (options.SourceDirectory == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var logDirectory = Path.GetDirectoryName(options.SourceDirectory);
+                if (logDirectory == null)
+                {
+                    return;
+                }
+                Directory.CreateDirectory(logDirectory);
+                File.WriteAllText(Path.Combine(logDirectory, "update.log"), log.ToString());
+            }
+            catch
+            {
+                // The log is a convenience for bug reports, never a reason to
+                // fail an otherwise successful update.
+            }
+        }
+
+        private static void TryDeleteDirectory(string directory)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+            catch
+            {
+                // Whatever is left behind is removed at the next startup.
+            }
+        }
+
+        private sealed class ApplyOptions
+        {
+            public int? ProcessId { get; set; }
+            public string? SourceDirectory { get; set; }
+            public string? TargetDirectory { get; set; }
+            public string? LaunchPath { get; set; }
+        }
+    }
+}

--- a/TarkovMonitor/Updating/UpdateCoordinator.cs
+++ b/TarkovMonitor/Updating/UpdateCoordinator.cs
@@ -1,0 +1,234 @@
+using MudBlazor;
+
+namespace TarkovMonitor.Updating
+{
+    /// <summary>
+    /// Turns a new-version notice into an actionable message: the user is told
+    /// an update exists, and can install it without leaving the application.
+    /// Nothing is downloaded until the user asks for it.
+    /// </summary>
+    internal sealed class UpdateCoordinator
+    {
+        private const int CleanupAttempts = 6;
+        private static readonly TimeSpan CleanupRetryDelay = TimeSpan.FromSeconds(5);
+
+        private readonly MessageLog messageLog;
+        private readonly Action requestExit;
+        private readonly object gate = new();
+        private Version? announcedVersion;
+        private bool updateStarted;
+
+        internal UpdateCoordinator(MessageLog messageLog, Action requestExit)
+        {
+            this.messageLog = messageLog;
+            this.requestExit = requestExit;
+        }
+
+        /// <summary>
+        /// Discards staging folders from previous updates, which hold a full
+        /// copy of the application and are worth reclaiming promptly. The
+        /// launcher that applied the last update exits moments after starting
+        /// this process, so the first attempt usually cannot delete it.
+        /// </summary>
+        internal void CleanStaleStaging()
+        {
+            _ = Task.Run(async () =>
+            {
+                for (var attempt = 0; attempt < CleanupAttempts; attempt++)
+                {
+                    lock (gate)
+                    {
+                        // A download started in the meantime owns a staging
+                        // folder that must not be deleted underneath it.
+                        if (updateStarted)
+                        {
+                            return;
+                        }
+                    }
+
+                    UpdateInstaller.CleanStaleStaging();
+                    if (!UpdateInstaller.HasStaging)
+                    {
+                        return;
+                    }
+                    await Task.Delay(CleanupRetryDelay);
+                }
+            });
+        }
+
+        internal void Announce(NewVersionEventArgs newVersion)
+        {
+            lock (gate)
+            {
+                // The check runs again every day, and a user who is not ready
+                // to restart should not collect a message per day.
+                if (announcedVersion == newVersion.Version)
+                {
+                    return;
+                }
+                announcedVersion = newVersion.Version;
+            }
+
+            var canInstall = newVersion.Asset != null && UpdateInstaller.IsSupportedInstallation;
+            var message = new MonitorMessage(
+                canInstall
+                    ? $"Tarkov Monitor {newVersion.Version} is available. Install it before reporting a bug."
+                    : $"Tarkov Monitor {newVersion.Version} is available. Download it before reporting a bug.",
+                "update",
+                newVersion.Uri.ToString(),
+                "View the release");
+
+            if (canInstall)
+            {
+                message.Buttons.Add(CreateInstallButton(message, newVersion));
+            }
+
+            messageLog.AddMessage(message);
+        }
+
+        private MonitorMessageButton CreateInstallButton(MonitorMessage message, NewVersionEventArgs newVersion)
+        {
+            var button = new MonitorMessageButton("Install and restart", icon: Icons.Material.Filled.Update)
+            {
+                Color = MudBlazor.Color.Info,
+                Confirm = new MonitorMessageButtonConfirm(
+                    "Install update",
+                    $"Tarkov Monitor will download version {newVersion.Version}, close, and reopen to finish installing."
+                        + "<br /><br />Do not do this while you are in a raid.",
+                    "Install",
+                    "Not now"),
+            };
+            button.OnClick = () => BeginUpdate(message, button, newVersion);
+            return button;
+        }
+
+        private void BeginUpdate(MonitorMessage message, MonitorMessageButton installButton, NewVersionEventArgs newVersion)
+        {
+            var asset = newVersion.Asset;
+            if (asset == null)
+            {
+                return;
+            }
+
+            CancellationTokenSource cancellation;
+            lock (gate)
+            {
+                if (updateStarted)
+                {
+                    return;
+                }
+                updateStarted = true;
+                cancellation = new CancellationTokenSource();
+            }
+
+            var cancelButton = new MonitorMessageButton("Cancel", icon: Icons.Material.Filled.Cancel)
+            {
+                Color = MudBlazor.Color.Default,
+            };
+            cancelButton.OnClick = () => cancellation.Cancel();
+            message.Buttons.Remove(installButton);
+            message.Buttons.Add(cancelButton);
+            SetMessageText(message, $"Preparing to download Tarkov Monitor {newVersion.Version}...");
+
+            _ = Task.Run(() => RunUpdateAsync(message, installButton, cancelButton, newVersion, asset, cancellation));
+        }
+
+        private async Task RunUpdateAsync(
+            MonitorMessage message,
+            MonitorMessageButton installButton,
+            MonitorMessageButton cancelButton,
+            NewVersionEventArgs newVersion,
+            UpdateCheck.ReleaseAsset asset,
+            CancellationTokenSource cancellation)
+        {
+            var startedUtc = DateTime.UtcNow;
+            try
+            {
+                var progress = new Progress<UpdateProgress>(update => SetMessageText(
+                    message,
+                    DescribeProgress(newVersion.Version, update)));
+
+                var staged = await UpdateInstaller.StageAsync(
+                    newVersion.Version,
+                    asset,
+                    progress,
+                    cancellation.Token);
+
+                message.Buttons.Remove(cancelButton);
+                SetMessageText(message, $"Tarkov Monitor {newVersion.Version} is ready. Restarting...");
+
+                UpdateInstaller.StartApply(staged);
+                requestExit();
+            }
+            catch (OperationCanceledException)
+            {
+                Reset(message, installButton, cancelButton, "The update was cancelled.", newVersion);
+            }
+            catch (Exception exception)
+            {
+                Reset(
+                    message,
+                    installButton,
+                    cancelButton,
+                    $"Tarkov Monitor {newVersion.Version} could not be installed. Use the link above to download it.",
+                    newVersion);
+                messageLog.AddException(
+                    "Installing the update failed; copy diagnostics for details.",
+                    "TM-UPDATE-003",
+                    "InstallUpdate",
+                    exception,
+                    "UpdateCheck",
+                    "Install",
+                    asset.browser_download_url,
+                    DiagnosticsService.ElapsedMilliseconds(startedUtc));
+            }
+            finally
+            {
+                cancellation.Dispose();
+            }
+        }
+
+        private void Reset(
+            MonitorMessage message,
+            MonitorMessageButton installButton,
+            MonitorMessageButton cancelButton,
+            string text,
+            NewVersionEventArgs newVersion)
+        {
+            lock (gate)
+            {
+                updateStarted = false;
+            }
+            message.Buttons.Remove(cancelButton);
+            // The original button carries the confirmation dialog and the
+            // closure over this release, so it can simply be put back.
+            message.Buttons.Add(installButton);
+            SetMessageText(message, $"{text} Tarkov Monitor {newVersion.Version} is still available.");
+        }
+
+        private static void SetMessageText(MonitorMessage message, string text)
+        {
+            message.Message = text;
+            message.NotifyChanged();
+        }
+
+        private static string DescribeProgress(Version version, UpdateProgress update)
+        {
+            return update.Stage switch
+            {
+                UpdateStage.Downloading when update.Percent is int percent
+                    => $"Downloading Tarkov Monitor {version}... {percent}% ({DescribeSize(update.BytesReceived)} of {DescribeSize(update.TotalBytes)})",
+                UpdateStage.Downloading
+                    => $"Downloading Tarkov Monitor {version}... {DescribeSize(update.BytesReceived)}",
+                UpdateStage.Verifying => $"Verifying the Tarkov Monitor {version} download...",
+                UpdateStage.Extracting => $"Unpacking Tarkov Monitor {version}...",
+                _ => $"Tarkov Monitor {version} is ready to install.",
+            };
+        }
+
+        private static string DescribeSize(long bytes)
+        {
+            return $"{bytes / 1024d / 1024d:0.#} MB";
+        }
+    }
+}

--- a/TarkovMonitor/Updating/UpdateInstaller.cs
+++ b/TarkovMonitor/Updating/UpdateInstaller.cs
@@ -1,0 +1,298 @@
+using System.Diagnostics;
+using System.IO.Compression;
+
+namespace TarkovMonitor.Updating
+{
+    internal enum UpdateStage
+    {
+        Downloading,
+        Verifying,
+        Extracting,
+        Ready,
+    }
+
+    internal readonly record struct UpdateProgress(UpdateStage Stage, long BytesReceived, long TotalBytes)
+    {
+        /// <summary>
+        /// Null while the server does not report a content length, which keeps
+        /// the caller from displaying a percentage it cannot compute.
+        /// </summary>
+        public int? Percent => TotalBytes > 0
+            ? (int)Math.Clamp(BytesReceived * 100 / TotalBytes, 0, 100)
+            : null;
+    }
+
+    /// <summary>
+    /// A staged update that has been downloaded and unpacked, and is ready to
+    /// replace the files of the running installation.
+    /// </summary>
+    internal sealed record StagedUpdate(Version Version, string StagingDirectory, string PayloadDirectory);
+
+    /// <summary>
+    /// Downloads a GitHub release archive, unpacks it under the user profile,
+    /// and hands control to a temporary copy of the running executable. The
+    /// copy can overwrite the installation directory because it does not run
+    /// from it; see <see cref="UpdateApplier"/> for the other half.
+    /// </summary>
+    internal static class UpdateInstaller
+    {
+        internal const string ApplyUpdateSwitch = "--apply-update";
+        internal const string ExecutableName = "TarkovMonitor.exe";
+        private const string StagingFolderName = "updates";
+        private const string PayloadFolderName = "payload";
+        private const string LauncherFolderName = "launcher";
+        private const string ArchiveFileName = "update.zip";
+
+        private static readonly HttpClient downloadClient = CreateDownloadClient();
+
+        /// <summary>
+        /// Staging lives under the local profile so an installation in a
+        /// read-only location can still download; only the final copy needs
+        /// write access to the application directory.
+        /// </summary>
+        internal static string StagingRoot => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "TarkovMonitor",
+            StagingFolderName);
+
+        internal static string InstallDirectory => AppContext.BaseDirectory.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar);
+
+        internal static string InstallExecutablePath => Path.Combine(InstallDirectory, ExecutableName);
+
+        /// <summary>
+        /// True when the running application is laid out the way the release
+        /// archive is built. A development run out of the build output has no
+        /// matching executable name and must not be self-updated.
+        /// </summary>
+        internal static bool IsSupportedInstallation => File.Exists(InstallExecutablePath);
+
+        /// <summary>
+        /// Downloads and unpacks the archive attached to the release. The
+        /// returned staging folder is left on disk for the launcher to consume.
+        /// </summary>
+        internal static async Task<StagedUpdate> StageAsync(
+            Version version,
+            UpdateCheck.ReleaseAsset asset,
+            IProgress<UpdateProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            var stagingDirectory = Path.Combine(StagingRoot, version.ToString());
+            // A previous attempt may have been cancelled or interrupted part
+            // way through, so never trust what is already there.
+            DeleteDirectory(stagingDirectory);
+            Directory.CreateDirectory(stagingDirectory);
+
+            var archivePath = Path.Combine(stagingDirectory, ArchiveFileName);
+            try
+            {
+                await DownloadAsync(asset, archivePath, progress, cancellationToken);
+
+                progress?.Report(new UpdateProgress(UpdateStage.Verifying, asset.size, asset.size));
+                VerifyArchive(archivePath);
+
+                progress?.Report(new UpdateProgress(UpdateStage.Extracting, asset.size, asset.size));
+                var payloadDirectory = Path.Combine(stagingDirectory, PayloadFolderName);
+                // ExtractToDirectory rejects entries that resolve outside the
+                // destination, so a malformed archive cannot write elsewhere.
+                ZipFile.ExtractToDirectory(archivePath, payloadDirectory, overwriteFiles: true);
+
+                if (!File.Exists(Path.Combine(payloadDirectory, ExecutableName)))
+                {
+                    throw new InvalidDataException($"The downloaded archive did not contain {ExecutableName}.");
+                }
+
+                // The archive is no longer needed and is the largest thing in
+                // staging, so reclaim the space before the restart.
+                TryDeleteFile(archivePath);
+
+                progress?.Report(new UpdateProgress(UpdateStage.Ready, asset.size, asset.size));
+                return new StagedUpdate(version, stagingDirectory, payloadDirectory);
+            }
+            catch
+            {
+                DeleteDirectory(stagingDirectory);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Copies the running executable out of the installation directory and
+        /// starts it in apply mode. The caller is expected to exit immediately
+        /// afterwards; the copy waits for this process to end before replacing
+        /// any files.
+        /// </summary>
+        internal static void StartApply(StagedUpdate staged)
+        {
+            var launcherDirectory = Path.Combine(staged.StagingDirectory, LauncherFolderName);
+            Directory.CreateDirectory(launcherDirectory);
+            var launcherPath = Path.Combine(launcherDirectory, ExecutableName);
+
+            // The currently running build applies the update rather than the
+            // downloaded one, so the command line contract is always the one
+            // this version was compiled against.
+            File.Copy(Environment.ProcessPath ?? InstallExecutablePath, launcherPath, overwrite: true);
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = launcherPath,
+                WorkingDirectory = launcherDirectory,
+                UseShellExecute = false,
+            };
+            startInfo.ArgumentList.Add(ApplyUpdateSwitch);
+            startInfo.ArgumentList.Add("--pid");
+            startInfo.ArgumentList.Add(Environment.ProcessId.ToString());
+            startInfo.ArgumentList.Add("--source");
+            startInfo.ArgumentList.Add(staged.PayloadDirectory);
+            startInfo.ArgumentList.Add("--target");
+            startInfo.ArgumentList.Add(InstallDirectory);
+            startInfo.ArgumentList.Add("--launch");
+            startInfo.ArgumentList.Add(InstallExecutablePath);
+
+            if (!IsDirectoryWritable(InstallDirectory))
+            {
+                // An installation under Program Files needs an elevated copy
+                // step. UseShellExecute is required to request the prompt.
+                startInfo.UseShellExecute = true;
+                startInfo.Verb = "runas";
+            }
+
+            Process.Start(startInfo);
+        }
+
+        internal static bool HasStaging => Directory.Exists(StagingRoot)
+            && Directory.EnumerateDirectories(StagingRoot).Any();
+
+        /// <summary>
+        /// Removes staging folders left behind by earlier updates. The launcher
+        /// that applied the last update is usually still exiting, so its own
+        /// folder can survive the first attempt.
+        /// </summary>
+        internal static void CleanStaleStaging()
+        {
+            if (!Directory.Exists(StagingRoot))
+            {
+                return;
+            }
+
+            foreach (var directory in Directory.EnumerateDirectories(StagingRoot))
+            {
+                DeleteDirectory(directory);
+            }
+        }
+
+        private static async Task DownloadAsync(
+            UpdateCheck.ReleaseAsset asset,
+            string destinationPath,
+            IProgress<UpdateProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            using var response = await downloadClient.GetAsync(
+                asset.browser_download_url,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var totalBytes = response.Content.Headers.ContentLength ?? asset.size;
+            progress?.Report(new UpdateProgress(UpdateStage.Downloading, 0, totalBytes));
+
+            using var source = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var destination = new FileStream(
+                destinationPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                useAsync: true);
+
+            var buffer = new byte[81920];
+            long received = 0;
+            var lastReported = 0L;
+            int read;
+            while ((read = await source.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
+                received += read;
+
+                // Reporting every chunk would redraw the notification thousands
+                // of times for a release archive this size.
+                if (received - lastReported < 1_000_000 && received != totalBytes)
+                {
+                    continue;
+                }
+                lastReported = received;
+                progress?.Report(new UpdateProgress(UpdateStage.Downloading, received, totalBytes));
+            }
+        }
+
+        private static void VerifyArchive(string archivePath)
+        {
+            using var archive = ZipFile.OpenRead(archivePath);
+            var hasExecutable = archive.Entries.Any(entry => string.Equals(
+                entry.FullName,
+                ExecutableName,
+                StringComparison.OrdinalIgnoreCase));
+            if (!hasExecutable)
+            {
+                throw new InvalidDataException($"The downloaded archive did not contain {ExecutableName}.");
+            }
+        }
+
+        private static bool IsDirectoryWritable(string directory)
+        {
+            var probePath = Path.Combine(directory, $".tarkovmonitor-write-probe-{Guid.NewGuid():N}");
+            try
+            {
+                using (File.Create(probePath, 1, FileOptions.DeleteOnClose))
+                {
+                }
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void DeleteDirectory(string directory)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+            }
+            catch
+            {
+                // Staging cleanup is opportunistic; a locked folder is retried
+                // the next time the application starts.
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+                // See DeleteDirectory.
+            }
+        }
+
+        private static HttpClient CreateDownloadClient()
+        {
+            var client = new HttpClient
+            {
+                // Release archives are large and users are frequently on slow
+                // connections, so the default 100 second timeout is not enough.
+                Timeout = TimeSpan.FromMinutes(30),
+            };
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("tarkov-monitor");
+            return client;
+        }
+    }
+}


### PR DESCRIPTION
Updating meant downloading the release archive from GitHub, deleting the old folder, and unpacking the new one by hand. The update check already detected new releases, but could only offer a link to the download page.

The new-version notification now carries an "Install and restart" button. The release archive is downloaded to the local profile with progress reported in place, verified, and unpacked; the running executable then copies itself to staging and relaunches in --apply-update mode. That copy waits for the application to exit, replaces the installation directory, and starts the new version. Reusing the running executable as the launcher avoids shipping a second artifact, and keeps the command line contract the one that build was compiled against.

Every replaced file is backed up first. If a copy fails after retries the previous version is restored, so a failed update leaves a working install rather than a mixed one. Locked files are retried, because anti-virus scanners hold handles briefly after exit, and an installation directory that is not writable requests elevation instead of failing.

Nothing is downloaded until the user asks for it, and the confirmation dialog warns against restarting mid-raid.

The release workflow now also passes AssemblyVersion. Version is set from the tag but does not override the AssemblyVersion held in the project file, so the two only matched because the value was bumped by hand. A passive notification tolerates that drift; an updater does not, since a missed bump would make it reoffer a version already installed.